### PR TITLE
fix: sync-eval first decode token to fix Gemma 4 pad-token bug

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1063,7 +1063,17 @@ public struct TokenIterator: Sequence, IteratorProtocol {
             let token = step(previous: y)
             y = .init(tokens: token)
 
-            asyncEval(y.tokens)
+            // Sync-eval the first decode token before returning to the iterator.
+            //
+            // Using asyncEval here causes garbage decode on Gemma 4 (every token
+            // after the first is <pad>): the second forward pass starts before
+            // the prefill's per-layer KV-cache writes have committed, so the
+            // shared/donor-offset path in Gemma4ModelInner reads stale state.
+            // eval() walks the lazy graph and forces the cache writes through.
+            // The cost is one ~10ms barrier at the prefill→decode boundary,
+            // not a per-token sync, so steady-state decode throughput is
+            // unchanged. (Verified on Gemma 4 E2B 4bit, M5 Max: 132 tok/s.)
+            eval(y.tokens)
 
         case .logits(let result):
             y = .init(tokens: convertToToken(logits: result.logits))


### PR DESCRIPTION
## Summary

After [`000c43f`](https://github.com/ekryski/mlx-swift-lm/commit/000c43f2c020f3ab9a7858076cdf7cd78a515369) reverted the prefill→decode boundary from sync to `asyncEval`, **Gemma 4 produces garbage decode output**: every token after the first is `<pad>`, regardless of context size, sampling config, or KV-quant setting.

```
[BENCH] Output: Hello<pad><pad><pad><pad><pad><pad><pad><pad>...
```

## Root cause

With `asyncEval(y.tokens)`, the second forward pass is allowed to start before the prefill's per-layer KV-cache writes have committed. Gemma 4's `Gemma4ModelInner.callAsFunction` snapshots `cache.offset` for the shared/donor-offset path (lines 904–906), which then reads stale state. The first decode token works because computing it forces lazy eval through `.item()` on the logits, but every subsequent token sees uncommitted KV from the donor layer and samples token id 0 (`<pad>`).

## Why other models were unaffected

- **Qwen 3.5 0.8B** uses GatedDeltaNet — completely different cache path. Verified still 393 tok/s, coherent.
- Models without KV donor sharing don't depend on a snapshotted offset.

## Why both `MLX_DISABLE_COMPILE=1` and `GEMMA4_FUSED_NORM_ROPE=0` had to be set together for the bug to disappear

Each fused path on its own keeps the decode pipeline async enough to expose the race. Only when **both** are off does the dispatch pattern hit a barrier that "rescues" the in-flight prefill work — masking the bug. That's why the bisect was confusing.

## Fix

Replace the single `asyncEval` with `eval(y.tokens)`. This walks the lazy graph for the first decode token, which forces the prefill cache writes through. It is **a one-time barrier at the prefill→decode boundary, not a per-token sync** — steady-state decode throughput is unchanged.

We do **not** restore the previous `synchronize()` + `clearCache()` — those were the parts that motivated the original revert and they're not needed for correctness.

## Verification — M5 Max, macOS 26.3, Gemma 4 E2B 4bit

| Ctx   | Decode    | GPU Peak | Output                                                                            |
| ----- | --------- | -------- | --------------------------------------------------------------------------------- |
| 128   | 132.4 t/s | 3.48 GB  | "This is a very fragmented excerpt, making a precise summary difficult..."        |
| 1024  | 129.2 t/s | 4.71 GB  | "The provided text is an excerpt from **The Great Gatsby** by F. Scott..."        |
| 4096  | 133.6 t/s | 5.72 GB  | "This excerpt from *The Great Gatsby* focuses on a character..."                  |
| 32768 | 107.1 t/s | 7.67 GB  | "This is a significant excerpt from **The Great Gatsby** by F. Scott Fitzgerald." |

Decode throughput matches the broken-output number from before this fix → no perf regression.

## Repro

```bash
bash scripts/benchmark.sh --model gemma4-e2b --method simple --quant 4bit --kv none
```

Pre-fix: `Hello<pad><pad>...`
Post-fix: `Hello! I am a helpful assistant. I can help you with answering questions...`

## Test plan

- [x] Gemma 4 E2B 4bit, simple — coherent
- [x] Gemma 4 E2B 4bit, summarization 128/1024/4096/32768 — coherent at all context sizes
- [x] Qwen 3.5 0.8B 4bit, simple — still 393 tok/s, coherent (regression check)
- [ ] Other Gemma 4 variants (E4B, 26B-A4B, 31B) — should benefit from the same fix; not yet tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)