### PR TITLE
fix(prefill): chunked-prefill must process every token except the last

### DIFF
--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -17,20 +17,29 @@ extension LLMModel {
 
     /// Default prepare step for ``LLMModel``.
     ///
-    /// This will evaluate the prompt in chunks until there is a small number of
-    /// tokens left to feed into the `TokenIterator`.
+    /// Matches Python mlx-lm's `generate_step` prefill loop: process every
+    /// prompt token except the LAST one through chunked prefill (with
+    /// `eval(cache)` + `clearCache()` between chunks). The trailing token is
+    /// returned to the iterator's "primes the pump" call.
+    ///
+    /// Previously the loop only ran when the prompt exceeded `prefillStepSize`,
+    /// so a 1024-token prompt with chunk size 512 chunked correctly but a
+    /// 256-token prompt would skip the loop entirely and process the whole
+    /// thing inside the iterator with no cache cleanup, leaking ~1 GB of
+    /// activation buffers per model into the MLX recycle pool.
     public func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws
         -> PrepareResult
     {
         let prefillStepSize = windowSize ?? 512
         var y = input.text
 
-        // Prepare the prompt in chunks if larger than the prefill size
-        while y.tokens.size > prefillStepSize {
-            let input = y[.newAxis, ..<prefillStepSize]
+        // Prepare the prompt in chunks, leaving exactly 1 token for the iterator.
+        while y.tokens.size > 1 {
+            let chunkSize = min(prefillStepSize, y.tokens.size - 1)
+            let input = y[.newAxis, ..<chunkSize]
             _ = self(input, cache: cache.isEmpty ? nil : cache, state: nil)
             eval(cache)
-            y = y[prefillStepSize...]
+            y = y[chunkSize...]
             // Free intermediate activation buffers between chunks to reduce memory pressure,
             // matching Python mlx-lm's mx.clear_cache() after each prefill chunk.
             MLX.Memory.clearCache()

--- a/Libraries/MLXLLM/Models/GPTOSS.swift
+++ b/Libraries/MLXLLM/Models/GPTOSS.swift
@@ -439,11 +439,15 @@ public class GPTOSSModel: Module, LLMModel, KVCacheDimensionProvider {
         let prefillStepSize = max(windowSize ?? 512, 2048)
         var y = input.text
 
-        while y.tokens.size > prefillStepSize {
-            let input = y[.newAxis, ..<prefillStepSize]
+        // Match Python mlx-lm: process every prefill token except the LAST one
+        // through chunked prefill so we always hit the eval+clearCache between
+        // chunks, even when the prompt fits in a single chunk.
+        while y.tokens.size > 1 {
+            let chunkSize = min(prefillStepSize, y.tokens.size - 1)
+            let input = y[.newAxis, ..<chunkSize]
             _ = self(input, cache: cache.isEmpty ? nil : cache, state: nil)
             eval(cache)
-            y = y[prefillStepSize...]
+            y = y[chunkSize...]
             // Free intermediate activation buffers between chunks to reduce memory pressure,
             // matching Python mlx-lm's mx.clear_cache() after each prefill chunk.
             MLX.Memory.clearCache()

--- a/Libraries/MLXLLM/Models/Gemma4.swift
+++ b/Libraries/MLXLLM/Models/Gemma4.swift
@@ -841,16 +841,14 @@ public class Gemma4ModelInner: Module {
             perLayerInputs = pli
         }
 
-        // Pre-slice per-layer inputs upfront (matching Python's list comprehension pattern).
-        // Avoids re-slicing the 4D tensor 35 times inside the loop.
-        let perLayerSlices: [MLXArray?]
-        if let pli = perLayerInputs {
-            perLayerSlices = (0..<layers.count).map { i in
-                pli[0..., 0..., i, 0...]
-            }
-        } else {
-            perLayerSlices = [MLXArray?](repeating: nil, count: layers.count)
-        }
+        // NOTE: Previously we pre-sliced perLayerInputs into a 35-element array
+        // upfront. That held 35 strong refs to slice views of the parent 4D
+        // tensor for the entire forward pass, keeping the full pli alive in
+        // GPU memory across all layer iterations. Switched to lazy on-demand
+        // slicing inside the loop so each per-layer slice can be released as
+        // soon as the layer that consumed it is done. Matches Python's pattern
+        // (Python's list comprehension is also eager but Python doesn't have
+        // ARC closure capture semantics, so the lifetime ends earlier).
 
         // Pre-compute masks once per forward pass (GPTOSS pattern)
         let seqLen = h.dim(1)
@@ -888,7 +886,7 @@ public class Gemma4ModelInner: Module {
                 maskMode = slidingMask!
             }
 
-            let pli = perLayerSlices[i]
+            let pli: MLXArray? = perLayerInputs.map { $0[0..., 0..., i, 0...] }
 
             // KV sharing: shared layers use the donor's cache to read K/V
             let donorIdx = previousKVs[i]
@@ -947,15 +945,28 @@ public class Gemma4TextModel: Module, LLMModel, KVCacheDimensionProvider {
         let prefillStepSize = max(windowSize ?? 512, 2048)
         var y = input.text
 
-        while y.tokens.size > prefillStepSize {
-            let input = y[.newAxis, ..<prefillStepSize]
+        // Match Python mlx-lm: process every prefill token except the LAST one
+        // through chunked prefill with eval(cache) + clearCache between chunks.
+        // The single trailing token is returned to the iterator's "primes the
+        // pump" call, which produces the first decode logits.
+        //
+        // Previously this loop only ran for prompts > prefillStepSize, so for
+        // any prompt that fit in a single chunk (e.g. 1024 tokens with chunk
+        // size 2048) the entire prompt was processed in one shot inside the
+        // iterator with NO clearCache, leaving 1–5 GB of intermediate
+        // activation buffers in the MLX recycle pool until the user
+        // explicitly cleared it. (M5 Max, Gemma 4 E2B 4bit, 1024 ctx:
+        // ~3.3 GB cache pool growth before this fix.)
+        while y.tokens.size > 1 {
+            let chunkSize = min(prefillStepSize, y.tokens.size - 1)
+            let input = y[.newAxis, ..<chunkSize]
             // Call model() directly — skip lmHead + softcap during prefill chunks.
             // The LM head projects hidden states to vocab_size (262K), creating a
             // ~1GB tensor that eval(cache) doesn't need. Skipping it avoids
             // allocating that dead-end buffer in the lazy graph.
             _ = model(input.tokens, cache: cache.isEmpty ? nil : cache)
             eval(cache)
-            y = y[prefillStepSize...]
+            y = y[chunkSize...]
             // Free intermediate activation buffers between chunks to reduce memory pressure,
             // matching Python mlx-lm's mx.clear_cache() after each prefill chunk.
             MLX.Memory.clearCache()

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -693,11 +693,15 @@ public class Qwen35Model: Module, LLMModel, KVCacheDimensionProvider {
         let prefillStepSize = max(windowSize ?? 512, 4096)
         var y = input.text
 
-        while y.tokens.size > prefillStepSize {
-            let input = y[.newAxis, ..<prefillStepSize]
+        // Match Python mlx-lm: process every prefill token except the LAST one
+        // through chunked prefill so we always hit the eval+clearCache between
+        // chunks, even when the prompt fits in a single chunk.
+        while y.tokens.size > 1 {
+            let chunkSize = min(prefillStepSize, y.tokens.size - 1)
+            let input = y[.newAxis, ..<chunkSize]
             _ = self(input, cache: cache.isEmpty ? nil : cache, state: nil)
             eval(cache)
-            y = y[prefillStepSize...]
+            y = y[chunkSize...]
             // Free intermediate activation buffers between chunks to reduce memory pressure,
             // matching Python mlx-lm's mx.clear_cache() after each prefill chunk.
             MLX.Memory.clearCache()


### PR DESCRIPTION
## Summary

The prefill loops in `LLMModel.prepare` and the per-model overrides (Gemma4, Qwen35, GPTOSS) only ran when `y.tokens.size > prefillStepSize`, so any prompt that fit in a single chunk (e.g. 1024 tokens with `prefillStepSize=2048`) skipped the loop entirely. The whole prompt then got processed in one shot inside `TokenIterator.prepare`'s "primes the pump" call, with **no `eval(cache)` + `clearCache()` cleanup**, leaking 1–5 GB of intermediate activation buffers into the MLX recycle pool.

This matches Python `mlx-lm`'s pattern (`mlx_lm/generate.py:429–450`): process all prompt tokens **except the LAST one** through chunked prefill, leaving exactly 1 trailing token for the iterator. That way we always hit `eval(cache) + clearCache()`, regardless of prompt size.

Also drops the 35-element pre-sliced `perLayerInputs` array in `Gemma4ModelInner.callAsFunction` in favor of lazy on-demand slicing inside the layer loop. The pre-slice held 35 strong refs to slice views of the parent 4D `pli` tensor for the entire forward pass — Swift ARC closure capture extends the parent tensor's lifetime across all 35 layer iterations, where Python's list comprehension doesn't.

## Measurements (M5 Max, Gemma 4 E2B 4bit, summarization)

| Ctx   | Decode (was → is)        | asyncEval (was → is)  | KV+weights delta (was → is)   |
| ----- | ------------------------ | --------------------- | ----------------------------- |
| 128   | 130 → **165 t/s** (+27%) | 6.65 → 5.21 ms        | 169 MB → **5 MB** (33x less)  |
| 1024  | 131 → **152 t/s** (+16%) | 6.62 → 5.40 ms        | 145 MB → 17 MB (8.5x less)    |
| 4096  | 132 → 129 t/s (~flat)    | 6.61 → 5.84 ms        | 211 MB → 213 MB               |

The 4096 case is ~flat because the loop already ran for that prompt size. 128 and 1024 see the big jumps because they previously skipped the loop entirely.

The asyncEval drop on top of the throughput gain is interesting — fewer live MLXArrays in the lazy graph means smaller per-token graph at decode time and likely fewer GPU dispatches.

## Regression check

Qwen 3.5 0.8B (GatedDeltaNet, hits `LLMModel.prepare`): 395.4 tok/s decode, coherent. No regression.

## Test plan

- [x] Gemma 4 E2B 4bit summarization 128/1024/4096 — coherent, faster, less memory
- [x] Qwen 3.5 0.8B 4bit simple — still 395 tok/s, coherent
- [ ] Gemma 4 E2B 4bit summarization 32768 — should be ~flat like 4096
- [ ] GPTOSS 20B — same loop pattern, expected to benefit similarly to Gemma at small/medium prompts
- [ ] Qwen 3.5 9B / 27B — same as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)