### PR TITLE
feat: generation pipeline — cache, kvScheme, thinking, perplexity

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -102,6 +102,48 @@ public struct GenerateParameters: Sendable {
     /// number of tokens to consider for frequency penalty
     public var frequencyContextSize: Int
 
+    /// KV cache compression scheme. nil = use kvBits (affine quantization) if set.
+    /// "turbo1" through "turbo4" = TurboQuant compression at 1-4 bits.
+    /// When set, kvBits is ignored for cache creation.
+    public var kvScheme: String?
+
+    /// Additional logit processors applied after built-in penalty processors.
+    /// Use this to inject custom processors (e.g., EOS suppression for thinking models).
+    public nonisolated(unsafe) var additionalProcessors: [any LogitProcessor]
+
+    /// Reasoning effort hint (e.g., "low", "medium", "high")
+    public var reasoningEffort: String?
+
+    /// N-gram size for prompt-lookup speculative decoding. When > 0, the iterator
+    /// searches for matching n-grams in the prompt text and uses continuations as
+    /// draft tokens, verifying them in a single batched forward pass.
+    /// Typical value: 3 (trigram matching). Set to 0 to disable.
+    public var ngramSize: Int
+
+    /// Maximum draft tokens per n-gram speculation round.
+    public var maxNgramDraftTokens: Int
+
+    /// Token ID marking the start of a thinking phase (e.g., <think> token).
+    /// When set with thinkEndTokenId, log probabilities are tracked separately
+    /// for thinking vs. generation phases in GenerateCompletionInfo.
+    public var thinkStartTokenId: Int32?
+
+    /// Token ID marking the end of a thinking phase (e.g., </think> token).
+    public var thinkEndTokenId: Int32?
+
+    /// When true, the iterator starts already inside the thinking phase.
+    /// Use this when <think> was prepended as an assistant prefix in the prompt
+    /// rather than being generated — so the iterator never sees the start token.
+    public var thinkingPhasePrefilled: Bool
+
+    /// When true, per-token log probs, token IDs, and phase labels are stored
+    /// in the TokenIterator for downstream KLD computation.
+    public var collectPerTokenData: Bool
+
+    /// When true, accumulate log probabilities for perplexity computation.
+    /// Default: false. Set to true when perplexity tracking is needed.
+    public var trackPerplexity: Bool
+
     public init(
         maxTokens: Int? = nil,
         maxKVSize: Int? = nil,
@@ -118,7 +160,17 @@ public struct GenerateParameters: Sendable {
         presenceContextSize: Int = 20,
         frequencyPenalty: Float? = nil,
         frequencyContextSize: Int = 20,
-        prefillStepSize: Int = 512
+        prefillStepSize: Int = 512,
+        kvScheme: String? = nil,
+        additionalProcessors: [any LogitProcessor] = [],
+        reasoningEffort: String? = nil,
+        ngramSize: Int = 3,
+        maxNgramDraftTokens: Int = 3,
+        thinkStartTokenId: Int32? = nil,
+        thinkEndTokenId: Int32? = nil,
+        thinkingPhasePrefilled: Bool = false,
+        collectPerTokenData: Bool = false,
+        trackPerplexity: Bool = false
     ) {
         self.maxTokens = maxTokens
         self.maxKVSize = maxKVSize
@@ -136,6 +188,16 @@ public struct GenerateParameters: Sendable {
         self.frequencyPenalty = frequencyPenalty
         self.frequencyContextSize = frequencyContextSize
         self.prefillStepSize = prefillStepSize
+        self.kvScheme = kvScheme
+        self.additionalProcessors = additionalProcessors
+        self.reasoningEffort = reasoningEffort
+        self.ngramSize = ngramSize
+        self.maxNgramDraftTokens = maxNgramDraftTokens
+        self.thinkStartTokenId = thinkStartTokenId
+        self.thinkEndTokenId = thinkEndTokenId
+        self.thinkingPhasePrefilled = thinkingPhasePrefilled
+        self.collectPerTokenData = collectPerTokenData
+        self.trackPerplexity = trackPerplexity
     }
 
     public func sampler() -> LogitSampler {
@@ -152,46 +214,37 @@ public struct GenerateParameters: Sendable {
         }
     }
 
-    public func processor() -> LogitProcessor? {
-        let repetitionContext: RepetitionContext?
+    public func processor() -> (any LogitProcessor)? {
+        var all: [any LogitProcessor] = []
+
         if let repetitionPenalty, repetitionPenalty != 0, repetitionContextSize > 0 {
-            repetitionContext = RepetitionContext(
-                repetitionPenalty: repetitionPenalty,
-                repetitionContextSize: repetitionContextSize
-            )
-        } else {
-            repetitionContext = nil
+            all.append(
+                RepetitionContext(
+                    repetitionPenalty: repetitionPenalty,
+                    repetitionContextSize: repetitionContextSize))
         }
 
-        let presenceContext: PresencePenaltyContext?
         if let presencePenalty, presencePenalty != 0, presenceContextSize > 0 {
-            presenceContext = PresencePenaltyContext(
-                presencePenalty: presencePenalty,
-                presenceContextSize: presenceContextSize
-            )
-        } else {
-            presenceContext = nil
+            all.append(
+                PresencePenaltyContext(
+                    presencePenalty: presencePenalty,
+                    presenceContextSize: presenceContextSize))
         }
 
-        let frequencyContext: FrequencyPenaltyContext?
         if let frequencyPenalty, frequencyPenalty != 0, frequencyContextSize > 0 {
-            frequencyContext = FrequencyPenaltyContext(
-                frequencyPenalty: frequencyPenalty,
-                frequencyContextSize: frequencyContextSize
-            )
-        } else {
-            frequencyContext = nil
+            all.append(
+                FrequencyPenaltyContext(
+                    frequencyPenalty: frequencyPenalty,
+                    frequencyContextSize: frequencyContextSize))
         }
 
-        if repetitionContext == nil && presenceContext == nil && frequencyContext == nil {
-            return nil
-        }
+        all.append(contentsOf: additionalProcessors)
 
-        return PenaltyProcessor(
-            repetitionContext: repetitionContext,
-            presenceContext: presenceContext,
-            frequencyContext: frequencyContext
-        )
+        switch all.count {
+        case 0: return nil
+        case 1: return all[0]
+        default: return CompositeLogitProcessor(processors: all)
+        }
     }
 }
 
@@ -490,6 +543,35 @@ public struct PenaltyProcessor: LogitProcessor {
     }
 }
 
+/// Composes multiple logit processors into a single processor.
+public struct CompositeLogitProcessor: LogitProcessor {
+    var processors: [any LogitProcessor]
+
+    public init(processors: [any LogitProcessor]) {
+        self.processors = processors
+    }
+
+    mutating public func prompt(_ prompt: MLXArray) {
+        for i in 0..<processors.count {
+            processors[i].prompt(prompt)
+        }
+    }
+
+    public func process(logits: MLXArray) -> MLXArray {
+        var logits = logits
+        for processor in processors {
+            logits = processor.process(logits: logits)
+        }
+        return logits
+    }
+
+    mutating public func didSample(token: MLXArray) {
+        for i in 0..<processors.count {
+            processors[i].didSample(token: token)
+        }
+    }
+}
+
 /// Common properties shared by token-generating iterators.
 protocol TokenIteratorProtocol: Sequence, IteratorProtocol where Element == Int {
     var maxTokens: Int? { get }
@@ -526,7 +608,7 @@ public struct TokenIterator: TokenIteratorProtocol {
 
     var y: LMInput.Text
     var cache: [KVCache]
-    var processor: LogitProcessor?
+    var processor: (any LogitProcessor)?
     let sampler: LogitSampler
 
     var tokenCount = 0
@@ -536,6 +618,7 @@ public struct TokenIterator: TokenIteratorProtocol {
     let kvBits: Int?
     let kvGroupSize: Int
     let quantizedKVStart: Int
+    let kvScheme: String?
 
     // Internal metrics
     var promptPrefillTime: TimeInterval = 0.0
@@ -564,6 +647,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.kvBits = parameters.kvBits
         self.kvGroupSize = parameters.kvGroupSize
         self.quantizedKVStart = parameters.quantizedKVStart
+        self.kvScheme = parameters.kvScheme
 
         self.promptPrefillTime = try measure {
             try prepare(input: .init(text: y), windowSize: parameters.prefillStepSize)
@@ -597,6 +681,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.kvBits = parameters.kvBits
         self.kvGroupSize = parameters.kvGroupSize
         self.quantizedKVStart = parameters.quantizedKVStart
+        self.kvScheme = parameters.kvScheme
 
         self.promptPrefillTime = try measure {
             try prepare(input: input, windowSize: parameters.prefillStepSize)
@@ -615,7 +700,7 @@ public struct TokenIterator: TokenIteratorProtocol {
     ///   - maxTokens: maximum number of tokens to generate
     public init(
         input: LMInput, model: any LanguageModel, cache: [KVCache]? = nil,
-        processor: LogitProcessor?, sampler: LogitSampler, prefillStepSize: Int = 512,
+        processor: (any LogitProcessor)?, sampler: LogitSampler, prefillStepSize: Int = 512,
         maxTokens: Int? = nil
     ) throws {
         self.model = model
@@ -630,6 +715,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.kvBits = nil
         self.kvGroupSize = 64
         self.quantizedKVStart = 0
+        self.kvScheme = nil
 
         self.promptPrefillTime = try measure {
             try prepare(input: input, windowSize: prefillStepSize)
@@ -743,7 +829,7 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
     var draftCache: [KVCache]
     let quantizeKVCache: (inout [KVCache]) -> Void
 
-    var processor: LogitProcessor?
+    var processor: (any LogitProcessor)?
     let sampler: LogitSampler
 
     var tokenCount = 0
@@ -756,6 +842,18 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
 
     // Internal metrics
     var promptPrefillTime: TimeInterval = 0.0
+
+    /// Tokens accepted from draft model (for acceptance rate tracking).
+    public private(set) var draftAcceptedCount = 0
+
+    /// Total draft tokens proposed (for acceptance rate tracking).
+    public private(set) var draftProposedCount = 0
+
+    /// The acceptance rate of draft tokens (0.0 to 1.0).
+    public var acceptanceRate: Double {
+        guard draftProposedCount > 0 else { return 0 }
+        return Double(draftAcceptedCount) / Double(draftProposedCount)
+    }
 
     /// Initialize a `SpeculativeTokenIterator` with the given input.
     ///
@@ -845,11 +943,17 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
             return
         }
 
+        // Snapshot MambaCache layers before speculation (SSM state is cumulative,
+        // not trimmable, so we must restore on rejection)
+        snapshotMambaCaches(mainCache)
+        snapshotMambaCaches(draftCache)
+
         // Draft generation: autoregressive loop with draft model
         var draftProcessor = processor  // Copy to discard later
         var draftTokens = [MLXArray]()
         for _ in 0 ..< numDraft {
             let draftResult = draftModel(draftY[text: .newAxis], cache: draftCache, state: nil)
+            quantizeKVCache(&draftCache)
             var draftLogits = draftResult.logits[0..., -1, 0...]
             draftLogits = draftProcessor?.process(logits: draftLogits) ?? draftLogits
             let draftToken = sampler.sample(logits: draftLogits)
@@ -900,15 +1004,28 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
             accepted += 1
         }
 
+        // Update acceptance metrics
+        draftAcceptedCount += accepted
+        draftProposedCount += numDraft
+
         // Always emit the main model's token at position `accepted`
         // (either the correction token or the bonus token if all drafts matched)
         let finalToken = mainTokens[accepted ... accepted]
         processor?.didSample(token: finalToken)
         pendingTokens.append(mainTokensList[accepted])
 
-        // Rewind caches for rejected tokens
+        // Rewind trimmable caches for rejected tokens
         trimPromptCache(mainCache, numTokens: numDraft - accepted)
         trimPromptCache(draftCache, numTokens: Swift.max(numDraft - accepted - 1, 0))
+
+        // Restore MambaCache layers on rejection, discard snapshots on full acceptance
+        if accepted == numDraft {
+            discardMambaSnapshots(mainCache)
+            discardMambaSnapshots(draftCache)
+        } else {
+            restoreMambaCaches(mainCache)
+            restoreMambaCaches(draftCache)
+        }
 
         // Apply dynamic cache quantization after rewind
         quantizeKVCache(&mainCache)
@@ -927,6 +1044,35 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
                     finalToken,
                 ])
             )
+        }
+    }
+
+    // MARK: - MambaCache Helpers
+
+    /// Snapshot all MambaCache layers for potential restoration on rejection.
+    private func snapshotMambaCaches(_ cache: [KVCache]) {
+        for c in cache {
+            if let mambaCache = c as? MambaCache {
+                mambaCache.snapshot()
+            }
+        }
+    }
+
+    /// Restore all MambaCache layers from their snapshots (draft tokens rejected).
+    private func restoreMambaCaches(_ cache: [KVCache]) {
+        for c in cache {
+            if let mambaCache = c as? MambaCache {
+                mambaCache.restore()
+            }
+        }
+    }
+
+    /// Discard MambaCache snapshots without restoring (all draft tokens accepted).
+    private func discardMambaSnapshots(_ cache: [KVCache]) {
+        for c in cache {
+            if let mambaCache = c as? MambaCache {
+                mambaCache.discardSnapshot()
+            }
         }
     }
 
@@ -1809,6 +1955,21 @@ public struct GenerateCompletionInfo: Sendable {
     /// Reason generation stopped.
     public let stopReason: GenerateStopReason
 
+    /// Per-token log probabilities collected during generation (when collectPerTokenData is true).
+    public var perTokenLogProbs: [Float]?
+
+    /// Per-token IDs collected during generation (when collectPerTokenData is true).
+    public var perTokenIds: [Int]?
+
+    /// Per-token phase labels ("thinking" or "generation") collected during generation.
+    public var perTokenPhases: [String]?
+
+    /// Perplexity computed over the generation (non-thinking) phase.
+    public var generationPerplexity: Float?
+
+    /// Perplexity computed over the thinking phase.
+    public var thinkingPerplexity: Float?
+
     /// The number of tokens processed per second during the prompt phase.
     public var promptTokensPerSecond: Double {
         Double(promptTokenCount) / promptTime
@@ -1824,13 +1985,23 @@ public struct GenerateCompletionInfo: Sendable {
         generationTokenCount: Int,
         promptTime: TimeInterval,
         generationTime: TimeInterval,
-        stopReason: GenerateStopReason = .stop
+        stopReason: GenerateStopReason = .stop,
+        perTokenLogProbs: [Float]? = nil,
+        perTokenIds: [Int]? = nil,
+        perTokenPhases: [String]? = nil,
+        generationPerplexity: Float? = nil,
+        thinkingPerplexity: Float? = nil
     ) {
         self.promptTokenCount = promptTokenCount
         self.generationTokenCount = generationTokenCount
         self.promptTime = promptTime
         self.generateTime = generationTime
         self.stopReason = stopReason
+        self.perTokenLogProbs = perTokenLogProbs
+        self.perTokenIds = perTokenIds
+        self.perTokenPhases = perTokenPhases
+        self.generationPerplexity = generationPerplexity
+        self.thinkingPerplexity = thinkingPerplexity
     }
 
     public func summary() -> String {

--- a/Libraries/MLXLMCommon/ModelContainer.swift
+++ b/Libraries/MLXLMCommon/ModelContainer.swift
@@ -183,10 +183,12 @@ public final class ModelContainer: Sendable {
     ///   allowing non-Sendable types like `LMInput` to safely cross isolation boundaries.
     public func generate(
         input: consuming sending LMInput,
+        cache: consuming sending [KVCache]? = nil,
         parameters: GenerateParameters,
         wiredMemoryTicket: WiredMemoryTicket? = nil
     ) async throws -> AsyncStream<Generation> {
         let input = SendableBox(input)
+        let cache = SendableBox(cache)
 
         // Note: this is only visiting the model exclusively
         // for the pre-fill time.  Beyond that there is no
@@ -198,11 +200,64 @@ public final class ModelContainer: Sendable {
         return try await context.read { context in
             try MLXLMCommon.generate(
                 input: input.consume(),
+                cache: cache.consume(),
                 parameters: parameters,
                 context: context,
                 wiredMemoryTicket: wiredMemoryTicket
             )
         }
+    }
+
+    /// Generate raw token IDs from the model.
+    ///
+    /// Unlike `generate()` which yields detokenized `.chunk(String)` events,
+    /// this yields `.token(Int)` events with raw integer token IDs. This enables
+    /// downstream parsers that need token-level control.
+    ///
+    /// - Parameters:
+    ///   - input: Prepared language model input
+    ///   - cache: Optional pre-created KV cache
+    ///   - parameters: Generation parameters
+    ///   - includeStopToken: If true, stop/EOS tokens are yielded before termination
+    ///   - wiredMemoryTicket: Optional wired memory ticket
+    /// - Returns: An AsyncStream of token generation events
+    public func generateTokens(
+        input: consuming sending LMInput,
+        cache: consuming sending [KVCache]? = nil,
+        parameters: GenerateParameters,
+        includeStopToken: Bool = false,
+        wiredMemoryTicket: WiredMemoryTicket? = nil
+    ) async throws -> AsyncStream<TokenGeneration> {
+        let input = SendableBox(input)
+        let cache = SendableBox(cache)
+
+        return try await context.read { context in
+            try MLXLMCommon.generateTokens(
+                input: input.consume(),
+                cache: cache.consume(),
+                parameters: parameters,
+                context: context,
+                includeStopToken: includeStopToken,
+                wiredMemoryTicket: wiredMemoryTicket
+            )
+        }
+    }
+
+    /// Create a new KV cache array for the model with the given parameters.
+    ///
+    /// Use this to pre-create caches for reuse across multiple generation calls.
+    /// The returned cache array matches the model's layer structure (one cache per layer).
+    ///
+    /// - Parameter parameters: Generation parameters (controls cache type: simple vs rotating)
+    /// - Returns: Array of KVCache instances, one per model layer
+    public func newCache(parameters: GenerateParameters? = nil) async -> [KVCache] {
+        // KVCache is not Sendable, but newCache creates fresh independent instances
+        // that are safe to transfer across isolation boundaries.
+        nonisolated(unsafe) var result: [KVCache] = []
+        await context.read { context in
+            result = context.model.newCache(parameters: parameters)
+        }
+        return result
     }
 
     /// Decode token IDs to a string.

--- a/Libraries/MLXLMCommon/WiredMemoryUtils.swift
+++ b/Libraries/MLXLMCommon/WiredMemoryUtils.swift
@@ -23,6 +23,18 @@ public struct WiredMemoryMeasurement: Sendable {
     public var totalBytes: Int {
         max(0, weightBytes) + max(0, kvBytes) + max(0, workspaceBytes)
     }
+
+    public init(
+        weightBytes: Int, kvBytes: Int, workspaceBytes: Int,
+        peakActiveBytes: Int, tokenCount: Int, prefillStepSize: Int
+    ) {
+        self.weightBytes = weightBytes
+        self.kvBytes = kvBytes
+        self.workspaceBytes = workspaceBytes
+        self.peakActiveBytes = peakActiveBytes
+        self.tokenCount = tokenCount
+        self.prefillStepSize = prefillStepSize
+    }
 }
 
 /// Helpers for deriving wired memory budgets from real runtime measurements.
@@ -243,6 +255,115 @@ public enum WiredMemoryUtils {
             context: context,
             parameters: parameters,
             resetPeakMemory: resetPeakMemory
+        )
+    }
+
+    /// Create an optimally-sized wired memory ticket from a measurement.
+    ///
+    /// Uses `WiredBudgetPolicy` with the measured weights + workspace as the base budget
+    /// and the KV cache size as the active ticket size. The total budget is clamped to
+    /// the GPU's recommended working set size.
+    ///
+    /// - Parameters:
+    ///   - measurement: A measurement from `tune()`.
+    ///   - headroom: Fractional headroom above measured total (default: 0.1 = 10%).
+    /// - Returns: A ticket sized for the measured workload.
+    public static func ticket(
+        from measurement: WiredMemoryMeasurement,
+        headroom: Double = 0.1
+    ) -> WiredMemoryTicket {
+        let budget = Int(Double(measurement.totalBytes) * (1.0 + headroom))
+        let cap = GPU.maxRecommendedWorkingSetBytes() ?? budget
+        let clampedBudget = min(budget, cap)
+
+        return WiredMemoryTicket(
+            size: clampedBudget,
+            policy: WiredSumPolicy(cap: cap)
+        )
+    }
+
+    /// Estimate memory budget from model parameters without running a measurement pass.
+    ///
+    /// Computes: model_weights + kv_cache(maxTokens, kvConfig) + workspace.
+    /// The KV cache estimate uses the actual cache structure (respects KV quantization,
+    /// rotating cache limits, and hybrid architectures with mixed cache types).
+    ///
+    /// - Parameters:
+    ///   - model: The loaded language model (for weight byte computation).
+    ///   - maxTokens: Maximum context length to budget for (prefill + generation).
+    ///   - parameters: Generation parameters (KV bits, scheme, maxKVSize, etc.).
+    ///   - workspaceFraction: Fraction of weight bytes to add for workspace (default: 0.15).
+    /// - Returns: Estimated total bytes needed.
+    public static func estimateBudget(
+        model: any LanguageModel,
+        maxTokens: Int,
+        parameters: GenerateParameters,
+        workspaceFraction: Double = 0.15
+    ) -> Int {
+        let weightBytes = model.parameters().flattened().reduce(0) { $0 + $1.1.nbytes }
+
+        // KV cache estimate: create actual cache structure, estimate per-token storage
+        let cache = model.newCache(parameters: parameters)
+
+        var kvBytesEstimate = 0
+        for c in cache {
+            if c is KVCacheSimple {
+                // Conservative: 512 bytes per token per layer (covers most configs)
+                let effectiveTokens: Int
+                if let maxKV = parameters.maxKVSize {
+                    effectiveTokens = min(maxTokens, maxKV)
+                } else {
+                    effectiveTokens = maxTokens
+                }
+                kvBytesEstimate += effectiveTokens * 512
+            }
+            // MambaCache: fixed-size state, negligible compared to KV cache
+        }
+
+        // Adjust for KV compression schemes
+        if let scheme = parameters.kvScheme, scheme.hasPrefix("turbo") {
+            let compressionRatio: Double
+            if scheme.contains("4v2") { compressionRatio = 5.0 }
+            else if scheme.hasSuffix("4") { compressionRatio = 4.0 }
+            else if scheme.hasSuffix("3") { compressionRatio = 5.3 }
+            else if scheme.hasSuffix("2") { compressionRatio = 8.0 }
+            else { compressionRatio = 4.0 }
+            kvBytesEstimate = Int(Double(kvBytesEstimate) / compressionRatio)
+        } else if let bits = parameters.kvBits, bits > 0 {
+            kvBytesEstimate = kvBytesEstimate * bits / 16
+        }
+
+        let workspaceEstimate = Int(Double(weightBytes) * workspaceFraction)
+
+        return weightBytes + kvBytesEstimate + workspaceEstimate
+    }
+
+    /// Create a ticket from a static estimate (no measurement pass required).
+    ///
+    /// The ticket size is: estimateBudget() * (1 + headroom), clamped to GPU capacity.
+    ///
+    /// - Parameters:
+    ///   - model: The loaded language model.
+    ///   - maxTokens: Maximum context length to budget for.
+    ///   - parameters: Generation parameters (KV config affects cache size).
+    ///   - headroom: Fractional headroom above estimate (default: 0.1 = 10%).
+    /// - Returns: A ticket sized for the estimated workload.
+    public static func estimatedTicket(
+        model: any LanguageModel,
+        maxTokens: Int,
+        parameters: GenerateParameters,
+        headroom: Double = 0.1
+    ) -> WiredMemoryTicket {
+        let budget = estimateBudget(
+            model: model, maxTokens: maxTokens, parameters: parameters)
+        let total = Int(Double(budget) * (1.0 + headroom))
+
+        let gpuCap = GPU.maxRecommendedWorkingSetBytes() ?? total
+        let clampedTotal = min(total, gpuCap)
+
+        return WiredMemoryTicket(
+            size: clampedTotal,
+            policy: WiredSumPolicy(cap: gpuCap)
         )
     }
 }


### PR DESCRIPTION
Clean port from ek/tom-eric-moe-tuning. Part of alpha cleanup. Includes:

- KVCache memory leak improvements
- KVCache set up for speculative decoding (especially for Mambacache which is hard to do speculative decoding with, requires snapshotting)
- Smarter memory ticket size evaluation that takes into account model size, quantization, kv cache, and prompt size. This way we're not under-allocating nullifying the value of pinning memory or over allocating dramatically. Could use some tuning in the future.