### PR TITLE
fix: GemmaPrefillBridge Sendable + benchmark resource path

### DIFF
--- a/Libraries/MLXLLM/Models/GemmaPrefillBridge.swift
+++ b/Libraries/MLXLLM/Models/GemmaPrefillBridge.swift
@@ -41,8 +41,8 @@ private typealias GemmaCleanupFn = @convention(c) () -> Void
 
 // MARK: - Bridge
 
-final class GemmaPrefillBridge {
-    static let shared = GemmaPrefillBridge()
+final class GemmaPrefillBridge: @unchecked Sendable {
+    nonisolated(unsafe) static let shared = GemmaPrefillBridge()
 
     private var handle: UnsafeMutableRawPointer?
     private var initialized = false

--- a/Tests/Benchmarks/InferenceBenchmark.swift
+++ b/Tests/Benchmarks/InferenceBenchmark.swift
@@ -1775,6 +1775,7 @@ struct InferenceBenchmarks {
         let thisFile = URL(fileURLWithPath: filePath)
         let benchDir = thisFile.deletingLastPathComponent()
         let resourceURL = benchDir.appendingPathComponent("Resources")
+            .appendingPathComponent("llm-test-prompts")
             .appendingPathComponent(name)
             .appendingPathExtension(ext)
         return FileManager.default.fileExists(atPath: resourceURL.path) ? resourceURL : nil


### PR DESCRIPTION
## Summary
Two small fixes needed after the alpha cleanup merges:

1. **GemmaPrefillBridge Sendable**: alpha's Swift 6 strict concurrency rejects the `static let shared` without Sendable conformance. Add `@unchecked Sendable` + `nonisolated(unsafe)`.

2. **Benchmark resource path**: prompt files live in `Tests/Benchmarks/Resources/llm-test-prompts/` but the code was looking in `Resources/` directly. Add the subdirectory to the path.

## Test
After these fixes, benchmark runs clean:
```
[ENV] NAX: ENABLED ✓
[ENV] Gemma template: OK (16317 chars)
[BENCH] Prefill: 15616.6 tok/s
[BENCH] Generation: 190.1 tok/s
[BENCH] TTFT: 28ms
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)