### PR TITLE
evaluate: populate per-token data for PPL and KLD (opt-in, ~zero overhead)

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -572,11 +572,82 @@ public struct CompositeLogitProcessor: LogitProcessor {
     }
 }
 
+// MARK: - Per-Token Data Capture (opt-in)
+
+/// Per-token data produced during generation when
+/// ``GenerateParameters/trackPerplexity`` or ``GenerateParameters/collectPerTokenData``
+/// is set.
+///
+/// Surfaces on ``GenerateCompletionInfo``. Downstream consumers such as the
+/// benchmark harness use `tokenIds` + `logProbs` to compute KL divergence
+/// against a baseline model via forced decode; `thinkingPerplexity` and
+/// `generationPerplexity` are the model's own per-phase perplexity over
+/// the generated tokens it sampled.
+public struct PerTokenData: Sendable {
+    public let tokenIds: [Int]
+    public let logProbs: [Float]
+    public let phases: [String]
+    public let thinkingPerplexity: Float?
+    public let generationPerplexity: Float?
+
+    public init(
+        tokenIds: [Int],
+        logProbs: [Float],
+        phases: [String],
+        thinkingPerplexity: Float?,
+        generationPerplexity: Float?
+    ) {
+        self.tokenIds = tokenIds
+        self.logProbs = logProbs
+        self.phases = phases
+        self.thinkingPerplexity = thinkingPerplexity
+        self.generationPerplexity = generationPerplexity
+    }
+}
+
+/// Reference-type box holding the lazy MLXArray handles accumulated during a
+/// generation run.
+///
+/// `TokenIterator` is a struct and `for token in iterator { … }` copies it into
+/// the for-in machinery before iterating. A reference-type capture box keeps
+/// the data the copy appends visible to the outer iterator so the final flush
+/// can happen after the loop returns.
+///
+/// Entries are lazy — no GPU→CPU transfer happens per step; all transfers are
+/// batched in ``TokenIterator/finalizePerTokenData()`` after
+/// `Stream().synchronize()`.
+final class PerTokenDataCapture {
+    var logProbs: [MLXArray] = []
+    var tokenIds: [MLXArray] = []
+}
+
+extension GenerateParameters {
+    /// True when the generation loop must emit per-token logprobs for PPL or KLD.
+    /// When false, `TokenIterator` leaves its capture slot nil and runs the
+    /// inference path unchanged.
+    var needsPerTokenCapture: Bool {
+        trackPerplexity || collectPerTokenData
+    }
+}
+
 /// Common properties shared by token-generating iterators.
 protocol TokenIteratorProtocol: Sequence, IteratorProtocol where Element == Int {
     var maxTokens: Int? { get }
     var tokenCount: Int { get }
     var promptPrefillTime: TimeInterval { get }
+
+    /// Flush lazy per-token data to CPU, label tokens with phase, and compute
+    /// per-phase perplexity. Returns nil when per-token capture was not enabled.
+    ///
+    /// Must be called only after `Stream().synchronize()` so all lazy logprob
+    /// MLXArrays have completed. Implementations must perform a single batched
+    /// GPU→CPU transfer rather than per-token `.item()` calls.
+    func finalizePerTokenData() -> PerTokenData?
+}
+
+extension TokenIteratorProtocol {
+    /// Default: iterators that don't capture per-token data return nil.
+    public func finalizePerTokenData() -> PerTokenData? { nil }
 }
 
 /// Generator of tokens.
@@ -620,6 +691,19 @@ public struct TokenIterator: TokenIteratorProtocol {
     let quantizedKVStart: Int
     let kvScheme: String?
 
+    // Phase tracking for per-token data capture (cheap Ints + Bool, only read
+    // at finalize time — no inference-loop cost).
+    let thinkStartTokenId: Int?
+    let thinkEndTokenId: Int?
+    let thinkingPhasePrefilled: Bool
+
+    /// Lazy per-token logprob/id capture. Non-nil only when parameters enable
+    /// ``GenerateParameters/trackPerplexity`` or
+    /// ``GenerateParameters/collectPerTokenData``. The `if let` check in
+    /// ``convertToToken(logits:)`` is the only inference-path cost when
+    /// capture is disabled.
+    let perTokenCapture: PerTokenDataCapture?
+
     // Internal metrics
     var promptPrefillTime: TimeInterval = 0.0
 
@@ -648,6 +732,11 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.kvGroupSize = parameters.kvGroupSize
         self.quantizedKVStart = parameters.quantizedKVStart
         self.kvScheme = parameters.kvScheme
+
+        self.thinkStartTokenId = parameters.thinkStartTokenId.map { Int($0) }
+        self.thinkEndTokenId = parameters.thinkEndTokenId.map { Int($0) }
+        self.thinkingPhasePrefilled = parameters.thinkingPhasePrefilled
+        self.perTokenCapture = parameters.needsPerTokenCapture ? PerTokenDataCapture() : nil
 
         self.promptPrefillTime = try measure {
             try prepare(input: .init(text: y), windowSize: parameters.prefillStepSize)
@@ -683,6 +772,11 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.quantizedKVStart = parameters.quantizedKVStart
         self.kvScheme = parameters.kvScheme
 
+        self.thinkStartTokenId = parameters.thinkStartTokenId.map { Int($0) }
+        self.thinkEndTokenId = parameters.thinkEndTokenId.map { Int($0) }
+        self.thinkingPhasePrefilled = parameters.thinkingPhasePrefilled
+        self.perTokenCapture = parameters.needsPerTokenCapture ? PerTokenDataCapture() : nil
+
         self.promptPrefillTime = try measure {
             try prepare(input: input, windowSize: parameters.prefillStepSize)
         }
@@ -716,6 +810,13 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.kvGroupSize = 64
         self.quantizedKVStart = 0
         self.kvScheme = nil
+
+        // The manual init does not carry thinking config or per-token capture.
+        // Callers that need PPL/KLD should use the `parameters:` init instead.
+        self.thinkStartTokenId = nil
+        self.thinkEndTokenId = nil
+        self.thinkingPhasePrefilled = false
+        self.perTokenCapture = nil
 
         self.promptPrefillTime = try measure {
             try prepare(input: input, windowSize: prefillStepSize)
@@ -753,9 +854,100 @@ public struct TokenIterator: TokenIteratorProtocol {
         // transform logits back to a token
         let y = sampler.sample(logits: logits)
 
+        // Opt-in per-token data capture for PPL / KLD.
+        //
+        // Zero inference-path overhead when `perTokenCapture == nil` — the
+        // guard is a single pointer nil-check the optimizer can hoist.
+        //
+        // When enabled, we emit a scalar-output kernel chain per step:
+        //   1. `logSumExp(logits, axes: [-1])` — one reduction producing [1].
+        //   2. `takeAlong(logits, y_exp, axis: -1)` — scalar gather producing [1, 1].
+        //   3. subtract to get logprob[y] = logits[y] - logSumExp(logits).
+        //
+        // This avoids materialising a full-vocab logSoftmax output tensor
+        // (V can be 250k+ tokens → ~1MB per step on decode). Both branches
+        // depend on `logits` only — no data dependency on `y` for the
+        // reduction — so the reduction runs concurrently with sampling.
+        // `asyncEval(selected)` detaches the scalar subgraph from the
+        // token-eval pipeline so the next forward pass is not blocked on
+        // the logprob.
+        if let capture = perTokenCapture {
+            let logSumExpLogits = logSumExp(logits, axes: [-1])
+            let yExpanded = y.expandedDimensions(axis: -1)
+            let yLogit = takeAlong(logits, yExpanded, axis: -1)
+            let selected = yLogit - logSumExpLogits
+            asyncEval(selected)
+            capture.logProbs.append(selected)
+            capture.tokenIds.append(y)
+        }
+
         processor?.didSample(token: y)
 
         return y
+    }
+
+    /// Flush lazy per-token data collected during generation.
+    ///
+    /// Called by the generation loop after `Stream().synchronize()` so all
+    /// captured logprob and token-id MLXArrays have finished evaluating on
+    /// the GPU. Performs one batched GPU→CPU transfer for the whole run,
+    /// assigns phase labels ("thinking" / "generation") based on the
+    /// model's configured `thinkStartTokenId` / `thinkEndTokenId`, and
+    /// computes `exp(-mean(logprobs))` per phase.
+    ///
+    /// Returns `nil` when per-token capture was not enabled for this run.
+    public func finalizePerTokenData() -> PerTokenData? {
+        guard let capture = perTokenCapture, !capture.logProbs.isEmpty else {
+            return nil
+        }
+
+        // Batch the GPU→CPU transfer: concatenate all the 1-element logprob
+        // tensors into a single [N] tensor, then pull it to CPU once.
+        let reshapedLogProbs = capture.logProbs.map { $0.reshaped(1) }
+        let reshapedIds = capture.tokenIds.map { $0.reshaped(1) }
+        let stackedLogprobs = concatenated(reshapedLogProbs).asType(.float32)
+        let stackedIds = concatenated(reshapedIds).asType(.int32)
+
+        let floatLogprobs = stackedLogprobs.asArray(Float.self)
+        let intIds = stackedIds.asArray(Int32.self).map { Int($0) }
+
+        // Phase labels — pure Swift, zero GPU work.
+        var phases: [String] = []
+        phases.reserveCapacity(intIds.count)
+        var inThinking = thinkStartTokenId != nil && thinkingPhasePrefilled
+        for id in intIds {
+            if !inThinking, let startId = thinkStartTokenId, id == startId {
+                inThinking = true
+                phases.append("thinking")
+                continue
+            }
+            if inThinking, let endId = thinkEndTokenId, id == endId {
+                inThinking = false
+                // The end-of-think token itself is part of the thinking phase.
+                phases.append("thinking")
+                continue
+            }
+            phases.append(inThinking ? "thinking" : "generation")
+        }
+
+        func perplexity(for phase: String) -> Float? {
+            var sum: Double = 0
+            var count = 0
+            for i in intIds.indices where phases[i] == phase {
+                sum += Double(floatLogprobs[i])
+                count += 1
+            }
+            guard count > 0 else { return nil }
+            return Float(exp(-sum / Double(count)))
+        }
+
+        return PerTokenData(
+            tokenIds: intIds,
+            logProbs: floatLogprobs,
+            phases: phases,
+            thinkingPerplexity: perplexity(for: "thinking"),
+            generationPerplexity: perplexity(for: "generation")
+        )
     }
 
     /// Evaluate the next token and return the new token (y), updating cache state
@@ -1446,12 +1638,23 @@ public func generate(
         didGenerate(token)
     }
 
+    // runSynchronousGenerationLoop already calls Stream().synchronize() so any
+    // lazy logprobs captured during the loop are safe to flush here. The
+    // capture box is a reference held by a class so the appends the loop made
+    // (through its own mutable copy of the iterator) are visible to us.
+    let perTokenData = iterator.finalizePerTokenData()
+
     return GenerateCompletionInfo(
         promptTokenCount: input.text.tokens.size,
         generationTokenCount: result.generatedTokenIds.count,
         promptTime: result.promptTime + result.promptPrefillTime,
         generationTime: result.generateTime,
-        stopReason: result.stopReason
+        stopReason: result.stopReason,
+        perTokenLogProbs: perTokenData?.logProbs,
+        perTokenIds: perTokenData?.tokenIds,
+        perTokenPhases: perTokenData?.phases,
+        generationPerplexity: perTokenData?.generationPerplexity,
+        thinkingPerplexity: perTokenData?.thinkingPerplexity
     )
 }
 
@@ -1883,17 +2086,27 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
             let now = Date.timeIntervalSinceReferenceDate
             let generateTime = now - start
 
+            // Synchronize before flushing per-token data so the logprob
+            // MLXArrays captured during the loop have all been evaluated.
+            // The synchronize is required for asyncEval-driven safety
+            // anyway; we simply moved it ahead of the info-event emit.
+            Stream().synchronize()
+
+            let perTokenData = iterator.finalizePerTokenData()
+
             let info = GenerateCompletionInfo(
                 promptTokenCount: promptTokenCount,
                 generationTokenCount: tokenCount,
                 promptTime: promptTime + iterator.promptPrefillTime,
                 generationTime: generateTime,
-                stopReason: stopReason ?? .cancelled
+                stopReason: stopReason ?? .cancelled,
+                perTokenLogProbs: perTokenData?.logProbs,
+                perTokenIds: perTokenData?.tokenIds,
+                perTokenPhases: perTokenData?.phases,
+                generationPerplexity: perTokenData?.generationPerplexity,
+                thinkingPerplexity: perTokenData?.thinkingPerplexity
             )
             _ = continuation.yield(handler.infoEvent(info))
-
-            // Synchronize with the stream to ensure tasks are completed
-            Stream().synchronize()
 
             // Finalize the stream
             continuation.finish()

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -136,6 +136,21 @@ public struct GenerateParameters: Sendable {
     /// rather than being generated — so the iterator never sees the start token.
     public var thinkingPhasePrefilled: Bool
 
+    /// Token ID of the harmony channel marker, typically `<|channel|>` (e.g. 200005
+    /// on the GPT-OSS tokenizer). When set, phase labeling uses a harmony state
+    /// machine: the token immediately following the marker selects the phase via
+    /// ``harmonyThinkingChannelTokenIds`` / ``harmonyGenerationChannelTokenIds``.
+    /// Takes precedence over ``thinkStartTokenId`` / ``thinkEndTokenId``.
+    public var harmonyChannelMarkerTokenId: Int32?
+
+    /// Token IDs whose appearance immediately after the harmony channel marker
+    /// transitions the phase to "think" (e.g. `analysis` → 35644 on GPT-OSS).
+    public var harmonyThinkingChannelTokenIds: [Int32]
+
+    /// Token IDs whose appearance immediately after the harmony channel marker
+    /// transitions the phase to "gen" (e.g. `final` → 17196 on GPT-OSS).
+    public var harmonyGenerationChannelTokenIds: [Int32]
+
     /// When true, per-token log probs, token IDs, and phase labels are stored
     /// in the TokenIterator for downstream KLD computation.
     public var collectPerTokenData: Bool
@@ -169,6 +184,9 @@ public struct GenerateParameters: Sendable {
         thinkStartTokenId: Int32? = nil,
         thinkEndTokenId: Int32? = nil,
         thinkingPhasePrefilled: Bool = false,
+        harmonyChannelMarkerTokenId: Int32? = nil,
+        harmonyThinkingChannelTokenIds: [Int32] = [],
+        harmonyGenerationChannelTokenIds: [Int32] = [],
         collectPerTokenData: Bool = false,
         trackPerplexity: Bool = false
     ) {
@@ -196,6 +214,9 @@ public struct GenerateParameters: Sendable {
         self.thinkStartTokenId = thinkStartTokenId
         self.thinkEndTokenId = thinkEndTokenId
         self.thinkingPhasePrefilled = thinkingPhasePrefilled
+        self.harmonyChannelMarkerTokenId = harmonyChannelMarkerTokenId
+        self.harmonyThinkingChannelTokenIds = harmonyThinkingChannelTokenIds
+        self.harmonyGenerationChannelTokenIds = harmonyGenerationChannelTokenIds
         self.collectPerTokenData = collectPerTokenData
         self.trackPerplexity = trackPerplexity
     }
@@ -691,11 +712,18 @@ public struct TokenIterator: TokenIteratorProtocol {
     let quantizedKVStart: Int
     let kvScheme: String?
 
-    // Phase tracking for per-token data capture (cheap Ints + Bool, only read
-    // at finalize time — no inference-loop cost).
+    // Phase tracking for per-token data capture (cheap Ints / Sets / Bool,
+    // only read at finalize time — no inference-loop cost). Three mutually
+    // exclusive modes:
+    //   • harmonyChannelMarkerTokenId set → harmony channel transitions.
+    //   • thinkStartTokenId + thinkEndTokenId set → bracket pair.
+    //   • neither set → all tokens labelled "gen".
     let thinkStartTokenId: Int?
     let thinkEndTokenId: Int?
     let thinkingPhasePrefilled: Bool
+    let harmonyChannelMarkerTokenId: Int?
+    let harmonyThinkingChannelTokenIds: Set<Int>
+    let harmonyGenerationChannelTokenIds: Set<Int>
 
     /// Lazy per-token logprob/id capture. Non-nil only when parameters enable
     /// ``GenerateParameters/trackPerplexity`` or
@@ -736,6 +764,9 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.thinkStartTokenId = parameters.thinkStartTokenId.map { Int($0) }
         self.thinkEndTokenId = parameters.thinkEndTokenId.map { Int($0) }
         self.thinkingPhasePrefilled = parameters.thinkingPhasePrefilled
+        self.harmonyChannelMarkerTokenId = parameters.harmonyChannelMarkerTokenId.map { Int($0) }
+        self.harmonyThinkingChannelTokenIds = Set(parameters.harmonyThinkingChannelTokenIds.map { Int($0) })
+        self.harmonyGenerationChannelTokenIds = Set(parameters.harmonyGenerationChannelTokenIds.map { Int($0) })
         self.perTokenCapture = parameters.needsPerTokenCapture ? PerTokenDataCapture() : nil
 
         self.promptPrefillTime = try measure {
@@ -775,6 +806,9 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.thinkStartTokenId = parameters.thinkStartTokenId.map { Int($0) }
         self.thinkEndTokenId = parameters.thinkEndTokenId.map { Int($0) }
         self.thinkingPhasePrefilled = parameters.thinkingPhasePrefilled
+        self.harmonyChannelMarkerTokenId = parameters.harmonyChannelMarkerTokenId.map { Int($0) }
+        self.harmonyThinkingChannelTokenIds = Set(parameters.harmonyThinkingChannelTokenIds.map { Int($0) })
+        self.harmonyGenerationChannelTokenIds = Set(parameters.harmonyGenerationChannelTokenIds.map { Int($0) })
         self.perTokenCapture = parameters.needsPerTokenCapture ? PerTokenDataCapture() : nil
 
         self.promptPrefillTime = try measure {
@@ -816,6 +850,9 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.thinkStartTokenId = nil
         self.thinkEndTokenId = nil
         self.thinkingPhasePrefilled = false
+        self.harmonyChannelMarkerTokenId = nil
+        self.harmonyThinkingChannelTokenIds = []
+        self.harmonyGenerationChannelTokenIds = []
         self.perTokenCapture = nil
 
         self.promptPrefillTime = try measure {
@@ -891,7 +928,7 @@ public struct TokenIterator: TokenIteratorProtocol {
     /// Called by the generation loop after `Stream().synchronize()` so all
     /// captured logprob and token-id MLXArrays have finished evaluating on
     /// the GPU. Performs one batched GPU→CPU transfer for the whole run,
-    /// assigns phase labels ("thinking" / "generation") based on the
+    /// assigns phase labels ("think" / "gen") based on the
     /// model's configured `thinkStartTokenId` / `thinkEndTokenId`, and
     /// computes `exp(-mean(logprobs))` per phase.
     ///
@@ -911,24 +948,15 @@ public struct TokenIterator: TokenIteratorProtocol {
         let floatLogprobs = stackedLogprobs.asArray(Float.self)
         let intIds = stackedIds.asArray(Int32.self).map { Int($0) }
 
-        // Phase labels — pure Swift, zero GPU work.
-        var phases: [String] = []
-        phases.reserveCapacity(intIds.count)
-        var inThinking = thinkStartTokenId != nil && thinkingPhasePrefilled
-        for id in intIds {
-            if !inThinking, let startId = thinkStartTokenId, id == startId {
-                inThinking = true
-                phases.append("thinking")
-                continue
-            }
-            if inThinking, let endId = thinkEndTokenId, id == endId {
-                inThinking = false
-                // The end-of-think token itself is part of the thinking phase.
-                phases.append("thinking")
-                continue
-            }
-            phases.append(inThinking ? "thinking" : "generation")
-        }
+        // Phase labels — pure Swift, zero GPU work. Three modes dispatched
+        // by which fields were populated at init time:
+        //   1. Harmony channel mode (GPT-OSS):  <|channel|> <channel-name>
+        //      <|message|> ...  where the channel-name token flips phase.
+        //   2. Bracket mode (Qwen, Gemma 4):    <think> ... </think>
+        //      where a single token opens and another closes the block.
+        //   3. None:                            every token labelled
+        //      "gen".
+        let phases: [String] = labelPhases(intIds)
 
         func perplexity(for phase: String) -> Float? {
             var sum: Double = 0
@@ -945,9 +973,73 @@ public struct TokenIterator: TokenIteratorProtocol {
             tokenIds: intIds,
             logProbs: floatLogprobs,
             phases: phases,
-            thinkingPerplexity: perplexity(for: "thinking"),
-            generationPerplexity: perplexity(for: "generation")
+            thinkingPerplexity: perplexity(for: "think"),
+            generationPerplexity: perplexity(for: "gen")
         )
+    }
+
+    /// Assign a phase label ("think" / "gen") to every generated token.
+    ///
+    /// Harmony mode (GPT-OSS and other harmony-format models) is a 2-state
+    /// state machine: on each token we check whether it is the channel marker
+    /// (e.g. `<|channel|>` → 200005). The very next token is the channel name
+    /// (`analysis` → thinking, `final` / `commentary` → generation). The
+    /// marker, name, and subsequent message tokens are all attributed to the
+    /// resolved phase. Unknown channel names keep the prior phase.
+    ///
+    /// Bracket mode (Qwen, Gemma 4) is a single-token boundary: seeing the
+    /// configured `thinkStartTokenId` opens the block, seeing the
+    /// `thinkEndTokenId` closes it; both markers themselves stay in the
+    /// "think" bucket.
+    private func labelPhases(_ intIds: [Int]) -> [String] {
+        if let markerId = harmonyChannelMarkerTokenId {
+            var phases: [String] = []
+            phases.reserveCapacity(intIds.count)
+            var inThinking = thinkingPhasePrefilled
+            var awaitingChannelName = false
+            for id in intIds {
+                if id == markerId {
+                    awaitingChannelName = true
+                    // Attribute marker to current phase — transition hasn't
+                    // been resolved yet.
+                    phases.append(inThinking ? "think" : "gen")
+                    continue
+                }
+                if awaitingChannelName {
+                    awaitingChannelName = false
+                    if harmonyThinkingChannelTokenIds.contains(id) {
+                        inThinking = true
+                    } else if harmonyGenerationChannelTokenIds.contains(id) {
+                        inThinking = false
+                    }
+                    // Unknown channel names fall through with phase unchanged.
+                    phases.append(inThinking ? "think" : "gen")
+                    continue
+                }
+                phases.append(inThinking ? "think" : "gen")
+            }
+            return phases
+        }
+
+        // Bracket mode.
+        var phases: [String] = []
+        phases.reserveCapacity(intIds.count)
+        var inThinking = thinkStartTokenId != nil && thinkingPhasePrefilled
+        for id in intIds {
+            if !inThinking, let startId = thinkStartTokenId, id == startId {
+                inThinking = true
+                phases.append("think")
+                continue
+            }
+            if inThinking, let endId = thinkEndTokenId, id == endId {
+                inThinking = false
+                // The end-of-think token itself is part of the thinking phase.
+                phases.append("think")
+                continue
+            }
+            phases.append(inThinking ? "think" : "gen")
+        }
+        return phases
     }
 
     /// Evaluate the next token and return the new token (y), updating cache state
@@ -2177,7 +2269,7 @@ public struct GenerateCompletionInfo: Sendable {
     /// Per-token IDs collected during generation (when collectPerTokenData is true).
     public var perTokenIds: [Int]?
 
-    /// Per-token phase labels ("thinking" or "generation") collected during generation.
+    /// Per-token phase labels ("think" or "gen") collected during generation.
     public var perTokenPhases: [String]?
 
     /// Perplexity computed over the generation (non-thinking) phase.

--- a/Tests/Benchmarks/InferenceBenchmark.swift
+++ b/Tests/Benchmarks/InferenceBenchmark.swift
@@ -26,6 +26,16 @@ private let benchmarkTokenizerLoader: any TokenizerLoader = #huggingFaceTokenize
 /// Forces </think> after a token budget to prevent unbounded thinking phases.
 /// This keeps benchmarks tractable: models think up to `maxThinkingTokens`,
 /// then must emit </think> and generate the actual response.
+/// Reference-type box for additive logit-suppression masks, populated lazily
+/// on the first `process()` call (vocab size isn't known at processor init).
+/// The containing processor is a struct with a non-mutating `process(logits:)`
+/// per the `LogitProcessor` protocol, so cacheing through this shared class
+/// lets us populate the masks without making `process` mutating.
+fileprivate final class SuppressMaskCache {
+    var thinking: MLXArray?
+    var postExhaust: MLXArray?
+}
+
 private struct ThinkingBudgetProcessor: LogitProcessor {
     let thinkStartTokenId: Int32
     let thinkEndTokenId: Int32
@@ -44,6 +54,31 @@ private struct ThinkingBudgetProcessor: LogitProcessor {
     /// with no actual content — resulting in Gen PPL = nil.
     var budgetExhausted: Bool = false
 
+    /// Pre-built additive masks applied to logits via one `+` op, replacing the
+    /// previous scatter-per-suppressed-token loop. Shape `[V]`, value 0 at all
+    /// positions except suppressed IDs which hold -inf. Built lazily on the
+    /// first `process()` call when the vocabulary size is first observed.
+    ///
+    /// Stored in a reference-type box because `process(logits:)` is non-mutating
+    /// on the `LogitProcessor` protocol — we need to populate the cache without
+    /// marking the method mutating.
+    let masks = SuppressMaskCache()
+
+    /// Lazy accumulator of sampled tokens awaiting a batched state-machine
+    /// update. Batching eliminates the per-token GPU→CPU sync that would
+    /// otherwise block the next forward-pass dispatch on every step — the
+    /// primary source of `--think` decode overhead on large models. The
+    /// iterator has already called `asyncEval(token)` on every pending entry,
+    /// so by the time we flush, evaluation is in flight and a single `eval`
+    /// call syncs the whole batch.
+    var pendingTokens: [MLXArray] = []
+
+    /// Upper bound on pending-token buffer size. The state machine may be up
+    /// to `flushBatchSize - 1` steps stale between flushes, which can cause
+    /// the thinking budget to overshoot by the same amount. Chosen small
+    /// enough that the overshoot is ≤5% of a typical 200-token budget.
+    private static let flushBatchSize = 10
+
     init(
         thinkStartTokenId: Int32, thinkEndTokenId: Int32,
         maxThinkingTokens: Int, prefilled: Bool = false,
@@ -61,39 +96,48 @@ private struct ThinkingBudgetProcessor: LogitProcessor {
         inThinkingPhase = initialThinkingPhase
         thinkingTokenCount = 0
         budgetExhausted = false
+        pendingTokens.removeAll(keepingCapacity: true)
     }
 
     func process(logits: MLXArray) -> MLXArray {
-        // After budget exhaustion, suppress think-start to prevent re-entry loops
+        // Lazy mask construction: vocab size only known once we see the logits.
+        // Shape [V] broadcasts against both [V] and [1, V] input shapes.
+        let vocab = logits.shape.last ?? 0
+        if masks.thinking == nil && vocab > 0 {
+            masks.thinking = buildSuppressMask(
+                suppressedIds: eosTokenIds, vocabSize: vocab)
+        }
+        if masks.postExhaust == nil && vocab > 0 {
+            masks.postExhaust = buildSuppressMask(
+                suppressedIds: [thinkStartTokenId], vocabSize: vocab)
+        }
+
+        // After budget exhaustion, suppress think-start to prevent re-entry loops.
         if budgetExhausted && !inThinkingPhase {
-            var modified = logits
-            if logits.ndim == 1 {
-                modified[Int(thinkStartTokenId)] = MLXArray(-Float.infinity)
-            } else {
-                modified[0..., Int(thinkStartTokenId)] = MLXArray(-Float.infinity)
+            if let m = masks.postExhaust {
+                return logits + m
             }
-            return modified
+            return logits
         }
 
         guard inThinkingPhase else { return logits }
 
+        // Single elementwise-add replaces the per-EOS scatter loop.
         var modified = logits
-
-        // Suppress EOS tokens during thinking phase so the model is forced to generate </think>
-        // before ending. Without this, small models (0.8B, 2B) terminate inside the thinking
-        // phase and never produce generation tokens, causing Gen PPL to be nil.
-        for eosId in eosTokenIds {
-            if logits.ndim == 1 {
-                modified[Int(eosId)] = MLXArray(-Float.infinity)
-            } else {
-                modified[0..., Int(eosId)] = MLXArray(-Float.infinity)
-            }
+        if let m = masks.thinking {
+            modified = modified + m
         }
 
         // Budget exceeded: force </think> by boosting its logit to dominate softmax.
         // Use a large FINITE value (not +inf) — softmax(+inf) = exp(+inf)/sum = NaN
         // which causes the sampler to return garbage (token 0), never triggering transition.
         // With logits typically in [-30, 30], 100.0 gives P(</think>) ≈ 1.0 with no NaN.
+        //
+        // NB: due to batched state flushing, thinkingTokenCount may lag by up to
+        // `flushBatchSize` tokens. This means the forced </think> actually triggers
+        // somewhere in the [budget, budget + flushBatchSize) range. For a typical
+        // 200-token budget that's ≤5% overshoot — acceptable slack in exchange
+        // for removing the per-step GPU sync.
         if thinkingTokenCount >= maxThinkingTokens {
             if logits.ndim == 1 {
                 modified[Int(thinkEndTokenId)] = MLXArray(Float(100.0))
@@ -108,12 +152,43 @@ private struct ThinkingBudgetProcessor: LogitProcessor {
     }
 
     mutating func didSample(token: MLXArray) {
-        let id = token.item(Int32.self)
+        // Defer the item() sync: the iterator has already asyncEval'd the
+        // token, so by the time we flush a batch the syncs are close to free.
+        // Synchronously calling .item() here would block the next forward
+        // pass from dispatching — a per-step stall that dominates on large
+        // models.
+        pendingTokens.append(token)
+
+        // Dynamic flush threshold: shrink when approaching the budget so
+        // forcing triggers within a few tokens of the configured limit.
+        //   thinkingTokenCount=195, budget=200 → headroom=5 → flush every 2.
+        //   thinkingTokenCount=100, budget=200 → headroom=100 → flush every 10.
+        let headroom = inThinkingPhase
+            ? max(0, maxThinkingTokens - thinkingTokenCount)
+            : Int.max
+        let threshold = max(1, min(Self.flushBatchSize, headroom / 2))
+        if pendingTokens.count >= threshold {
+            flushPending()
+        }
+    }
+
+    mutating func flushPending() {
+        guard !pendingTokens.isEmpty else { return }
+        // Batch eval — tokens were already async-dispatched by the iterator,
+        // so one eval() call completes the whole queue in one sync point.
+        eval(pendingTokens)
+        let ids = pendingTokens.map { $0.item(Int32.self) }
+        pendingTokens.removeAll(keepingCapacity: true)
+        for id in ids {
+            applyStateUpdate(id: id)
+        }
+    }
+
+    private mutating func applyStateUpdate(id: Int32) {
         if id == thinkStartTokenId {
             inThinkingPhase = true
         } else if id == thinkEndTokenId {
             inThinkingPhase = false
-            // Mark budget as exhausted when the forced end token is emitted
             if thinkingTokenCount >= maxThinkingTokens {
                 budgetExhausted = true
             }
@@ -121,6 +196,23 @@ private struct ThinkingBudgetProcessor: LogitProcessor {
             thinkingTokenCount += 1
         }
     }
+}
+
+/// Build a `[V]` additive mask with `-inf` at `suppressedIds` positions and
+/// `0` elsewhere. Constructed host-side so the upload to GPU is one kernel —
+/// not `N` scatter ops, which is what a naïve
+/// `modified[id] = MLXArray(-inf)` loop would emit per call.
+fileprivate func buildSuppressMask(
+    suppressedIds: [Int32], vocabSize: Int
+) -> MLXArray {
+    var mask = [Float](repeating: 0, count: vocabSize)
+    for id in suppressedIds {
+        let i = Int(id)
+        if i >= 0 && i < vocabSize {
+            mask[i] = -.infinity
+        }
+    }
+    return MLXArray(mask)
 }
 
 /// Harmony-format thinking-budget enforcer.
@@ -160,6 +252,25 @@ private struct HarmonyThinkingBudgetProcessor: LogitProcessor {
     var forceIndex: Int = -1
     var budgetExhausted: Bool = false
 
+    /// Pre-built additive masks — one per cacheable set of suppressed IDs.
+    /// Replaces the scatter-per-suppressed-token loops with one elementwise
+    /// add. `thinking` suppresses EOS during reasoning so the model emits a
+    /// channel transition; `postExhaust` suppresses analysis-channel re-entry
+    /// after the budget has forced a transition. See ``SuppressMaskCache``.
+    let masks = SuppressMaskCache()
+
+    /// Lazy accumulator of sampled content tokens awaiting a batched
+    /// state-machine update. See ``ThinkingBudgetProcessor`` for the
+    /// rationale; the win on GPT-OSS is larger because per-step GPU→CPU
+    /// syncs block dispatch of the next forward pass on a 20B MoE.
+    ///
+    /// Tokens sampled while `forceIndex >= 0` are NOT queued — during an
+    /// active force-emit we know each sampled ID deterministically (we
+    /// pinned the sampler), so state can advance without any sync.
+    var pendingTokens: [MLXArray] = []
+
+    private static let flushBatchSize = 10
+
     init(
         channelMarkerTokenId: Int32,
         thinkingChannelTokenIds: Set<Int32>,
@@ -182,9 +293,21 @@ private struct HarmonyThinkingBudgetProcessor: LogitProcessor {
         thinkingTokenCount = 0
         forceIndex = -1
         budgetExhausted = false
+        pendingTokens.removeAll(keepingCapacity: true)
     }
 
     func process(logits: MLXArray) -> MLXArray {
+        // Lazy mask construction on first use.
+        let vocab = logits.shape.last ?? 0
+        if masks.thinking == nil && vocab > 0 {
+            masks.thinking = buildSuppressMask(
+                suppressedIds: eosTokenIds, vocabSize: vocab)
+        }
+        if masks.postExhaust == nil && vocab > 0 {
+            masks.postExhaust = buildSuppressMask(
+                suppressedIds: Array(thinkingChannelTokenIds), vocabSize: vocab)
+        }
+
         // Active force-emit: pin the next sequence token.
         if forceIndex >= 0 && forceIndex < forcedTransitionSequence.count {
             var modified = logits
@@ -202,40 +325,28 @@ private struct HarmonyThinkingBudgetProcessor: LogitProcessor {
         // After completing the forced transition, suppress analysis-channel
         // entry so the model can't oscillate back into reasoning.
         if budgetExhausted && !inThinking {
-            var modified = logits
-            for id in thinkingChannelTokenIds {
-                if logits.ndim == 1 {
-                    modified[Int(id)] = MLXArray(-Float.infinity)
-                } else {
-                    modified[0..., Int(id)] = MLXArray(-Float.infinity)
-                }
+            if let m = masks.postExhaust {
+                return logits + m
             }
-            return modified
+            return logits
         }
 
         // During reasoning, suppress EOS so the model is forced to emit a
-        // channel transition before terminating. Small models would otherwise
-        // quit mid-reasoning with no visible answer.
+        // channel transition before terminating.
         guard inThinking else { return logits }
-        var modified = logits
-        for eosId in eosTokenIds {
-            if logits.ndim == 1 {
-                modified[Int(eosId)] = MLXArray(-Float.infinity)
-            } else {
-                modified[0..., Int(eosId)] = MLXArray(-Float.infinity)
-            }
+        if let m = masks.thinking {
+            return logits + m
         }
-        return modified
+        return logits
     }
 
     mutating func didSample(token: MLXArray) {
-        let id = token.item(Int32.self)
-
-        // Advance forced sequence if in progress.
+        // During active force-emit we know each sampled token deterministically
+        // (we pinned its logit to +100). Advance state without any sync — no
+        // need to queue the lazy MLXArray.
         if forceIndex >= 0 {
             forceIndex += 1
             if forceIndex >= forcedTransitionSequence.count {
-                // Transition complete — we're now in the final channel.
                 forceIndex = -1
                 inThinking = false
                 awaitingChannelName = false
@@ -244,7 +355,39 @@ private struct HarmonyThinkingBudgetProcessor: LogitProcessor {
             return
         }
 
-        // Harmony state machine (mirrors labelPhases in TokenIterator).
+        // Otherwise defer the sync: queue lazily and flush in batches. See
+        // `ThinkingBudgetProcessor.didSample` for the full rationale.
+        pendingTokens.append(token)
+
+        let headroom = inThinking
+            ? max(0, maxThinkingTokens - thinkingTokenCount)
+            : Int.max
+        let threshold = max(1, min(Self.flushBatchSize, headroom / 2))
+        if pendingTokens.count >= threshold {
+            flushPending()
+        }
+    }
+
+    mutating func flushPending() {
+        guard !pendingTokens.isEmpty else { return }
+        eval(pendingTokens)
+        let ids = pendingTokens.map { $0.item(Int32.self) }
+        pendingTokens.removeAll(keepingCapacity: true)
+        for id in ids {
+            applyStateUpdate(id: id)
+            // If the state machine armed force-emit mid-batch, stop draining
+            // here — the remaining pending tokens (if any) were sampled
+            // BEFORE the armed point, and the next `process()` call needs to
+            // see `forceIndex >= 0` to start pinning the transition.
+            //
+            // Note: pendingTokens is already empty by the time we get here
+            // (removeAll above), so there's nothing to preserve — the break
+            // is defensive in case the loop is refactored.
+            if forceIndex >= 0 { break }
+        }
+    }
+
+    private mutating func applyStateUpdate(id: Int32) {
         if id == channelMarkerTokenId {
             awaitingChannelName = true
             return
@@ -253,16 +396,14 @@ private struct HarmonyThinkingBudgetProcessor: LogitProcessor {
             awaitingChannelName = false
             if thinkingChannelTokenIds.contains(id) {
                 inThinking = true
-                thinkingTokenCount = 0  // reset per analysis entry
+                thinkingTokenCount = 0
             } else if generationChannelTokenIds.contains(id) {
                 inThinking = false
             }
             return
         }
-
         if inThinking {
             thinkingTokenCount += 1
-            // Arm the force sequence for the next process() call.
             if thinkingTokenCount >= maxThinkingTokens {
                 forceIndex = 0
             }

--- a/Tests/Benchmarks/InferenceBenchmark.swift
+++ b/Tests/Benchmarks/InferenceBenchmark.swift
@@ -123,6 +123,153 @@ private struct ThinkingBudgetProcessor: LogitProcessor {
     }
 }
 
+/// Harmony-format thinking-budget enforcer.
+///
+/// Analogue to ``ThinkingBudgetProcessor`` for models whose reasoning is
+/// delimited by channel transitions rather than a `<think>…</think>`
+/// bracket pair. Counts tokens emitted inside the analysis channel; once
+/// `maxThinkingTokens` are produced, pins the next `forcedTransitionSequence.count`
+/// sampling steps to force-emit the multi-token sequence that closes the
+/// analysis message and opens the final-channel visible answer.
+///
+/// For GPT-OSS / harmony the transition is
+/// `<|end|> <|start|> assistant <|channel|> final <|message|>` (6 tokens).
+///
+/// After the forced transition completes, the model is free to generate
+/// final-channel content normally — but the analysis channel is
+/// suppressed to prevent bouncing back into reasoning.
+///
+/// Caveat: the 6 forced tokens land in ``GenerateCompletionInfo.perTokenLogProbs``
+/// with logprob ≈ 0 (we pinned the sampler). They slightly bias per-phase
+/// PPL toward 1.0 — bounded contribution (6 tokens out of hundreds) and
+/// not material to the signal we care about (reasoning-phase PPL/KLD
+/// comparisons across KV configs).
+private struct HarmonyThinkingBudgetProcessor: LogitProcessor {
+    let channelMarkerTokenId: Int32
+    let thinkingChannelTokenIds: Set<Int32>
+    let generationChannelTokenIds: Set<Int32>
+    let forcedTransitionSequence: [Int32]
+    let maxThinkingTokens: Int
+    let eosTokenIds: [Int32]
+
+    var inThinking: Bool = false
+    var awaitingChannelName: Bool = false
+    var thinkingTokenCount: Int = 0
+    /// When ≥ 0, we're actively forcing the transition sequence;
+    /// indexes the next token to force. When the sequence completes, reset to -1.
+    var forceIndex: Int = -1
+    var budgetExhausted: Bool = false
+
+    init(
+        channelMarkerTokenId: Int32,
+        thinkingChannelTokenIds: Set<Int32>,
+        generationChannelTokenIds: Set<Int32>,
+        forcedTransitionSequence: [Int32],
+        maxThinkingTokens: Int,
+        eosTokenIds: [Int32] = []
+    ) {
+        self.channelMarkerTokenId = channelMarkerTokenId
+        self.thinkingChannelTokenIds = thinkingChannelTokenIds
+        self.generationChannelTokenIds = generationChannelTokenIds
+        self.forcedTransitionSequence = forcedTransitionSequence
+        self.maxThinkingTokens = maxThinkingTokens
+        self.eosTokenIds = eosTokenIds
+    }
+
+    mutating func prompt(_ prompt: MLXArray) {
+        inThinking = false
+        awaitingChannelName = false
+        thinkingTokenCount = 0
+        forceIndex = -1
+        budgetExhausted = false
+    }
+
+    func process(logits: MLXArray) -> MLXArray {
+        // Active force-emit: pin the next sequence token.
+        if forceIndex >= 0 && forceIndex < forcedTransitionSequence.count {
+            var modified = logits
+            let targetId = Int(forcedTransitionSequence[forceIndex])
+            // Use a large finite value (100) — softmax(+inf) → NaN which the
+            // sampler would misroute. 100 gives P(target) ≈ 1.0 with no NaN.
+            if logits.ndim == 1 {
+                modified[targetId] = MLXArray(Float(100.0))
+            } else {
+                modified[0..., targetId] = MLXArray(Float(100.0))
+            }
+            return modified
+        }
+
+        // After completing the forced transition, suppress analysis-channel
+        // entry so the model can't oscillate back into reasoning.
+        if budgetExhausted && !inThinking {
+            var modified = logits
+            for id in thinkingChannelTokenIds {
+                if logits.ndim == 1 {
+                    modified[Int(id)] = MLXArray(-Float.infinity)
+                } else {
+                    modified[0..., Int(id)] = MLXArray(-Float.infinity)
+                }
+            }
+            return modified
+        }
+
+        // During reasoning, suppress EOS so the model is forced to emit a
+        // channel transition before terminating. Small models would otherwise
+        // quit mid-reasoning with no visible answer.
+        guard inThinking else { return logits }
+        var modified = logits
+        for eosId in eosTokenIds {
+            if logits.ndim == 1 {
+                modified[Int(eosId)] = MLXArray(-Float.infinity)
+            } else {
+                modified[0..., Int(eosId)] = MLXArray(-Float.infinity)
+            }
+        }
+        return modified
+    }
+
+    mutating func didSample(token: MLXArray) {
+        let id = token.item(Int32.self)
+
+        // Advance forced sequence if in progress.
+        if forceIndex >= 0 {
+            forceIndex += 1
+            if forceIndex >= forcedTransitionSequence.count {
+                // Transition complete — we're now in the final channel.
+                forceIndex = -1
+                inThinking = false
+                awaitingChannelName = false
+                budgetExhausted = true
+            }
+            return
+        }
+
+        // Harmony state machine (mirrors labelPhases in TokenIterator).
+        if id == channelMarkerTokenId {
+            awaitingChannelName = true
+            return
+        }
+        if awaitingChannelName {
+            awaitingChannelName = false
+            if thinkingChannelTokenIds.contains(id) {
+                inThinking = true
+                thinkingTokenCount = 0  // reset per analysis entry
+            } else if generationChannelTokenIds.contains(id) {
+                inThinking = false
+            }
+            return
+        }
+
+        if inThinking {
+            thinkingTokenCount += 1
+            // Arm the force sequence for the next process() call.
+            if thinkingTokenCount >= maxThinkingTokens {
+                forceIndex = 0
+            }
+        }
+    }
+}
+
 // MARK: - KV Cache Configuration
 
 /// KV cache quantization configuration for benchmarks.
@@ -657,6 +804,7 @@ struct InferenceBenchmarks {
             var harmonyMarkerId: Int32?
             var harmonyThinkingIds: [Int32] = []
             var harmonyGenerationIds: [Int32] = []
+            var harmonyTransitionIds: [Int32] = []
             var eosTokenIds: [Int32] = []
         }
         let thinkingTokenIds: ThinkingTokens = useThinking
@@ -674,7 +822,7 @@ struct InferenceBenchmarks {
                 case .bracket(let start, let end):
                     result.thinkStartId = ctx.tokenizer.convertTokenToId(start).map { Int32($0) }
                     result.thinkEndId = ctx.tokenizer.convertTokenToId(end).map { Int32($0) }
-                case .harmonyChannel(let marker, let thinkingChans, let genChans):
+                case .harmonyChannel(let marker, let thinkingChans, let genChans, let transitionSeq):
                     result.harmonyMarkerId = ctx.tokenizer.convertTokenToId(marker).map { Int32($0) }
                     result.harmonyThinkingIds = thinkingChans.compactMap {
                         ctx.tokenizer.convertTokenToId($0).map { Int32($0) }
@@ -682,6 +830,12 @@ struct InferenceBenchmarks {
                     result.harmonyGenerationIds = genChans.compactMap {
                         ctx.tokenizer.convertTokenToId($0).map { Int32($0) }
                     }
+                    // The forced-transition sequence is only useful if every
+                    // token resolves; a missing ID would derail the force SM.
+                    let resolved = transitionSeq.compactMap {
+                        ctx.tokenizer.convertTokenToId($0).map { Int32($0) }
+                    }
+                    result.harmonyTransitionIds = resolved.count == transitionSeq.count ? resolved : []
                 }
                 return result
               }
@@ -692,6 +846,7 @@ struct InferenceBenchmarks {
         let harmonyMarkerId = thinkingTokenIds.harmonyMarkerId
         let harmonyThinkingIds = thinkingTokenIds.harmonyThinkingIds
         let harmonyGenerationIds = thinkingTokenIds.harmonyGenerationIds
+        let harmonyTransitionIds = thinkingTokenIds.harmonyTransitionIds
         let eosTokenIds = thinkingTokenIds.eosTokenIds
 
         if let s = thinkStartId, let e = thinkEndId {
@@ -699,10 +854,10 @@ struct InferenceBenchmarks {
                 print("[BENCH] Thinking tokens: \(startStr)=\(s), \(endStr)=\(e), budget=\(thinkingBudget), eos=\(eosTokenIds)")
             }
         } else if let m = harmonyMarkerId {
-            print("[BENCH] Harmony channel marker=\(m), thinking=\(harmonyThinkingIds), generation=\(harmonyGenerationIds), eos=\(eosTokenIds)")
+            print("[BENCH] Harmony channel marker=\(m), thinking=\(harmonyThinkingIds), generation=\(harmonyGenerationIds), transition=\(harmonyTransitionIds), eos=\(eosTokenIds)")
         }
         let thinkingPrefilled = !family.thinkingConfig.assistantPrefill.isEmpty
-        let budgetProcessor: ThinkingBudgetProcessor? = thinkStartId.flatMap { startId in
+        let bracketBudgetProcessor: ThinkingBudgetProcessor? = thinkStartId.flatMap { startId in
             thinkEndId.map { endId in
                 ThinkingBudgetProcessor(
                     thinkStartTokenId: startId,
@@ -713,6 +868,23 @@ struct InferenceBenchmarks {
                 )
             }
         }
+        // Harmony equivalent: enforce the thinking budget by force-emitting
+        // the channel-transition sequence after N analysis-message tokens.
+        // Only constructed when every transition-sequence token resolved.
+        let harmonyBudgetProcessor: HarmonyThinkingBudgetProcessor? = {
+            guard let markerId = harmonyMarkerId,
+                  !harmonyTransitionIds.isEmpty,
+                  !harmonyGenerationIds.isEmpty
+            else { return nil }
+            return HarmonyThinkingBudgetProcessor(
+                channelMarkerTokenId: markerId,
+                thinkingChannelTokenIds: Set(harmonyThinkingIds),
+                generationChannelTokenIds: Set(harmonyGenerationIds),
+                forcedTransitionSequence: harmonyTransitionIds,
+                maxThinkingTokens: thinkingBudget,
+                eosTokenIds: eosTokenIds
+            )
+        }()
 
         // ── 5. Prepare input ──────────────────────────────────────────────────
         let prepareStart = Date()
@@ -762,9 +934,17 @@ struct InferenceBenchmarks {
         print("[BENCH] Prepared \(promptTokens) tokens in \(String(format: "%.0f", Date().timeIntervalSince(prepareStart) * 1000))ms")
 
         // ── 6. Generate ───────────────────────────────────────────────────────
-        // effectiveMaxTokens = thinking budget + response budget for thinking models
-        let effectiveMaxTokens = thinkStartId != nil ? thinkingBudget + maxTokens : maxTokens
-        let additionalProcessors: [any LogitProcessor] = budgetProcessor.map { [$0] } ?? []
+        // effectiveMaxTokens = thinking budget + response budget for thinking models.
+        // Bracket mode (Qwen, Gemma 4) keys off thinkStartId; harmony mode
+        // (GPT-OSS) keys off harmonyMarkerId. Either path reserves the same
+        // thinkingBudget tokens for reasoning before the response budget.
+        let hasThinkingBudget = thinkStartId != nil || harmonyMarkerId != nil
+        let effectiveMaxTokens = hasThinkingBudget ? thinkingBudget + maxTokens : maxTokens
+        // Exactly one budget enforcer applies per run: bracket XOR harmony.
+        // Both nil → model runs unconstrained.
+        var additionalProcessors: [any LogitProcessor] = []
+        if let p = bracketBudgetProcessor { additionalProcessors.append(p) }
+        if let p = harmonyBudgetProcessor { additionalProcessors.append(p) }
 
         // When KLD is enabled, collect per-token data during generation so we can
         // compare against the bf16/8bit baseline (no KV quant) via forced decode.
@@ -1022,7 +1202,7 @@ struct InferenceBenchmarks {
             parameters: .init(
                 generate: params,
                 thinkingEnabled: useThinking,
-                thinkingTokenBudget: thinkStartId != nil ? thinkingBudget : nil,
+                thinkingTokenBudget: hasThinkingBudget ? thinkingBudget : nil,
                 kldSummary: kldParameterSummary(needsKLD: needsKLD, isWikitext2: false),
                 maxOpsPerBuffer: BenchmarkWriter.resolvedMaxOpsPerBufferReport(),
                 batchSize: BenchEnv.batch,
@@ -1521,7 +1701,12 @@ struct InferenceBenchmarks {
         thinkingBudget: Int,
         maxTokens: Int
     ) async throws -> (thinkKLD: Double?, genKLD: Double?) {
-        let effectiveMaxTokens = thinkStartId != nil ? thinkingBudget + maxTokens : maxTokens
+        // effectiveMaxTokens keys off whichever thinking style is active, matching
+        // the hasThinkingBudget computation at the main call site.
+        let hasThinkingBudget = thinkStartId != nil  // bracket-only here; harmony path
+                                                      // populates quantizedData directly and we
+                                                      // just process everything captured.
+        let effectiveMaxTokens = hasThinkingBudget ? thinkingBudget + maxTokens : maxTokens
 
         // Params WITHOUT KV quantization — the baseline model runs unquantized
         let params = GenerateParameters(
@@ -1565,11 +1750,14 @@ struct InferenceBenchmarks {
                 state = result.state
             }
 
-            // 2. Forced decode: compute baseline (unquantized) log prob for each token
+            // 2. Forced decode: compute baseline (unquantized) log prob for each token.
+            // Process the full captured sequence — the target's generation loop already
+            // bounded it via its own maxTokens, so capping again here would drop data.
             let tokenIds = quantizedData.tokenIds
             let quantizedLogProbs = quantizedData.logProbs
             let phases = quantizedData.phases
-            let tokenCount = min(tokenIds.count, effectiveMaxTokens)
+            let tokenCount = tokenIds.count
+            _ = effectiveMaxTokens  // retained for the Parameters summary only
 
             var thinkKLDSum: Double = 0
             var thinkCount = 0

--- a/Tests/Benchmarks/InferenceBenchmark.swift
+++ b/Tests/Benchmarks/InferenceBenchmark.swift
@@ -277,6 +277,18 @@ private enum BenchEnv {
     static var thinkEnabled: Bool {
         ProcessInfo.processInfo.environment["MLX_BENCH_THINK"] == "1"
     }
+    /// Reasoning effort override for models that honour it (e.g. GPT-OSS).
+    /// When nil, the family's default is used. Accepted values: "low",
+    /// "medium", "high" — or any string the underlying chat template
+    /// understands. Value validation is deliberately loose so future
+    /// models' vocabularies pass through without a harness change.
+    static var reasoningEffort: String? {
+        guard let raw = ProcessInfo.processInfo.environment["MLX_BENCH_REASONING"] else {
+            return nil
+        }
+        let v = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return v.isEmpty ? nil : v
+    }
 }
 
 // MARK: - Baseline Token Data
@@ -632,23 +644,62 @@ struct InferenceBenchmarks {
         let container = try await loadOrCacheModel(family: family, repoId: repoId)
 
         // ── 4. Discover thinking tokens with target container ─────────────────
-        let thinkingTokens = family.thinkingConfig
-        let (thinkStartId, thinkEndId, eosTokenIds): (Int32?, Int32?, [Int32]) = useThinking
+        //
+        // Two styles per ThinkingConfig:
+        //   • bracket       — resolve a single start + end token pair (Qwen, Gemma 4).
+        //   • harmonyChannel — resolve the channel marker plus each channel-name
+        //                     token so phase labeling can run the harmony SM
+        //                     (GPT-OSS analysis vs final/commentary).
+        let thinkingConfig = family.thinkingConfig
+        struct ThinkingTokens {
+            var thinkStartId: Int32?
+            var thinkEndId: Int32?
+            var harmonyMarkerId: Int32?
+            var harmonyThinkingIds: [Int32] = []
+            var harmonyGenerationIds: [Int32] = []
+            var eosTokenIds: [Int32] = []
+        }
+        let thinkingTokenIds: ThinkingTokens = useThinking
             ? await container.perform { ctx in
-                let startId = ctx.tokenizer.convertTokenToId(thinkingTokens.startToken).map { Int32($0) }
-                let endId = ctx.tokenizer.convertTokenToId(thinkingTokens.endToken).map { Int32($0) }
+                var result = ThinkingTokens()
                 // Collect all EOS token IDs so we can suppress them during thinking phase
                 var eosIds = ctx.configuration.eosTokenIds.map { Int32($0) }
                 if let tokEos = ctx.tokenizer.eosTokenId { eosIds.append(Int32(tokEos)) }
                 for token in ctx.configuration.extraEOSTokens {
                     if let id = ctx.tokenizer.convertTokenToId(token) { eosIds.append(Int32(id)) }
                 }
-                return (startId, endId, Array(Set(eosIds)))
+                result.eosTokenIds = Array(Set(eosIds))
+
+                switch thinkingConfig.style {
+                case .bracket(let start, let end):
+                    result.thinkStartId = ctx.tokenizer.convertTokenToId(start).map { Int32($0) }
+                    result.thinkEndId = ctx.tokenizer.convertTokenToId(end).map { Int32($0) }
+                case .harmonyChannel(let marker, let thinkingChans, let genChans):
+                    result.harmonyMarkerId = ctx.tokenizer.convertTokenToId(marker).map { Int32($0) }
+                    result.harmonyThinkingIds = thinkingChans.compactMap {
+                        ctx.tokenizer.convertTokenToId($0).map { Int32($0) }
+                    }
+                    result.harmonyGenerationIds = genChans.compactMap {
+                        ctx.tokenizer.convertTokenToId($0).map { Int32($0) }
+                    }
+                }
+                return result
               }
-            : (nil, nil, [])
+            : ThinkingTokens()
+
+        let thinkStartId = thinkingTokenIds.thinkStartId
+        let thinkEndId = thinkingTokenIds.thinkEndId
+        let harmonyMarkerId = thinkingTokenIds.harmonyMarkerId
+        let harmonyThinkingIds = thinkingTokenIds.harmonyThinkingIds
+        let harmonyGenerationIds = thinkingTokenIds.harmonyGenerationIds
+        let eosTokenIds = thinkingTokenIds.eosTokenIds
 
         if let s = thinkStartId, let e = thinkEndId {
-            print("[BENCH] Thinking tokens: \(thinkingTokens.startToken)=\(s), \(thinkingTokens.endToken)=\(e), budget=\(thinkingBudget), eos=\(eosTokenIds)")
+            if case .bracket(let startStr, let endStr) = thinkingConfig.style {
+                print("[BENCH] Thinking tokens: \(startStr)=\(s), \(endStr)=\(e), budget=\(thinkingBudget), eos=\(eosTokenIds)")
+            }
+        } else if let m = harmonyMarkerId {
+            print("[BENCH] Harmony channel marker=\(m), thinking=\(harmonyThinkingIds), generation=\(harmonyGenerationIds), eos=\(eosTokenIds)")
         }
         let thinkingPrefilled = !family.thinkingConfig.assistantPrefill.isEmpty
         let budgetProcessor: ThinkingBudgetProcessor? = thinkStartId.flatMap { startId in
@@ -737,10 +788,13 @@ struct InferenceBenchmarks {
             prefillStepSize: 2048,
             kvScheme: kv.kvScheme,
             additionalProcessors: additionalProcessors,
-            reasoningEffort: family.reasoningEffort,
+            reasoningEffort: BenchEnv.reasoningEffort ?? family.reasoningEffort,
             thinkStartTokenId: thinkStartId,
             thinkEndTokenId: thinkEndId,
             thinkingPhasePrefilled: thinkStartId != nil && !family.thinkingConfig.assistantPrefill.isEmpty,
+            harmonyChannelMarkerTokenId: harmonyMarkerId,
+            harmonyThinkingChannelTokenIds: harmonyThinkingIds,
+            harmonyGenerationChannelTokenIds: harmonyGenerationIds,
             collectPerTokenData: needsKLD,
             trackPerplexity: ProcessInfo.processInfo.environment["MLX_BENCH_PPL"] == "1"
         )

--- a/Tests/Benchmarks/Utils/BenchmarkWriter.swift
+++ b/Tests/Benchmarks/Utils/BenchmarkWriter.swift
@@ -317,44 +317,79 @@ enum BenchmarkWriter {
         let strat = mdTableCell(kvCacheStrategyLine(from: gp))
         let maxKV = gp.maxKVSize.map { "\($0) tokens (RotatingKVCache)" } ?? "unbounded (KVCacheSimple)"
 
-        var rows: [[String]] = [
+        // Parameter table — ordered into semantic groups so readers can scan
+        // related knobs together. Groups in order: KV cache → generation →
+        // sampling → penalties → thinking → speculative decoding →
+        // telemetry/runtime.
+        var rows: [[String]] = []
+
+        // KV cache
+        rows.append(contentsOf: [
             ["KV cache strategy", strat],
             ["Max KV size", mdTableCell(maxKV)],
             ["KV bits", gp.kvBits.map(String.init) ?? "nil"],
             ["KV scheme", mdTableCell(gp.kvScheme ?? "nil")],
             ["KV group size", "\(gp.kvGroupSize)"],
             ["Quantized KV start", "\(gp.quantizedKVStart)"],
+        ])
+
+        // Generation budget
+        rows.append(contentsOf: [
             ["Prefill step size", "\(gp.prefillStepSize)"],
             ["Max tokens", gp.maxTokens.map(String.init) ?? "nil"],
+        ])
+
+        // Sampling
+        rows.append(contentsOf: [
             ["Temperature", "\(gp.temperature)"],
             ["Top P", "\(gp.topP)"],
             ["Top K", "\(gp.topK)"],
             ["Min P", "\(gp.minP)"],
+        ])
+
+        // Penalties
+        rows.append(contentsOf: [
             ["Repetition penalty", optFloat(gp.repetitionPenalty)],
             ["Repetition context size", "\(gp.repetitionContextSize)"],
             ["Presence penalty", optFloat(gp.presencePenalty)],
             ["Presence context size", "\(gp.presenceContextSize)"],
             ["Frequency penalty", optFloat(gp.frequencyPenalty)],
             ["Frequency context size", "\(gp.frequencyContextSize)"],
+        ])
+
+        // Thinking / reasoning
+        rows.append(contentsOf: [
             ["Reasoning effort", mdTableCell(gp.reasoningEffort ?? "nil")],
             ["Think start token id", gp.thinkStartTokenId.map { "\($0)" } ?? "nil"],
             ["Think end token id", gp.thinkEndTokenId.map { "\($0)" } ?? "nil"],
             ["Thinking phase prefilled", gp.thinkingPhasePrefilled ? "true" : "false"],
-            ["Collect per-token data", gp.collectPerTokenData ? "true" : "false"],
-            ["Track perplexity", gp.trackPerplexity ? "true" : "false"],
-            ["N-gram size", "\(gp.ngramSize)"],
-            ["Max n-gram draft tokens", "\(gp.maxNgramDraftTokens)"],
-            ["Additional processors count", "\(gp.additionalProcessors.count)"],
-        ]
+        ])
         if let budget = p.thinkingTokenBudget {
             rows.append(["Thinking token budget (processor)", "\(budget)"])
         }
         rows.append(["Thinking (effective)", p.thinkingEnabled ? "Yes" : "No"])
-        rows.append(["Perplexity tracking (MLX_BENCH_PPL)", gp.trackPerplexity ? "Yes" : "No"])
-        rows.append(["KL divergence (MLX_BENCH_KLD)", mdTableCell(p.kldSummary)])
-        rows.append(["Batch size (MLX_BENCH_BATCH)", "\(p.batchSize)"])
-        rows.append(["Speculative decoding", mdTableCell(p.speculativeDecoding)])
-        rows.append(["Max ops per buffer (MLX_MAX_OPS_PER_BUFFER)", mdTableCell(p.maxOpsPerBuffer)])
+
+        // Speculative decoding (n-gram + draft-model fields grouped together).
+        // A later row names the active strategy ("none", "ngram (size=N, …)",
+        // or "draft (repo-id)") so readers can see the strategy alongside its
+        // parameters without hopping around the table.
+        rows.append(contentsOf: [
+            ["Speculative decoding", mdTableCell(p.speculativeDecoding)],
+            ["N-gram size", "\(gp.ngramSize)"],
+            ["Max n-gram draft tokens", "\(gp.maxNgramDraftTokens)"],
+        ])
+
+        // Telemetry / runtime
+        rows.append(contentsOf: [
+            ["Collect per-token data", gp.collectPerTokenData ? "true" : "false"],
+            ["Track perplexity", gp.trackPerplexity ? "true" : "false"],
+            ["Perplexity tracking (MLX_BENCH_PPL)", gp.trackPerplexity ? "Yes" : "No"],
+            ["KL divergence (MLX_BENCH_KLD)", mdTableCell(p.kldSummary)],
+            ["Batch size (MLX_BENCH_BATCH)", "\(p.batchSize)"],
+            ["Additional processors count", "\(gp.additionalProcessors.count)"],
+            ["Max ops per buffer (MLX_MAX_OPS_PER_BUFFER)", mdTableCell(p.maxOpsPerBuffer)],
+        ])
+
         return rows
     }
 
@@ -550,11 +585,12 @@ enum BenchmarkWriter {
 
     // MARK: - MLX max ops per buffer (Metal backend defaults)
 
-    /// Hardware default for max ops per command buffer **before** `MLX_MAX_OPS_PER_BUFFER` is applied.
-    /// Must stay aligned with `mlx/backend/metal/device.cpp` (`Device::Device`, `arch_.back()` switch).
-    static func hardwareDefaultMaxOpsPerBuffer(gpuArch: String) -> Int {
-        guard let suffix = gpuArch.last else { return 40 }
-        switch suffix {
+    /// Hard-coded fallback values. Only used when the parser at
+    /// ``hardwareDefaultMaxOpsPerBuffer(gpuArch:)`` cannot locate
+    /// `device.cpp` or the file's format has drifted from what the parser
+    /// expects. Kept in sync with the current committed defaults.
+    private static func hardcodedFallback(gpuArchSuffix: Character) -> Int {
+        switch gpuArchSuffix {
         case "p": return 20
         case "g": return 40
         case "s": return 200
@@ -563,7 +599,118 @@ enum BenchmarkWriter {
         }
     }
 
-    /// Value shown in the Parameters table.
+    /// Hardware default for max ops per command buffer **before**
+    /// `MLX_MAX_OPS_PER_BUFFER` is applied.
+    ///
+    /// Resolved at runtime by parsing `mlx/backend/metal/device.cpp` from the
+    /// local mlx-swift dependency (sibling checkout or SPM-fetched path).
+    /// Reading the same source the library was compiled from eliminates the
+    /// staleness we otherwise get from duplicating the switch statement in
+    /// Swift. Falls back to a hardcoded table if the file can't be located or
+    /// parsed.
+    static func hardwareDefaultMaxOpsPerBuffer(gpuArch: String) -> Int {
+        guard let suffix = gpuArch.last else { return 40 }
+        if let parsed = parseMaxOpsPerBufferFromDeviceCpp(archSuffix: suffix) {
+            return parsed
+        }
+        return hardcodedFallback(gpuArchSuffix: suffix)
+    }
+
+    /// Whether the last call to ``hardwareDefaultMaxOpsPerBuffer(gpuArch:)``
+    /// resolved via the `device.cpp` parse (`true`) or fell back to the
+    /// hardcoded table (`false`). Surfaced in the Parameters row label so
+    /// readers can see which path produced the value.
+    nonisolated(unsafe) private static var lastParseSucceeded = false
+
+    /// Parse the `max_ops_per_buffer_ = N;` line for the given GPU arch
+    /// suffix from `mlx/backend/metal/device.cpp`. Returns `nil` if the file
+    /// can't be found or the case isn't present / doesn't match the expected
+    /// shape.
+    private static func parseMaxOpsPerBufferFromDeviceCpp(archSuffix: Character) -> Int? {
+        guard let source = loadDeviceCppSource() else {
+            lastParseSucceeded = false
+            return nil
+        }
+
+        // State machine: find the Device::Device() arch switch, advance to
+        // the case matching our suffix, then grab the first
+        // `max_ops_per_buffer_ = N;` inside that case block.
+        let caseNeedle = "case '\(archSuffix)'"
+        var inTargetCase = false
+        for rawLine in source.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if !inTargetCase {
+                if line.hasPrefix(caseNeedle) {
+                    inTargetCase = true
+                }
+                continue
+            }
+            // End of case block without finding the assignment — give up.
+            if line.hasPrefix("case ") || line.hasPrefix("default:") {
+                break
+            }
+            if let value = extractMaxOpsAssignment(line) {
+                lastParseSucceeded = true
+                return value
+            }
+            if line == "break;" {
+                break
+            }
+        }
+        lastParseSucceeded = false
+        return nil
+    }
+
+    /// Extract `N` from a line like `max_ops_per_buffer_ = 200;`.
+    private static func extractMaxOpsAssignment(_ line: String) -> Int? {
+        let prefix = "max_ops_per_buffer_"
+        guard line.hasPrefix(prefix) else { return nil }
+        // Skip past `max_ops_per_buffer_`, whitespace, `=`, whitespace.
+        let afterKey = line.dropFirst(prefix.count)
+            .drop(while: { $0.isWhitespace })
+        guard afterKey.first == "=" else { return nil }
+        let afterEq = afterKey.dropFirst().drop(while: { $0.isWhitespace })
+        let digits = afterEq.prefix(while: { $0.isNumber })
+        return Int(digits)
+    }
+
+    /// Locate and read the mlx `device.cpp` source file. Searches, in order:
+    ///
+    /// 1. `$MLX_SWIFT_PATH/Source/Cmlx/mlx/mlx/backend/metal/device.cpp`
+    ///    (explicit override, matches the Makefile's resolution).
+    /// 2. Sibling repository at `{projectRoot}/../mlx-swift/...` (our primary
+    ///    dev layout; aligned with how `Makefile` finds mlx-swift).
+    /// 3. SPM checkout at `{projectRoot}/.build/checkouts/mlx-swift/...`.
+    ///
+    /// Returns the full file contents, or `nil` if no candidate exists.
+    private static func loadDeviceCppSource() -> String? {
+        let relative = "Source/Cmlx/mlx/mlx/backend/metal/device.cpp"
+        var candidates: [URL] = []
+        if let override = ProcessInfo.processInfo.environment["MLX_SWIFT_PATH"], !override.isEmpty {
+            candidates.append(URL(fileURLWithPath: override).appendingPathComponent(relative))
+        }
+        let root = projectRoot()
+        candidates.append(root.deletingLastPathComponent()
+            .appendingPathComponent("mlx-swift")
+            .appendingPathComponent(relative))
+        candidates.append(root.appendingPathComponent(".build/checkouts/mlx-swift")
+            .appendingPathComponent(relative))
+
+        for url in candidates where FileManager.default.fileExists(atPath: url.path) {
+            if let text = try? String(contentsOf: url, encoding: .utf8) {
+                return text
+            }
+        }
+        return nil
+    }
+
+    /// Value shown in the Parameters table. Three-state label:
+    /// - `N (env)` — `MLX_MAX_OPS_PER_BUFFER` was set.
+    /// - `N (from device.cpp, <arch>)` — parsed directly from the mlx source
+    ///   that was built into the linked library. Authoritative.
+    /// - `N (fallback, <arch>)` — `device.cpp` not found or format drifted;
+    ///   hardcoded table was used. A warning signal that the benchmark harness
+    ///   may report stale values.
     static func resolvedMaxOpsPerBufferReport() -> String {
         let raw = ProcessInfo.processInfo.environment["MLX_MAX_OPS_PER_BUFFER"]?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -573,6 +720,7 @@ enum BenchmarkWriter {
         let arch = GPU.deviceInfo().architecture
         let d = hardwareDefaultMaxOpsPerBuffer(gpuArch: arch)
         let safeArch = arch.replacingOccurrences(of: "|", with: "\\|")
-        return "\(d) (hardware default, \(safeArch))"
+        let source = lastParseSucceeded ? "from device.cpp" : "fallback"
+        return "\(d) (\(source), \(safeArch))"
     }
 }

--- a/Tests/Benchmarks/Utils/ModelRegistry.swift
+++ b/Tests/Benchmarks/Utils/ModelRegistry.swift
@@ -21,7 +21,14 @@ struct ThinkingConfig {
         case harmonyChannel(
             marker: String,
             thinkingChannels: [String],
-            generationChannels: [String]
+            generationChannels: [String],
+            /// Token-string sequence forced into the output stream when the
+            /// harmony budget processor decides reasoning has run long enough.
+            /// For GPT-OSS: `<|end|>`, `<|start|>`, `assistant`, `<|channel|>`,
+            /// `final`, `<|message|>` — closing the analysis message and
+            /// opening the final-channel visible answer. All six are resolved
+            /// to token IDs at benchmark start-up and handed to the processor.
+            transitionSequence: [String]
         )
     }
 
@@ -54,7 +61,11 @@ struct ThinkingConfig {
         style: .harmonyChannel(
             marker: "<|channel|>",
             thinkingChannels: ["analysis"],
-            generationChannels: ["final", "commentary"]
+            generationChannels: ["final", "commentary"],
+            transitionSequence: [
+                "<|end|>", "<|start|>", "assistant",
+                "<|channel|>", "final", "<|message|>"
+            ]
         ),
         assistantPrefill: ""
     )

--- a/Tests/Benchmarks/Utils/ModelRegistry.swift
+++ b/Tests/Benchmarks/Utils/ModelRegistry.swift
@@ -9,26 +9,53 @@ struct ModelVariant {
 
 /// A model family with multiple quantization variants and generation parameters.
 /// Thinking token configuration for models that support reasoning traces.
+///
+/// Two styles are represented:
+/// - `bracket` — a single start token pairs with a single end token
+///   (Qwen `<think>…</think>`, Gemma 4 `<|channel>…<channel|>`).
+/// - `harmonyChannel` — channel transitions via a marker token plus a
+///   channel-name token (GPT-OSS `<|channel|>analysis<|message|>…`).
 struct ThinkingConfig {
-    /// Token string that starts the thinking block in the model's output.
-    let startToken: String
-    /// Token string that ends the thinking block.
-    let endToken: String
+    enum Style {
+        case bracket(start: String, end: String)
+        case harmonyChannel(
+            marker: String,
+            thinkingChannels: [String],
+            generationChannels: [String]
+        )
+    }
+
+    let style: Style
+
     /// Assistant prefill to inject before generation to trigger thinking mode.
-    /// Qwen-style models use "<think>\n" prefill; Gemma 4 uses the chat template's
-    /// enable_thinking parameter instead (empty prefill).
+    /// Qwen-style models use "<think>\n" prefill; Gemma 4 and GPT-OSS use their
+    /// chat template's enable_thinking / reasoning_effort controls instead.
     let assistantPrefill: String
 
     /// Qwen-style: <think>...</think>
     static let qwen = ThinkingConfig(
-        startToken: "<think>", endToken: "</think>",
+        style: .bracket(start: "<think>", end: "</think>"),
         assistantPrefill: "<think>\n"
     )
 
     /// Gemma 4 style: <|channel>thought\n...<channel|>
     /// Thinking is triggered via enable_thinking=true in the chat template.
     static let gemma4 = ThinkingConfig(
-        startToken: "<|channel>", endToken: "<channel|>",
+        style: .bracket(start: "<|channel>", end: "<channel|>"),
+        assistantPrefill: ""
+    )
+
+    /// GPT-OSS / harmony format: <|channel|>analysis<|message|>… for reasoning,
+    /// <|channel|>final<|message|>… for the visible answer. The model emits
+    /// the transitions itself; no assistant prefill is needed. `commentary`
+    /// channel is treated as a generation-phase channel (visible tool/meta
+    /// commentary rather than chain-of-thought).
+    static let harmony = ThinkingConfig(
+        style: .harmonyChannel(
+            marker: "<|channel|>",
+            thinkingChannels: ["analysis"],
+            generationChannels: ["final", "commentary"]
+        ),
         assistantPrefill: ""
     )
 }
@@ -209,7 +236,7 @@ enum ModelRegistry {
         temperature: 0.8, topP: 0.8, topK: 0, minP: 0.0,
         presencePenalty: nil, repetitionPenalty: nil,
         extraEOSTokens: [],
-        supportsThinking: false, reasoningEffort: "medium"
+        supportsThinking: true, thinkingConfig: .harmony, reasoningEffort: "medium"
     )
 
     // MARK: - Nemotron (Cascade 2)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -60,6 +60,9 @@ Then re-run your benchmark — it will recompile only the C/C++ target.
 
 # Two methods against the same model
 ./scripts/benchmark.sh --model qwen35-0.8b --method simple,summarization
+
+# GPT-OSS with high-effort reasoning, thinking + PPL tracking
+./scripts/benchmark.sh --model gpt-oss-20b --reasoning high --think --ppl
 ```
 
 ## CLI Reference
@@ -77,6 +80,7 @@ Then re-run your benchmark — it will recompile only the C/C++ target.
 | `--baseline` | Auto-select highest-fidelity variant that fits in GPU memory | Off |
 | `--batch N` | Run N concurrent generations | `1` |
 | `--think` | Enable thinking mode for thinking-capable models | Off |
+| `--reasoning EFFORT` | Reasoning effort for models that support it (e.g. GPT-OSS). Values: `low`, `medium`, `high`. Ignored by models without a reasoning-effort setting. | `medium` |
 | `-h`, `--help` | Show usage | — |
 
 **Comma-separated lists** on `--model`, `--method`, `--quant`, and `--kv` produce the full Cartesian product of permutations. Every permutation runs in sequence, and every row lands in the **same** hardware-dated output file (see [Output](#output)), grouped by model. A sweep like:
@@ -358,6 +362,7 @@ All configuration is passed via environment variables, enabling any backend to i
 | `MLX_BENCH_BASELINE` | `1` | unset | Auto-select highest-fidelity variant that fits in GPU memory |
 | `MLX_BENCH_BATCH` | integer | `1` | Number of concurrent generations |
 | `MLX_BENCH_THINK` | `1` | unset | Enable thinking mode |
+| `MLX_BENCH_REASONING` | `low`, `medium`, `high`, or passthrough | unset (falls back to the model family's registered default) | Reasoning effort for models that honour it (GPT-OSS). Plumbed into `GenerateParameters.reasoningEffort`; ignored by models whose chat templates don't consume it. |
 | `MLX_BENCH_PROMPT` | string | built-in | Override the `simple`-method user prompt |
 | `MLX_MAX_OPS_PER_BUFFER` | integer | hardware default (200 on Max/Ultra) | MLX Metal command-buffer commit threshold. Captured into every Parameters block so report readers can see what was in effect. |
 

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -45,6 +45,7 @@ PPL=false
 BASELINE=false
 BATCH=1
 THINK=false
+REASONING="medium"
 QUICK_CONTEXTS="128,1024,4096,32768"
 
 # ─────────────────────────────────────────────
@@ -79,6 +80,10 @@ Options:
   --baseline         Auto-select highest-fidelity variant (bf16 → 8bit → 4bit)
   --batch N          Run N concurrent generations (default: 1)
   --think            Enable thinking mode for thinking-capable models
+  --reasoning EFFORT Reasoning effort for models that support it (GPT-OSS).
+                     Values: low, medium, high (default: medium).
+                     Maps to MLX_BENCH_REASONING; ignored by models without
+                     a reasoning_effort setting.
   -h, --help         Show this help
 
 Model families:
@@ -107,6 +112,7 @@ Examples:
   ./scripts/benchmark.sh --model qwen35-0.8b,qwen35-2b --kv none,turbo4v2 --quick # Multi-model sweep
   ./scripts/benchmark.sh --model qwen35-0.8b --method simple,summarization        # Two methods
   ./scripts/benchmark.sh --model nemotron-cascade-2 --quant 4bit                  # Nemotron (alias)
+  ./scripts/benchmark.sh --model gpt-oss-20b --reasoning high --think --ppl       # Harmony reasoning at 'high'
 
 HELP
 }
@@ -127,6 +133,7 @@ while [[ $# -gt 0 ]]; do
         --baseline) BASELINE=true; shift ;;
         --batch)    BATCH="$2"; shift 2 ;;
         --think)    THINK=true; shift ;;
+        --reasoning) REASONING="$2"; shift 2 ;;
         -h|--help)  show_help; exit 0 ;;
         *) log_error "Unknown argument: $1"; show_help; exit 1 ;;
     esac
@@ -152,6 +159,13 @@ for m in "${METHODS[@]}"; do
         *) log_error "Unknown method: $m"; exit 1 ;;
     esac
 done
+
+# Validate reasoning effort — warn rather than error so new model vocabularies
+# pass through without requiring a harness change.
+case "$REASONING" in
+    low|medium|high) ;;
+    *) log_warn "Unusual reasoning effort '$REASONING' (expected low/medium/high); passing through" ;;
+esac
 
 # Build quant list
 QUANTS=()
@@ -190,7 +204,8 @@ log_info "Methods: $(IFS=,; echo "${METHODS[*]}")"
 log_info "Quants:  $(IFS=,; echo "${QUANTS[*]}")"
 log_info "KVs:     $(IFS=,; echo "${KVS[*]}")"
 $KLD && log_info "KLD:     yes"
-$THINK && log_info "Think:   yes"
+$PPL && log_info "PPL:     yes"
+$THINK && log_info "Think:   yes (reasoning=$REASONING)"
 [ "$BATCH" -gt 1 ] && log_info "Batch:   $BATCH"
 [ -n "$CONTEXTS" ] && log_info "Context: $CONTEXTS"
 log_info ""
@@ -218,6 +233,9 @@ if $KLD; then export MLX_BENCH_KLD=1; else unset MLX_BENCH_KLD; fi
 if ${PPL:-false}; then export MLX_BENCH_PPL=1; else unset MLX_BENCH_PPL; fi
 if [ "$BATCH" -gt 1 ]; then export MLX_BENCH_BATCH="$BATCH"; else unset MLX_BENCH_BATCH; fi
 if $THINK; then export MLX_BENCH_THINK=1; else unset MLX_BENCH_THINK; fi
+# Reasoning effort — only set when non-default so unset tells the harness to
+# fall back to the model family's registered value.
+if [ "$REASONING" != "medium" ]; then export MLX_BENCH_REASONING="$REASONING"; else unset MLX_BENCH_REASONING; fi
 
 TOTAL_RUNS=$(( ${#MODELS[@]} * ${#METHODS[@]} * ${#QUANTS[@]} * ${#KVS[@]} ))
 RUN_INDEX=0

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -266,7 +266,7 @@ for model in "${MODELS[@]}"; do
                 TMPOUT=$(mktemp)
                 script -q /dev/null swift test --skip-build -c release --filter "benchmark" 2>&1 \
                     | tee "$TMPOUT" \
-                    | grep -E --line-buffered "\[ENV\]|\[WARMUP\]|\[BENCH\]|\[MEM\]|\[KLD\]|\[RESULT\]|\[KV-QUANT\]|\[TURBO\]|\[PROGRESS\]|Test.*passed|Test.*failed|[Ee]rror|[Ff]atal|BenchmarkError|threw|[Ee]xception|issue at"
+                    | grep -E --line-buffered "\[ENV\]|\[WARMUP\]|\[BENCH\]|\[MEM\]|\[KLD\]|\[RESULT\]|\[KV-QUANT\]|\[TURBO\]|\[PROGRESS\]|\[HARMONY\]|Test.*passed|Test.*failed|[Ee]rror|[Ff]atal|BenchmarkError|threw|[Ee]xception|issue at"
                 EXIT_CODE=${PIPESTATUS[0]}
 
                 if [ "$EXIT_CODE" -ne 0 ]; then


### PR DESCRIPTION
## Summary

Actually populates the `GenerateCompletionInfo` fields that already existed on alpha as declared-only — `thinkingPerplexity`, `generationPerplexity`, `perTokenLogProbs`, `perTokenIds`, `perTokenPhases`. Before this change, every downstream consumer (benchmark harness PPL columns, the KLD forced-decode at `InferenceBenchmark.swift:854`, any `if let ids = info.perTokenIds` branch) silently read `nil`.

One commit: `67bf0c4` — `Libraries/MLXLMCommon/Evaluate.swift` only, +218 / −5 net.

> **Stacked on [#47](https://github.com/ekryski/mlx-swift-lm/pull/47)** (`ek/update-benchmark-build-tooling`). This PR's diff against `alpha` currently shows those 5 commits too. Once #47 merges, this becomes a clean single-commit delta.

## Design goals

1. **Zero inference-path overhead when flags are off.** A single `if let capture = perTokenCapture` guard — no extra MLX ops, no extra buffers, no extra syncs. The optimizer hoists the nil branch in the hot loop.
2. **Near-zero overhead when flags are on.** A scalar-output kernel chain detached from the token-eval pipeline via `asyncEval`, so the logprob computation runs concurrently with the next forward pass rather than blocking it.
3. **No public API change.** `GenerateCompletionInfo` fields and `GenerateParameters` flags already exist. This just populates them.
4. **No protocol break for speculative decoding.** `TokenIteratorProtocol.finalizePerTokenData()` has a default `nil` implementation; `SpeculativeTokenIterator` opts out automatically. PPL/KLD with spec decoding is a separate workstream.

## What's in the commit

**New types** near `TokenIteratorProtocol`:
- `public struct PerTokenData` — flushed, phase-labeled per-token result with precomputed PPL.
- `final class PerTokenDataCapture` — reference-type box holding lazy `MLXArray` handles during the loop. Class (not struct) is required because `TokenIterator` is a struct and `for token in iterator` copies it; the shared reference lets the for-in's mutations reach the outer iterator.
- `GenerateParameters.needsPerTokenCapture` — `trackPerplexity || collectPerTokenData`.

**`TokenIterator` changes**:
- Three new stored fields: `thinkStartTokenId` / `thinkEndTokenId` / `thinkingPhasePrefilled` (copied from `GenerateParameters` so the finalizer can label phases without threading parameters through `generateLoopTask`), plus the optional `perTokenCapture` box.
- All three init overloads wired.
- `convertToToken(logits:)` gets a 7-line capture block emitting the lean scalar-output chain:
  ```swift
  let lse = logSumExp(logits, axes: [-1])                   // 1 reduction → [1]
  let yLogit = takeAlong(logits,
                         y.expandedDimensions(axis: -1),
                         axis: -1)                          // scalar gather → [1, 1]
  let selected = yLogit - lse                               // [1, 1]
  asyncEval(selected)
  ```
  No full-vocab softmax buffer — vocab can be 250k+ tokens, that'd be ~1MB per step on decode.
- New non-mutating `finalizePerTokenData()`: concatenates all captured 1-element tensors into one `[N]` tensor, performs a **single** GPU→CPU transfer for the whole generation, labels phases in pure Swift, computes `exp(-mean(lp))` per phase.

**Generation-loop wiring** (both the async `generateLoopTask` and the deprecated sync `generate(input:context:iterator:didGenerate:)` returning `GenerateCompletionInfo`) calls `iterator.finalizePerTokenData()` and plumbs the five fields into the `GenerateCompletionInfo` constructor.

- Benchmark harness `[INFO] PPL: yes` log line at `scripts/benchmark.sh` — cosmetic parity with `--kld` and `--think` which we already log.

## Performance validation

M1 Max, Qwen3.5-0.8B 4bit `none`, summarization, 1024 ctx, 5 runs each:

| Metric | Flags OFF | Flags ON | Delta |
|--------|----------:|---------:|-------|
| Prefill tok/s | 236.4 ± 2.2 | 239.6 ± 2.2 | **+1.4% (within noise)** |
| Decode tok/s | 159.5 ± 7.9 | 161.1 ± 4.4 | **+1.0% (within noise)** |

A first-pass implementation used `logSoftmax(logits)` (materialising a `[1, V]` buffer) and showed ~8% decode regression. Swapping it for the scalar-output `logSumExp + takeAlong - subtract` chain got overhead into the noise floor.

## Correctness validation

Same config with `--ppl --kld --think`:

| Config | Think PPL | Gen PPL | Think KLD | Gen KLD |
|--------|----------:|--------:|----------:|--------:|
| 4bit / no-quant | 2.31 | 1.07 | 0.271 | 0.308 |
| 4bit / turbo4v2 | 3.39 | 1.98 | 0.322 | 0.406 |

**KLD is directionally correct** — turbo4v2 (K 4-bit, V 2-bit asymmetric) diverges more from the bf16 baseline than `none` does. The benchmark harness's KLD forced-decode path at [`InferenceBenchmark.swift:854`](Tests/Benchmarks/InferenceBenchmark.swift#L854) — previously dead code because `perTokenIds` was always nil — now fires as designed.

## Test plan

- [x] `xcodebuild test -scheme mlx-swift-lm-Package -only-testing MLXLMTests` — 54 tests, 4 suites, passes. Verified locally at 41s.
- [x] `./scripts/benchmark.sh --model qwen35-0.8b --quant 4bit --kv none --method summarization --context 1024` (no flags) — prefill/decode tok/s within ~2% of pre-change baseline. Confirms the nil-branch path stays inert.
- [x] `./scripts/benchmark.sh --model qwen35-0.8b --quant 4bit --kv none,turbo4v2 --method summarization --context 128 --ppl --kld --think` — all four PPL/KLD columns populate with finite values; turbo4v2 KLD > none KLD.
- [x] Speculative decoding path (`SpeculativeTokenIterator`) still works — uses the protocol's default `finalizePerTokenData() → nil`, info event emitted with nil PPL/KLD as before.

## Follow-ups (not in this PR)

- PPL/KLD for speculative decoding — `SpeculativeTokenIterator` currently returns `nil` from the default protocol method. A separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)