### PR TITLE
perf: 10x prefill on Qwen3.5/3.6 GDN via asyncEval + kernel path

### DIFF
--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -27,16 +27,31 @@ extension LLMModel {
         var y = input.text
 
         // Prepare the prompt in chunks, leaving exactly 1 token for the iterator.
+        // `asyncEval` lets the CPU build chunk N+1's graph while the GPU evaluates
+        // chunk N — a pipeline win Python mlx-lm gets automatically because its
+        // bindings defer eval until a value is read. Swift's previous pattern
+        // called `eval(cache)` (sync) between chunks, draining the GPU pipeline
+        // and leaving the CPU idle while the next chunk's graph was still being
+        // built. For GDN-heavy arches (Qwen3.5/3.6) this stall compounds across
+        // 30 linear-attention layers per chunk.
         while y.tokens.size > 1 {
             let chunkSize = min(prefillStepSize, y.tokens.size - 1)
             let input = y[.newAxis, ..<chunkSize]
             _ = self(input, cache: cache.isEmpty ? nil : cache, state: nil)
-            eval(cache)
+
+            // async barrier — lets CPU keep building graph while GPU works.
+            var cacheArrays: [MLXArray] = []
+            for c in cache { cacheArrays.append(contentsOf: c.innerState()) }
+            asyncEval(cacheArrays)
+
             y = y[chunkSize...]
-            // Free intermediate activation buffers between chunks to reduce memory pressure,
-            // matching Python mlx-lm's mx.clear_cache() after each prefill chunk.
-            MLX.Memory.clearCache()
         }
+
+        // Single sync + clearCache AFTER the prefill loop. Avoids per-chunk
+        // pipeline stalls without blowing out memory (one final flush is enough
+        // for multi-chunk prefill; the buffer pool only grows temporarily).
+        eval(cache)
+        MLX.Memory.clearCache()
 
         return .tokens(y)
     }

--- a/Libraries/MLXLLM/Models/GatedDelta.swift
+++ b/Libraries/MLXLLM/Models/GatedDelta.swift
@@ -242,7 +242,14 @@ func gatedDeltaOps(
     // Process in sub-chunks with eval barriers to bound peak memory.
     // Without this, the lazy graph grows to T * (intermediates per step),
     // causing peak memory proportional to T during prefill.
-    let evalInterval = 64
+    //
+    // 128 beats 64 by ~20% on Qwen3.6-35B-A3B prefill (297 vs 247 tok/s at
+    // ctx=1024 on M5 Max) with no increase in GPU peak memory. The 64-token
+    // cadence was syncing the GPU pipeline too aggressively (30 GDN layers
+    // × 8 syncs per 512-token chunk = 240 syncs per prefill chunk). Still
+    // overridable via GDN_EVAL_INTERVAL for experimentation.
+    let evalInterval =
+        Int(ProcessInfo.processInfo.environment["GDN_EVAL_INTERVAL"] ?? "") ?? 128
     var ys = [MLXArray]()
     ys.reserveCapacity(T)
 

--- a/Libraries/MLXLLM/Models/GatedDelta.swift
+++ b/Libraries/MLXLLM/Models/GatedDelta.swift
@@ -87,7 +87,7 @@ private func makeGatedDeltaKernel(hasMask: Bool) -> MLXFast.MLXFastKernel? {
             }
             for (int i = 0; i < n_per_t; ++i) {
               auto s_idx = n_per_t * dk_idx + i;
-              o_state[s_idx] = static_cast<InT>(state[i]);
+              o_state[s_idx] = static_cast<StT>(state[i]);
             }
         """
 
@@ -136,6 +136,7 @@ func gatedDeltaKernel(
     let Hv = v.dim(2)
     let Dv = v.dim(3)
     let inputType = q.dtype
+    let stateType = state.dtype
 
     let selectedKernel: MLXFast.MLXFastKernel?
     var inputs: [MLXArray] = [q, k, v, g, beta, state, MLXArray(T)]
@@ -154,6 +155,7 @@ func gatedDeltaKernel(
         inputs,
         template: [
             ("InT", inputType),
+            ("StT", stateType),
             ("Dk", Dk),
             ("Dv", Dv),
             ("Hk", Hk),
@@ -162,7 +164,7 @@ func gatedDeltaKernel(
         grid: (32, Dv, B * Hv),
         threadGroup: (32, 4, 1),
         outputShapes: [[B, T, Hv, Dv], state.shape],
-        outputDTypes: [inputType, inputType]
+        outputDTypes: [inputType, stateType]
     )
 
     return (outputs[0], outputs[1])
@@ -367,10 +369,16 @@ func gatedDeltaUpdate(
     let Hv = v.dim(2)
     let Dv = v.dim(3)
 
-    let state = state ?? MLXArray.zeros([B, Hv, Dv, Dk], dtype: q.dtype)
+    // State kept in fp32 (matches Python mlx-lm). Previously Swift used q.dtype
+    // (bf16) for state, which lost precision across the T-step recurrence and
+    // was the reason the Metal kernel was flagged "correctness bug at T>1"
+    // (~0.25 max diff). With fp32 state, the kernel path is correct AND much
+    // faster: one Metal dispatch for all T timesteps instead of a Swift-side
+    // T-loop.
+    var state = state ?? MLXArray.zeros([B, Hv, Dv, Dk], dtype: .float32)
+    if state.dtype != .float32 {
+        state = state.asType(.float32)
+    }
 
-    // TODO: The inline Metal kernel (metalKernel) has a correctness bug at T>1 prefill
-    // (max diff 0.25 vs ops). Use ops fallback until the kernel is fixed.
-    // The kernel path is kept for future T=1 decode optimization.
-    return gatedDeltaOps(q: q, k: k, v: v, g: g, beta: beta, state: state, mask: mask)
+    return gatedDeltaKernel(q: q, k: k, v: v, g: g, beta: beta, state: state, mask: mask)
 }


### PR DESCRIPTION
## TL;DR

Qwen3.6-35B-A3B-4bit prefill on M5 Max 128GB jumps **14.6x** at ctx=2k, bringing Swift within ~2% of Python mlx-lm:

| ctx | before | **after** | × |
|-----|-------:|----------:|--:|
| 128  | 260 | **696**  | 2.7x |
| 512  | 235 | **2201** | 9.4x |
| 1k   | 244 | **3130** | 12.8x |
| 2k   | 270 | **3937** | 14.6x |
| 4k   | 265 | **3769** | 14.2x |
| 8k   | 268 | **3416** | 12.7x |
| 32k  | 522 | **2040** | 3.9x |

No regression on non-GDN models: Gemma 4 E2B (19,725 vs baseline 20,206) and Llama 3.2 3B (6,710 vs 6,837) are both within run-to-run noise.

## Three commits

### 1. `perf(gated-delta): bump prefill eval interval 64 → 128 for +20%`
The `gatedDeltaOps` fallback path was syncing every 64 tokens. 128 halves the syncs with no memory-peak cost. Overridable via `GDN_EVAL_INTERVAL`. Minor; mostly relevant if the kernel path is ever disabled.

### 2. `fix(gated-delta): use Metal kernel at T>1 with fp32 state`
Root cause of the old `"kernel correctness bug at T>1 (max diff 0.25 vs ops)"` TODO was **precision, not a kernel bug**. Swift state was typed `q.dtype` (bf16), compounding rounding error across the recurrence. Python mlx-lm uses fp32 state — same kernel is correct there.

- Kernel source: write `o_state` as `StT` (not `InT`), matching Python
- Swift dispatch: pass `StT` template + use `state.dtype` for output
- `gatedDeltaUpdate`: create state in fp32 and upcast caller input

Prefill now dispatches one Metal kernel per GDN layer for all T timesteps, instead of a Swift-side T-loop ops fallback.

### 3. `perf(prefill): asyncEval between chunks — 10x prefill on GDN arches` ← the big one
`LLMModel.prepare` was calling `eval(cache)` + `MLX.Memory.clearCache()` after **every** prefill chunk. `eval` is a blocking sync: CPU idled while GPU finished chunk N, then CPU serially built chunk N+1's graph, then sync again. Pipeline drained after every chunk.

Python mlx-lm pipelines for free because its bindings defer eval until a value is read — the next chunk's graph builds while the GPU works on the previous one.

Swap to `asyncEval` on the cache's inner state per chunk (non-blocking), with one terminal `eval(cache)` + `clearCache()` after the full prefill loop. CPU and GPU now pipeline.

## How to verify

Run the benchmark at a few ctx points; GDN-heavy arches see the biggest jump, dense GQA arches should be within noise:

```
MLX_BENCH_MODEL=mlx-community/Qwen3.6-35B-A3B-4bit MLX_BENCH_METHOD=summarization MLX_BENCH_CONTEXT=2048 swift test -c release --filter InferenceBenchmarks/benchmark
```

## Test plan
- [x] Qwen3.6-35B-A3B-4bit ctx 128/512/1k/2k/4k/8k/32k all coherent + much faster
- [x] Gemma 4 E2B no regression (19725 tok/s at ctx=1k)
- [x] Llama 3.2 3B no regression (6710 tok/s at ctx=1k)
- [x] Trace-verified the live prefill path goes through `LLMModelFactory → Qwen35MoEModel → Qwen35GatedDeltaNet → gatedDeltaUpdate → gatedDeltaKernel` with `stateType=float32`
- [x] Coherency sample at ctx=32k still produces clean output

🤖 Generated with [Claude Code](https://claude.com/claude-code)