### PR TITLE
perf: asyncEval per-layer during prefill (Qwen35, NemotronH)

### DIFF
--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -686,11 +686,15 @@ private class NemotronHBackbone: Module {
 
             hidden = layer(hidden, attentionMask: attentionMask, ssmMask: ssmMask, cache: c)
 
-            // During prefill, eval after each layer to free activation buffers.
-            // Without this, the lazy graph spans all layers and peak memory scales
-            // with model depth × sequence length.
+            // During prefill, asyncEval after each layer. Previously `eval` forced
+            // a CPU↔GPU sync per layer, stalling the CPU from building layer i+1's
+            // graph until the GPU finished layer i. `asyncEval` schedules the
+            // evaluation but lets the CPU keep building ahead — the GPU pipeline
+            // stays fed through the Mamba+attention+MoE stack.
             if isPrefill, let c {
-                eval(hidden, c)
+                var toEval: [MLXArray] = [hidden]
+                toEval.append(contentsOf: c.innerState())
+                asyncEval(toEval)
             }
         }
 

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -574,13 +574,16 @@ public class Qwen35TextModelInner: Module {
             // asType is a no-op (zero overhead).
             hiddenStates = hiddenStates.asType(modelDtype)
 
-            // During prefill, eval after each layer to free intermediate activation
-            // buffers. Without this, the lazy graph spans all layers (~1.6GB for
-            // 0.8B at T=2048). Per-layer eval keeps peak bounded to one layer's
-            // activations (~110MB for GDN, ~90MB for attention+MoE).
+            // During prefill, asyncEval after each layer. `eval` would force a
+            // CPU↔GPU sync per layer, stalling the CPU from building layer i+1's
+            // graph until the GPU finished layer i. `asyncEval` submits the
+            // evaluation but lets the CPU keep building ahead — the GPU pipeline
+            // stays fed through the 40-layer GDN+attention+MoE stack.
             // Skip during decode (T=1) where the graph is tiny and eval overhead hurts tok/s.
             if isPrefill, let c = cacheArray?[i] {
-                eval(hiddenStates, c)
+                var toEval: [MLXArray] = [hiddenStates]
+                toEval.append(contentsOf: c.innerState())
+                asyncEval(toEval)
             }
         }
 


### PR DESCRIPTION
Follow-up to #49. Same asyncEval idea, applied to the **per-layer** eval barriers inside `Qwen35TextModelInner` and `NemotronHBackbone`.

## What and why

Both `Qwen35` (GDN hybrid) and `NemotronH` (Mamba+attention hybrid) already called `eval(hidden, cache)` after every layer during prefill to keep peak memory bounded to a single layer's activations. That's a CPU↔GPU sync per layer — the CPU idles waiting for the GPU to finish layer i before it can start building layer i+1's graph. For a 40-48 layer forward that's 40-48 pipeline drains per chunk.

Switch to `asyncEval` with the same arguments. Schedules the evaluation so MLX still frees the transient activations, but doesn't block the CPU. The GPU pipeline stays fed.

Same pattern Gemma 4's custom `prepare` already uses (no eval barriers in the forward, asyncEval at the chunk boundary).

## Numbers (M5 Max 128GB, summarization, 4-bit)

**Nemotron-Cascade-2 30B-A3B:**
| ctx | before → after (tok/s) | Δ |
|----:|-----------------------:|--:|
| 128 | 863 → 960 | **+11%** (3-run avg, repeatable 953-964) |
| 1024 | 2711 → 2764 | +2% |
| 4096 | 2481 → 2481 | 0% |

**Qwen3.5 / 3.6 family (ctx=128 slice, since that's where it hits):**
| Model | before → after |
|-------|----------------|
| Qwen3.5 2B | 2837 → 3018 tok/s (**+6%**) |
| Qwen3.5 9B | 1255 → 1320 tok/s (**+5%**) |
| Qwen3.6 35B-A3B | 718 → 712 tok/s (noise — already saturated) |

Wins taper to noise at ctx≥1k — at that point the GPU is already compute-bound on per-layer work and the pipeline stall was already shorter than each layer's matmul. Coherency unchanged on both models at ctx=1024.

## Test plan
- [x] Nemotron ctx=128 repeatability: 953.3 / 960.7 / 964.3 across 3 runs (stable)
- [x] Qwen3.6 35B-A3B prefill still coherent at ctx=1024
- [x] Nemotron 30B-A3B prefill still coherent at ctx=1024
- [x] Build clean with no new warnings
- [x] Only the two files with per-layer eval barriers touched; Gemma / Llama / Mistral / Phi / Qwen2.5 / Qwen3 / GPT-OSS / MiniMax / Qwen3Next untouched (they don't have this pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)