### PR TITLE
evaluate: disable n-gram speculative decoding by default

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -117,10 +117,18 @@ public struct GenerateParameters: Sendable {
     /// N-gram size for prompt-lookup speculative decoding. When > 0, the iterator
     /// searches for matching n-grams in the prompt text and uses continuations as
     /// draft tokens, verifying them in a single batched forward pass.
-    /// Typical value: 3 (trigram matching). Set to 0 to disable.
+    ///
+    /// **Default: 0 (disabled).** The speculation path is a net-win only when the
+    /// generated text has enough repetition that the trigram table hits with a
+    /// reasonable acceptance rate. For novel prose / summarisation / chat, accept
+    /// rate is often low and the draft work becomes pure overhead. Enable
+    /// explicitly (`ngramSize: 3`, or higher) when your workload has been
+    /// validated to benefit — e.g. code-heavy output or repetitive templates.
     public var ngramSize: Int
 
-    /// Maximum draft tokens per n-gram speculation round.
+    /// Maximum draft tokens per n-gram speculation round. Defaults to 0 so that
+    /// a bare `GenerateParameters()` disables speculation end-to-end; must be
+    /// set in tandem with `ngramSize` when enabling.
     public var maxNgramDraftTokens: Int
 
     /// Token ID marking the start of a thinking phase (e.g., <think> token).
@@ -179,8 +187,8 @@ public struct GenerateParameters: Sendable {
         kvScheme: String? = nil,
         additionalProcessors: [any LogitProcessor] = [],
         reasoningEffort: String? = nil,
-        ngramSize: Int = 3,
-        maxNgramDraftTokens: Int = 3,
+        ngramSize: Int = 0,
+        maxNgramDraftTokens: Int = 0,
         thinkStartTokenId: Int32? = nil,
         thinkEndTokenId: Int32? = nil,
         thinkingPhasePrefilled: Bool = false,


### PR DESCRIPTION
## Summary

Change `GenerateParameters.ngramSize` and `maxNgramDraftTokens` defaults from `3` to `0`. Every library consumer who constructs `GenerateParameters()` with defaults currently gets trigram prompt-lookup speculative decoding implicitly — that's the wrong default until we've validated the speculation path gives net wins on representative workloads.

One commit, `Libraries/MLXLMCommon/Evaluate.swift` only, +12 / -4.

## Why

Speculative decoding is only a net-win when the draft's **acceptance rate × speedup-if-accepted** exceeds the **overhead of the wasted draft work**. For general prose / summarisation / chat output, the trigram table hits infrequently — most draft tokens get rejected, and the extra forward passes become pure overhead. For repetitive output (code, templated answers) it's genuinely useful.

Yesterday's bench surfaced this on `ek/tom-eric-moe-tuning` → alpha: Qwen3.5-0.8B summarisation at 4096 ctx decoded ~10% slower when we flipped alpha on, entirely explained by the default going from `0` → `3` on that migration (see [#51](https://github.com/ekryski/mlx-swift-lm/pull/51) for the benchmark-harness companion that adds `--ngram SIZE` to opt in). The library default shouldn't silently impose this cost.

## What doesn't change

- Parameter names, types, and semantics stay the same.
- Existing callers that pass `ngramSize: N` / `maxNgramDraftTokens: N` explicitly keep their behaviour unchanged.
- The speculation code path is untouched — this is a defaults-only change.
- N-gram decoding remains fully available; callers opt in with:
  ```swift
  GenerateParameters(ngramSize: 3, maxNgramDraftTokens: 3)
  ```

## Coverage

Grepped `Libraries/` for any code that relies on the `ngramSize = 3` default: nothing but one doc snippet (`Libraries/MLXLMCommon/Documentation.docc/porting.md`). No ChatSession or factory code sets it explicitly today. Updated the doc comment to document the new default and the opt-in path.

## Test plan

- [x] `xcodebuild test -scheme mlx-swift-lm-Package -only-testing MLXLMTests` passes.
- [ ] Bench harness `Speculative decoding` row reads `none` when no `--ngram` flag passed, `ngram (size=N, maxDraft=N)` when `--ngram N` is passed (covered by #51).
- [x] Library consumer that passes `GenerateParameters(ngramSize: 3, maxNgramDraftTokens: 3)` explicitly gets the same behaviour as before this change.

## Related

- [#51](https://github.com/ekryski/mlx-swift-lm/pull/51) adds the benchmark-harness `--ngram SIZE` flag so users can opt into speculation measurements explicitly.
- Tom's `ek/ngram-speculative-decoding` branch has WIP improvements to the speculation path (adaptive auto-disable, MambaCache snapshot/restore). Once that lands, we can re-evaluate flipping the library default back on with the accept-rate gating it includes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)