### PR TITLE
fix: VLM language models handle 1D input tokens

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -921,6 +921,11 @@ enum Qwen35Language {
             imageGridTHW: [THW]? = nil,
             videoGridTHW: [THW]? = nil
         ) -> LMOutput {
+            // Normalise inputs to 2D `[batch, seqLen]`. Callers that pass flat
+            // token arrays (e.g. a prefix-cache delta path) would otherwise crash
+            // at the first `inputs.dim(1)` / `getRopeIndex` call.
+            let inputs = inputs.ndim == 1 ? inputs[.newAxis] : inputs
+
             if pixelValues != nil {
                 precomputedPositionIds = nil
                 ropeDeltas = nil

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -1245,6 +1245,11 @@ enum Qwen3VLLanguage {
             imageGridTHW: [THW]?,
             videoGridTHW: [THW]?
         ) -> LMOutput {
+            // Normalise inputs to 2D `[batch, seqLen]`. Callers passing flat
+            // token arrays (e.g. a prefix-cache delta path) would otherwise crash
+            // at the first `.dim(1)` call.
+            let inputIds = inputIds.map { $0.ndim == 1 ? $0[.newAxis] : $0 }
+
             if pixelValues != nil {
                 ropeDeltas = nil
             }
@@ -1336,6 +1341,10 @@ extension Qwen3VLLanguage {
         attentionMask: MLXArray? = nil
     ) -> (MLXArray, MLXArray) {
 
+        // Accept either a 1D `[seqLen]` or 2D `[batch, seqLen]` input so callers
+        // feeding raw token arrays (e.g. a prefix-cache delta) don't hit
+        // `SmallVector out of range` on `dim(1)`.
+        let inputIds = inputIds.ndim == 1 ? inputIds[.newAxis] : inputIds
         let (batchSize, seqLength) = (inputIds.dim(0), inputIds.dim(1))
 
         var positionIds = MLXArray(0 ..< seqLength).asType(.int32)


### PR DESCRIPTION
## Summary

- `Qwen3VLLanguage.getRopeIndex`, `Qwen35` VLM `LanguageModel.callAsFunction`, and `Qwen3VL` `LanguageModel.callAsFunction` all call `inputs.dim(1)` without guarding against 1D inputs.
- A caller passing a flat 1D `[seqLen]` tensor (for example a prefix-cache delta-prefill path that slices the prompt down to just the new-tail tokens) crashes with `SmallVector out of range` at `mlx/c/array.cpp:335`.
- Fix: normalise to 2D `[batch, seqLen]` at each affected entry point by adding `[.newAxis]` when `ndim == 1`. No change for existing 2D callers.

## Repro

Reproduced via Sam (Qwen3.5 0.8B 8-bit, prefix-cache HIT path):

```
[Agent] Prefix cache HIT: reusing 1684/1853 tokens (90%), prefilling 169 delta tokens
Fatal error: SmallVector out of range. at mlx-c/mlx/c/array.cpp:335
```

Stack top:
1. `Qwen3VLLanguage.getRopeIndex` — `inputIds.dim(1)`
2. `Qwen35Language.LanguageModel.callAsFunction`
3. `Qwen35.prepare`
4. `TokenIterator.prepare`

## Test plan

- [x] `swift build` clean on `mlx-swift-lm` alpha
- [x] Spot-check non-delta (2D) prefill path — no regression