### PR TITLE
perf(gemma4): use symbolic .slidingWindow SDPA mask

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4.swift
+++ b/Libraries/MLXLLM/Models/Gemma4.swift
@@ -1051,11 +1051,22 @@ public class Gemma4ModelInner: Module {
                 maskMode = fullMask!
             } else {
                 if slidingMask == nil {
-                    slidingMask = makeAttentionMask(
-                        n: seqLen,
-                        cache: cache[slidingAttentionIndex],
-                        windowSize: config.slidingWindow
-                    )
+                    // Symbolic sliding-window mask: the SDPA fallback path
+                    // constructs the window constraint on GPU (arange +
+                    // compare) instead of materializing a [B, H, L, window]
+                    // tensor here. Falls back to `.causal` when the cache
+                    // hasn't filled the window yet — causal alone is already
+                    // correct and the cheaper kernel path is available.
+                    let cacheOffset = cache[slidingAttentionIndex]?.offset ?? 0
+                    if seqLen > 1 && cacheOffset + seqLen > config.slidingWindow {
+                        slidingMask = .slidingWindow(size: config.slidingWindow)
+                    } else {
+                        slidingMask = makeAttentionMask(
+                            n: seqLen,
+                            cache: cache[slidingAttentionIndex],
+                            windowSize: config.slidingWindow
+                        )
+                    }
                 }
                 maskMode = slidingMask!
             }

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1715,12 +1715,18 @@ public func quantizedScaledDotProductAttention(
 
     // Apply mask
     switch mask {
-    case .causal:
+    case .causal, .slidingWindow:
         let (qL, kL) = (scores.dim(-2), scores.dim(-1))
         let qIndices = MLXArray(0 ..< qL) + MLXArray(kL - qL)
         let kIndices = MLXArray(0 ..< kL)
-        let causalMask = greaterEqual(
-            expandedDimensions(qIndices, axis: -1), expandedDimensions(kIndices, axis: -2))
+        let qExpanded = expandedDimensions(qIndices, axis: -1)
+        let kExpanded = expandedDimensions(kIndices, axis: -2)
+        var causalMask = greaterEqual(qExpanded, kExpanded)
+        if case .slidingWindow(let window) = mask {
+            let lowerBound = qExpanded - MLXArray(Int32(window))
+            let withinWindow = greater(kExpanded, lowerBound)
+            causalMask = logicalAnd(causalMask, withinWindow)
+        }
         scores = MLX.where(causalMask, scores, MLXArray(Float.leastNormalMagnitude))
 
     case .array(let maskArray):


### PR DESCRIPTION
## Summary

Gemma4's sliding-attention layers previously materialized a causal+window mask tensor (broadcast to \`[B, H, L, L]\`) on every prefill. With the new \`.slidingWindow(size:)\` SDPA mask mode, the op synthesizes the bound on GPU from arange + compare — no mask tensor crossing the Swift/Metal boundary.

## Paired with

Consumer-side change in this PR depends on:
- [ekryski/mlx#8](https://github.com/ekryski/mlx/pull/8) — C++ primitive + fallback
- [ekryski/mlx-c#3](https://github.com/ekryski/mlx-c/pull/3) — C ABI
- [ekryski/mlx-swift#11](https://github.com/ekryski/mlx-swift/pull/11) — Swift enum + dispatch

Merge order: mlx → mlx-c → mlx-swift → this PR.

## Logic

At the sliding-layer mask site in \`Gemma4ModelInner.callAsFunction\`:
- Decode (\`seqLen == 1\`): existing path — \`makeAttentionMask\` returns \`.none\`. No change.
- Prefill within window (\`cacheOffset + seqLen <= slidingWindow\`): existing path — \`makeAttentionMask\` returns \`.causal\`. Cheap symbolic form.
- Prefill past the window: new path — \`.slidingWindow(size: config.slidingWindow)\`. Previously materialized.

## Also

\`KVCache.swift\`'s quantized-attention mask-apply path updated to handle \`.slidingWindow\` exhaustively.

## Test plan

Correctness tested upstream (ekryski/mlx-swift#11 has \`SlidingWindowSDPATests\` with 8 configurations pinning symbolic vs. materialized output). In this repo, safety regression suite passes:
- [x] \`KVCacheTests\`
- [x] \`SpeculativeDecodingTests\`
- [x] \`Gemma3nOffsetTests\`
- [x] \`MaskedScatterTests\`
- [x] Benchmark: \`benchmark.sh --model gemma4-e2b --quant 4bit --kv turbo4v2 --method summarization --context 1024,4096,16384 --ppl\` — user to run

## Follow-up

Metal kernel variants (Steel BD=256, sdpa_vector BD=512, NAX) that natively honor \`window_size\` — would eliminate the fallback-compose path for windowed decode/prefill. Tracked in ekryski/mlx#8 description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)