### PR TITLE
Gemma4 Perf: compile()-cached SharedMLP forward

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4.swift
+++ b/Libraries/MLXLLM/Models/Gemma4.swift
@@ -685,6 +685,24 @@ class Gemma4SharedMLP: Module {
     @ModuleInfo(key: "up_proj") var upProj: Linear
     @ModuleInfo(key: "down_proj") var downProj: Linear
 
+    /// Gated graph-caching experiment: wraps the three-op forward
+    /// (gate_proj + geglu + up_proj → down_proj) in a compiled closure so
+    /// MLX's trace cache is consulted per input-shape instead of rebuilding
+    /// the DAG per call. The individual ops are opaque primitives, so the
+    /// win (if any) is CPU-side tape-replay cost, not kernel fusion.
+    ///
+    /// Off by default; set `MLX_COMPILE_SHARED_MLP=1` to exercise.
+    private lazy var compiledForward: @Sendable (MLXArray) -> MLXArray = {
+        compile(inputs: [self], outputs: [], shapeless: true) { [self] x in
+            let hidden = compiledGeglu(self.gateProj(x), self.upProj(x))
+            return self.downProj(hidden)
+        }
+    }()
+
+    private static let compileEnabled: Bool = {
+        ProcessInfo.processInfo.environment["MLX_COMPILE_SHARED_MLP"] == "1"
+    }()
+
     init(dimensions: Int, hiddenDimensions: Int, isDoubleWide: Bool = false) {
         let effectiveHidden = isDoubleWide ? hiddenDimensions * 2 : hiddenDimensions
         self._gateProj.wrappedValue = Linear(dimensions, effectiveHidden, bias: false)
@@ -694,7 +712,10 @@ class Gemma4SharedMLP: Module {
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        downProj(compiledGeglu(gateProj(x), upProj(x)))
+        if Self.compileEnabled {
+            return compiledForward(x)
+        }
+        return downProj(compiledGeglu(gateProj(x), upProj(x)))
     }
 }
 

--- a/Libraries/MLXLLM/Models/Gemma4.swift
+++ b/Libraries/MLXLLM/Models/Gemma4.swift
@@ -685,13 +685,20 @@ class Gemma4SharedMLP: Module {
     @ModuleInfo(key: "up_proj") var upProj: Linear
     @ModuleInfo(key: "down_proj") var downProj: Linear
 
-    /// Gated graph-caching experiment: wraps the three-op forward
-    /// (gate_proj + geglu + up_proj → down_proj) in a compiled closure so
-    /// MLX's trace cache is consulted per input-shape instead of rebuilding
-    /// the DAG per call. The individual ops are opaque primitives, so the
-    /// win (if any) is CPU-side tape-replay cost, not kernel fusion.
+    /// Wraps the three-op forward (gate_proj + geglu + up_proj → down_proj)
+    /// in a compiled closure so MLX's trace cache is consulted per input-shape
+    /// instead of rebuilding the DAG on every call. The individual ops are
+    /// opaque primitives, so the win is CPU-side tape-replay cost, not
+    /// kernel fusion.
     ///
-    /// Off by default; set `MLX_COMPILE_SHARED_MLP=1` to exercise.
+    /// Defaults to ON for dense Gemma4 layers (E2B/E4B/31B) and OFF for the
+    /// MoE 26B-A4B variant — the compile boundary loses scheduling
+    /// opportunities the MoE+full-precision-KV path picks up from the
+    /// uncached call site (~10% decode regression at kv=none, observed on
+    /// M1 Max). Override with `MLX_COMPILE_SHARED_MLP=1` (force on) or
+    /// `MLX_COMPILE_SHARED_MLP=0` (force off).
+    private let compileEnabled: Bool
+
     private lazy var compiledForward: @Sendable (MLXArray) -> MLXArray = {
         compile(inputs: [self], outputs: [], shapeless: true) { [self] x in
             let hidden = compiledGeglu(self.gateProj(x), self.upProj(x))
@@ -699,20 +706,25 @@ class Gemma4SharedMLP: Module {
         }
     }()
 
-    private static let compileEnabled: Bool = {
-        ProcessInfo.processInfo.environment["MLX_COMPILE_SHARED_MLP"] == "1"
-    }()
-
-    init(dimensions: Int, hiddenDimensions: Int, isDoubleWide: Bool = false) {
+    init(dimensions: Int, hiddenDimensions: Int, isDoubleWide: Bool = false, isMoEContext: Bool = false) {
         let effectiveHidden = isDoubleWide ? hiddenDimensions * 2 : hiddenDimensions
         self._gateProj.wrappedValue = Linear(dimensions, effectiveHidden, bias: false)
         self._upProj.wrappedValue = Linear(dimensions, effectiveHidden, bias: false)
         self._downProj.wrappedValue = Linear(effectiveHidden, dimensions, bias: false)
+        self.compileEnabled = Self.resolveCompileEnabled(architectureDefault: !isMoEContext)
         super.init()
     }
 
+    private static func resolveCompileEnabled(architectureDefault: Bool) -> Bool {
+        switch ProcessInfo.processInfo.environment["MLX_COMPILE_SHARED_MLP"] {
+        case "1": return true
+        case "0": return false
+        default:  return architectureDefault
+        }
+    }
+
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        if Self.compileEnabled {
+        if compileEnabled {
             return compiledForward(x)
         }
         return downProj(compiledGeglu(gateProj(x), upProj(x)))
@@ -784,7 +796,7 @@ class Gemma4TransformerBlock: Module {
 
         self._sharedMLP.wrappedValue = Gemma4SharedMLP(
             dimensions: config.hiddenSize, hiddenDimensions: config.intermediateSize,
-            isDoubleWide: isDoubleWide)
+            isDoubleWide: isDoubleWide, isMoEContext: config.enableMoeBlock)
 
         if config.enableMoeBlock {
             self._experts.wrappedValue = FusedGateUpSwitchGLU(

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1715,12 +1715,17 @@ public func quantizedScaledDotProductAttention(
 
     // Apply mask
     switch mask {
-    case .causal:
+    case .causal, .slidingWindow:
         let (qL, kL) = (scores.dim(-2), scores.dim(-1))
         let qIndices = MLXArray(0 ..< qL) + MLXArray(kL - qL)
         let kIndices = MLXArray(0 ..< kL)
-        let causalMask = greaterEqual(
-            expandedDimensions(qIndices, axis: -1), expandedDimensions(kIndices, axis: -2))
+        let qExpanded = expandedDimensions(qIndices, axis: -1)
+        let kExpanded = expandedDimensions(kIndices, axis: -2)
+        var causalMask = greaterEqual(qExpanded, kExpanded)
+        if case .slidingWindow(let window) = mask {
+            let lowerBound = qExpanded - MLXArray(Int32(window))
+            causalMask = logicalAnd(causalMask, greater(kExpanded, lowerBound))
+        }
         scores = MLX.where(causalMask, scores, MLXArray(Float.leastNormalMagnitude))
 
     case .array(let maskArray):


### PR DESCRIPTION
## Summary

Wraps `Gemma4SharedMLP.callAsFunction` in `compile(inputs: [self], outputs: [], shapeless: true)` so MLX's trace cache is consulted per input-shape signature instead of rebuilding the DAG on every call.

Not kernel fusion — the ops inside (Linear → geluApproximate → Linear) are opaque. The win is CPU-side tape-replay cost, literal graph caching: build the op graph once per shape, replay for every subsequent call at the same shape.

## Per-architecture default

After a wider benchmark sweep, the optimization helps dense Gemma4 layers but **regresses MoE 26B-A4B on `kv=none`** by ~10% decode (consistently reproducible across two independent 3-run sweeps). The compile boundary appears to lose scheduling opportunities the uncached path picks up from the surrounding MoE expert routing — the MoE+full-precision-KV combination specifically.

The PR now gates per architecture, with env-var overrides:

| `enable_moe_block` | Default | Override |
|---|---|---|
| `false` (E2B / E4B / 31B — dense) | **ON** | `MLX_COMPILE_SHARED_MLP=0` to force off |
| `true` (26B-A4B — MoE) | **OFF** | `MLX_COMPILE_SHARED_MLP=1` to force on |

## Benchmark — 4-bit, 3-run averages, M1 Max 64GB, summarization

### Decode tok/s (the metric the optimization moves)

| Model | KV | Ctx | Compile OFF | Compile ON | Δ |
|---|---|---:|---:|---:|---:|
| **E2B** | none | 1024 | 95.6 | 99.0 | **+3.6%** |
| E2B | none | 4096 | 97.0 | 99.1 | +2.1% |
| E2B | turbo4v2 | 1024 | 100.8 | 101.3 | +0.5% |
| E2B | turbo4v2 | 4096 | 97.4 | 98.8 | +1.4% |
| **E4B** | none | 1024 | 66.0 | 67.2 | **+1.8%** |
| E4B | none | 4096 | 63.5 | 63.8 | +0.4% |
| E4B | turbo4v2 | 1024 | 66.3 | 67.0 | +1.0% |
| E4B | turbo4v2 | 4096 | 63.6 | 64.4 | +1.4% |
| **26B-A4B** | none | 1024 | 30.9 | 27.4 | **−11.4%** ⚠️ |
| 26B-A4B | none | 4096 | 28.6 | 26.7 | **−6.6%** ⚠️ |
| 26B-A4B | turbo4v2 | 1024 | 28.4 | 29.0 | +2.2% |
| 26B-A4B | turbo4v2 | 4096 | 28.6 | 28.1 | -1.5% |
| **31B** | none | 1024 | 14.8 | 14.8 | -0.2% |
| 31B | none | 4096 | 14.4 | 14.4 | 0.0% |
| 31B | turbo4v2 | 1024 | 14.8 | 14.8 | +0.2% |
| 31B | turbo4v2 | 4096 | 14.3 | 14.3 | -0.2% |

### Prefill tok/s

Within ±1.5% across all 16 (model × KV × ctx) combinations — no signal. The optimization affects per-call CPU graph-replay cost, which is dwarfed by the compute work in a 1024+ token prefill batch.

### Memory

**Byte-identical across all 16 configs.** Compile-cache adds zero allocation cost.

## Phase 3 attribution (`MLX_METAL_PROFILE=1`)

Per-kernel `os_signpost` traces confirm the optimization is purely CPU-side: **identical Metal dispatch counts** between flag states (884/token E2B, 1088/token E4B, 2298/token 26B-A4B). It's literal graph caching, not kernel fusion.

The 26B-A4B regression on kv=none shows up as elevated **decode-loop CPU time** (sustained ~38 ms/token vs ~33 ms/token without compile), with the same kernel work done on the GPU. Hypothesis: MLX's normal scheduler can interleave kernel launches across separate `callAsFunction` invocations more freely than across a `compile()` boundary, and that interleaving happens to matter for the MoE expert-routing path. Quantized KV (turbo4v2) reduces the interleaving headroom enough that the optimization is wash either way.

## What changed in the PR vs the original

- **Was:** flat `MLX_COMPILE_SHARED_MLP=1` opt-in; off by default everywhere
- **Now:** per-architecture default (on for dense, off for MoE), env var still overrides either direction
- Updated per-arch numbers above replace the original "+10.6% prefill on E2B" claim, which doesn't reproduce on current alpha (the AB Phase 1+2 + signpost-instrumentation work that landed since the PR was written has lifted the dense baseline by ~20%, leaving smaller absolute headroom for the compile-cache to capture)

## Bundled

`KVCache.swift` quantized-attention mask switch updated to handle `.slidingWindow` exhaustively (needed once ekryski/mlx-swift#11 is pulled in and the new case exists in the consumed enum).

## Test plan

- [x] Safety regression: `KVCacheTests` + `SpeculativeDecodingTests` pass with the flag both ON and OFF
- [x] Benchmark with `--ppl`: PPL within noise in both states (1024: 1.4660–1.5505 OFF, 1.4534–1.4802 ON)
- [x] Per-architecture defaults verified against env-var overrides on M1 Max
- [x] Full sweep: 3 models × 2 KV × 2 ctx × 2 flag × 3 runs = 72 baseline runs, plus E4B + 26B + 31B re-run with 72 fresh runs to confirm 26B-A4B regression isn't system noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)