### PR TITLE
feat(evaluate): BatchTokenIterator for parallel decoding of B sequences

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1090,6 +1090,148 @@ public struct TokenIterator: TokenIteratorProtocol {
     }
 }
 
+/// Generator of tokens for B parallel sequences in lockstep.
+///
+/// Unlike ``TokenIterator`` which emits one token per `next()` call,
+/// `BatchTokenIterator` emits a `[Int]` of length B per step — one token per
+/// sequence. All B sequences are prefilled in a single forward pass (one
+/// `[B, L]` matmul), and each decode step processes B tokens in one forward
+/// pass, amortising model compute across the batch.
+///
+/// ## Scope (v1)
+///
+/// - All prompts must have the **same length**. Pad in Swift if necessary.
+/// - Pure-attention models only (Gemma4, GPT-OSS, Nemotron H). GatedDelta /
+///   Mamba hybrids are not in scope for this version because the sequential
+///   SSM recurrence needs per-sequence state isolation.
+/// - ``LogitProcessor`` chain (repetition / frequency / presence penalty) is
+///   not plumbed through. Penalties would need per-sequence state; adding
+///   that is a follow-up. Use greedy / top-p / top-k / categorical sampling
+///   today — these derive purely from current-step logits and work
+///   row-wise on `[B, V]` inputs.
+/// - Single-token step; no speculative / n-gram draft on the batched path.
+///
+/// ## Usage
+///
+/// ```swift
+/// let inputs: [LMInput] = prompts.map { LMInput(tokens: tokenise($0)) }
+/// var iter = try BatchTokenIterator(
+///     inputs: inputs, model: model, parameters: parameters)
+/// for batchTokens in iter {
+///     // batchTokens is [Int] of length B — batchTokens[i] is the token
+///     // just emitted for sequence i.
+/// }
+/// ```
+///
+/// Sequences advance in lockstep: `batchTokens.count == B` on every step.
+/// Callers are responsible for detecting per-sequence EOS and (optionally)
+/// masking completed sequences by ignoring their entries.
+public struct BatchTokenIterator: Sequence, IteratorProtocol {
+    public typealias Element = [Int]
+
+    let model: any LanguageModel
+    var state: LMOutput.State?
+
+    /// Current in-flight batched tokens of shape `[B, 1]` (next step's input).
+    var y: MLXArray
+    /// Pending batched tokens of shape `[B, 1]` sampled during the previous
+    /// step. Drained by `next()` and returned to the caller as `[Int]`.
+    var pending: MLXArray
+    var cache: [KVCache]
+    let sampler: LogitSampler
+    let batchSize: Int
+
+    var tokenCount = 0
+    let maxTokens: Int?
+
+    /// Initialize a `BatchTokenIterator` for B prompts.
+    ///
+    /// - Parameters:
+    ///   - inputs: the B prompts. Must all have the same token length.
+    ///   - model: the ``LanguageModel``
+    ///   - cache: optional ``KVCache`` (must be sized for batch B)
+    ///   - parameters: the generation parameters
+    public init(
+        inputs: [LMInput],
+        model: any LanguageModel,
+        cache: [KVCache]? = nil,
+        parameters: GenerateParameters
+    ) throws {
+        precondition(!inputs.isEmpty, "BatchTokenIterator requires at least one input")
+
+        let tokensList = inputs.map { $0.text.tokens }
+        let firstLen = tokensList[0].dim(0)
+        for (i, t) in tokensList.enumerated() {
+            precondition(
+                t.ndim == 1 && t.dim(0) == firstLen,
+                "BatchTokenIterator v1 requires 1-D prompts of equal length; "
+                    + "input \(i) has shape \(t.shape) vs expected [\(firstLen)]")
+        }
+
+        self.model = model
+        self.batchSize = inputs.count
+        self.cache = cache ?? model.newCache(parameters: parameters)
+        self.sampler = parameters.sampler()
+        self.maxTokens = parameters.maxTokens
+
+        // Stack [L] prompts into [B, L]. For B=1 we could just add a newAxis,
+        // but MLX.stacked([x], axis: 0) produces the same result and keeps
+        // the B=1 path identical to B>1 — worth it for simplicity.
+        let promptsBL = MLX.stacked(tokensList, axis: 0)
+
+        // Prefill — single forward pass across the whole batch.
+        let prefill = model(
+            LMInput.Text(tokens: promptsBL),
+            cache: self.cache,
+            state: nil)
+        self.state = prefill.state
+
+        // Sample first decode token per sequence. Last-position logits over
+        // the batch axis: [B, V] → [B] samples. Apply the logit-slice and
+        // sampler using the same indexing TokenIterator uses, matched to
+        // higher batch dim.
+        let lastLogits = prefill.logits[0..., -1, 0...]  // [B, V]
+        let sampled = sampler.sample(logits: lastLogits)  // [B]
+        // ArgMax / categorical return a 1-D [B] array. Reshape to [B, 1] so
+        // it feeds into the next step as a batched single-token input.
+        let firstTokensBT = sampled.reshaped([inputs.count, 1])
+        asyncEval(firstTokensBT)
+        self.y = firstTokensBT
+        self.pending = firstTokensBT
+    }
+
+    /// One decode step. Consumes `y` (shape `[B, 1]`), runs a forward pass,
+    /// and returns newly-sampled tokens (shape `[B]`).
+    mutating func step() -> MLXArray {
+        let result = model(
+            LMInput.Text(tokens: y),
+            cache: cache.isEmpty ? nil : cache,
+            state: state)
+        self.state = result.state
+        let lastLogits = result.logits[0..., -1, 0...]
+        return sampler.sample(logits: lastLogits)
+    }
+
+    public mutating func next() -> [Int]? {
+        if let maxTokens, tokenCount >= maxTokens {
+            return nil
+        }
+
+        // Return the previously-sampled batch tokens, and prefetch the next
+        // batch asynchronously so the next forward pass starts while the
+        // caller is consuming this step's output.
+        let drained = pending
+        let nextTokens = step()
+        y = nextTokens.expandedDimensions(axis: -1)
+        pending = y
+        asyncEval(y)
+        tokenCount += 1
+
+        // Single GPU→CPU transfer for the whole batch — one sync per step.
+        return drained.squeezed(axis: -1).asArray(Int.self)
+    }
+}
+
 /// Generator of tokens using speculative decoding.
 ///
 /// This is typically used via a call to ``generate(input:cache:parameters:context:draftModel:draftCache:numDraftTokens:wiredMemoryTicket:)``

--- a/Tests/MLXLMTests/BatchTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/BatchTokenIteratorTests.swift
@@ -1,0 +1,139 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import Testing
+
+@Suite(.serialized)
+struct BatchTokenIteratorTests {
+
+    let processor: any UserInputProcessor
+    let context: ModelContext
+
+    init() {
+        let processor = TestInputProcessor()
+        // Tiny Gemma3 text model — no weight loading, fast test cycle.
+        let modelConfig = Gemma3TextConfiguration(
+            modelType: "text",
+            hiddenSize: 64, hiddenLayers: 8, intermediateSize: 64,
+            attentionHeads: 4, headDim: 64,
+            rmsNormEps: 0.00001, vocabularySize: 100, kvHeads: 4,
+            ropeTheta: 1_000_000, ropeLocalBaseFreq: 10_000,
+            ropeTraditional: false, queryPreAttnScalar: 256,
+            slidingWindow: 512, slidingWindowPattern: 6,
+            maxPositionEmbeddings: 32768
+        )
+        let model = Gemma3TextModel(modelConfig)
+        eval(model)
+        self.processor = processor
+        self.context = ModelContext(
+            configuration: processor.configuration,
+            model: model,
+            processor: processor,
+            tokenizer: processor.tokenizer
+        )
+    }
+
+    /// Run `TokenIterator` on a single input — the canonical reference path.
+    private func runSingle(
+        prompt: String, maxTokens: Int
+    ) async throws -> [Int] {
+        let input = try await processor.prepare(
+            input: UserInput(prompt: prompt))
+        let params = GenerateParameters(
+            maxTokens: maxTokens,
+            temperature: 0.0  // argmax — deterministic
+        )
+        var iter = try TokenIterator(
+            input: input,
+            model: context.model,
+            parameters: params
+        )
+        var tokens: [Int] = []
+        while let t = iter.next() {
+            tokens.append(t)
+        }
+        return tokens
+    }
+
+    /// Run `BatchTokenIterator` with B parallel prompts.
+    private func runBatch(
+        prompts: [String], maxTokens: Int
+    ) async throws -> [[Int]] {
+        var inputs: [LMInput] = []
+        for p in prompts {
+            inputs.append(try await processor.prepare(input: UserInput(prompt: p)))
+        }
+        let params = GenerateParameters(
+            maxTokens: maxTokens,
+            temperature: 0.0
+        )
+        var iter = try BatchTokenIterator(
+            inputs: inputs,
+            model: context.model,
+            parameters: params
+        )
+        var streams: [[Int]] = Array(repeating: [], count: prompts.count)
+        while let step = iter.next() {
+            #expect(step.count == prompts.count)
+            for (i, tok) in step.enumerated() {
+                streams[i].append(tok)
+            }
+        }
+        return streams
+    }
+
+    @Test
+    func `B=4 forward pass: identical rows produce identical logits`() async throws {
+        // Direct sanity check: if the underlying model doesn't produce
+        // bit-identical output for identical batched rows, batch decode
+        // cannot work regardless of iterator correctness.
+        let tokens = MLXArray([Int32](1 ... 8))  // [8]
+        let batched = MLX.stacked(Array(repeating: tokens, count: 4), axis: 0)  // [4, 8]
+
+        let cache = context.model.newCache(parameters: GenerateParameters())
+        let output = context.model(LMInput.Text(tokens: batched), cache: cache, state: nil)
+        let logits = output.logits  // [4, 8, V]
+        eval(logits)
+
+        // Compare row 0 to row 1/2/3 for position 0 (last position is the
+        // sampling site, but all positions should be identical row-wise).
+        let row0 = logits[0].asArray(Float.self)
+        for r in 1 ..< 4 {
+            let rowR = logits[r].asArray(Float.self)
+            let maxDiff = zip(row0, rowR).map { abs($0 - $1) }.max() ?? 0
+            #expect(
+                maxDiff < 1e-4,
+                Comment(
+                    rawValue:
+                        "Row \(r) logits diverge from row 0 by \(maxDiff) — model may not be batch-safe"
+                ))
+        }
+    }
+
+    @Test
+    func `B=1 degenerates to TokenIterator`() async throws {
+        let prompt = "Hello world"
+        let reference = try await runSingle(prompt: prompt, maxTokens: 16)
+        let batched = try await runBatch(prompts: [prompt], maxTokens: 16)
+        #expect(batched.count == 1)
+        // Verify length parity — bit-exact match under temperature=0 with a
+        // tiny random-weight model is unreliable (argmax ties flip on tiny
+        // numerical differences between kernel paths). A real-model bench
+        // with `--ppl` is the right acceptance test for this property.
+        #expect(batched[0].count == reference.count)
+    }
+
+    @Test
+    func `B=4 returns the correct count per step`() async throws {
+        let prompt = "Same prompt"
+        let batched = try await runBatch(
+            prompts: Array(repeating: prompt, count: 4), maxTokens: 16)
+        #expect(batched.count == 4)
+        for (i, stream) in batched.enumerated() {
+            #expect(stream.count == 16, "Stream \(i) emitted \(stream.count) tokens")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds \`BatchTokenIterator\` for running B prompts through one model in lockstep. Emits \`[Int]\` of length B per step, amortising model compute across the batch via \`[B, L]\` input tensors.

## Usage

\`\`\`swift
let inputs: [LMInput] = prompts.map { LMInput(tokens: tokenise(\$0)) }
var iter = try BatchTokenIterator(
    inputs: inputs, model: model, parameters: parameters)
for batchTokens in iter {
    // batchTokens is [Int] of length B — batchTokens[i] is the token
    // just emitted for sequence i.
}
\`\`\`

## Scope (v1)

- Same-length prompts only (pad in Swift if needed).
- Pure-attention models (Gemma4, GPT-OSS, Nemotron H). GatedDelta / Mamba hybrids (Qwen3.5) are follow-up — their sequential SSM state needs per-sequence isolation.
- No LogitProcessor penalty chain yet — repetition/frequency/presence penalties need per-sequence state. Greedy / top-p / top-k / categorical samplers work on \`[B, V]\` and are supported.
- No speculative / n-gram draft on the batched path.

## Implementation

The cache and sampler machinery were already batch-shape-correct. Main additions:
1. Stacking \`[LMInput]\` into \`[B, L]\` at init.
2. Per-step \`[B] → [Int]\` drain to the caller.

Matches \`TokenIterator\`'s \`asyncEval\` pattern so the next forward pass kicks off while the caller drains this step.

## Test plan

New \`BatchTokenIteratorTests\`:

- **B=4 forward pass: identical rows produce identical logits** — pins the model's batch-safety at 1e-4. The critical correctness invariant.
- **B=1 degeneracy** — iterator emits the correct shape.
- **B=4 returns correct count per step** — every step emits exactly B tokens.

Bit-exact token equality vs \`TokenIterator\` is deliberately not tested — argmax at tiny random-weight scale flips on sub-1e-4 kernel-path differences. Real-model \`--ppl\` / correctness validation is the right acceptance gate for production parity.

Existing safety suite (\`KVCacheTests\`, \`SpeculativeDecodingTests\`, \`Gemma3nOffsetTests\`, \`MaskedScatterTests\`) continues to pass.

## Follow-up

- Per-sequence penalty processor state.
- Variable-length prompt support (per-sequence cache offsets).
- Hybrid Mamba/GatedDelta support.
- Real-model benchmarks: \`benchmark.sh --batch 2,4\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)