### PR TITLE
perf(moe): FusedGateUpSwitchGLU fixes — Gemma 4 26B A4B prefill +2.28x, GPT-OSS-20B decode +45%

### DIFF
--- a/Libraries/MLXLLM/Models/GPTOSS.swift
+++ b/Libraries/MLXLLM/Models/GPTOSS.swift
@@ -99,62 +99,6 @@ private let compiledSwiglu: @Sendable (MLXArray, MLXArray) -> MLXArray = compile
     swiglu(xLinear, xGlu)
 }
 
-class SwiGLUSwitchGLU: Module {
-    @ModuleInfo(key: "gate_proj") var gateProj: SwitchLinear
-    @ModuleInfo(key: "up_proj") var upProj: SwitchLinear
-    @ModuleInfo(key: "down_proj") var downProj: SwitchLinear
-
-    let inputDims: Int
-    let hiddenDims: Int
-    let numExperts: Int
-
-    init(
-        inputDims: Int,
-        hiddenDims: Int,
-        numExperts: Int,
-        bias: Bool = false
-    ) {
-        self.inputDims = inputDims
-        self.hiddenDims = hiddenDims
-        self.numExperts = numExperts
-
-        _gateProj.wrappedValue = SwitchLinear(
-            inputDims: inputDims, outputDims: hiddenDims, numExperts: numExperts, bias: bias)
-        _upProj.wrappedValue = SwitchLinear(
-            inputDims: inputDims, outputDims: hiddenDims, numExperts: numExperts, bias: bias)
-        _downProj.wrappedValue = SwitchLinear(
-            inputDims: hiddenDims, outputDims: inputDims, numExperts: numExperts, bias: bias)
-
-        super.init()
-    }
-
-    func callAsFunction(_ x: MLXArray, _ indices: MLXArray) -> MLXArray {
-        var x = MLX.expandedDimensions(x, axes: [-2, -3])
-
-        let doSort = indices.size >= 64
-
-        var idx = indices
-        var inverseOrder = MLXArray()
-
-        if doSort {
-            (x, idx, inverseOrder) = gatherSort(x: x, indices: indices)
-        }
-
-        let xUp = upProj(x, idx, sortedIndices: doSort)
-        let xGate = gateProj(x, idx, sortedIndices: doSort)
-        x = downProj(
-            compiledSwiglu(xUp, xGate),
-            idx,
-            sortedIndices: doSort)
-
-        if doSort {
-            x = scatterUnsort(x: x, invOrder: inverseOrder, shape: indices.shape)
-        }
-
-        return x.squeezed(axis: -2)
-    }
-}
-
 class AttentionBlock: Module {
     let headDim: Int
     let numAttentionHeads: Int
@@ -269,7 +213,7 @@ class MLPBlock: Module {
     let numLocalExperts: Int
     let numExpertsPerTok: Int
 
-    @ModuleInfo(key: "experts") var experts: SwiGLUSwitchGLU
+    @ModuleInfo(key: "experts") var experts: FusedGateUpSwitchGLU
     @ModuleInfo(key: "router") var router: Linear
 
     public init(_ config: GPTOSSConfiguration) {
@@ -277,10 +221,11 @@ class MLPBlock: Module {
         self.numLocalExperts = config.localExperts
         self.numExpertsPerTok = config.expertsPerToken
 
-        _experts.wrappedValue = SwiGLUSwitchGLU(
+        _experts.wrappedValue = FusedGateUpSwitchGLU(
             inputDims: config.hiddenSize,
             hiddenDims: config.intermediateSize,
             numExperts: config.localExperts,
+            twoArgActivation: compiledSwiglu,
             bias: true
         )
         _router.wrappedValue = Linear(config.hiddenSize, config.localExperts, bias: true)
@@ -464,10 +409,13 @@ public class GPTOSSModel: Module, LLMModel, KVCacheDimensionProvider {
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
         var weights = weights
 
-        if weights.keys.contains(where: { $0.contains("gate_proj.weight") }) {
-            return weights
+        // Already-quantized repos ship separate gate_proj / up_proj tensors.
+        // Fuse them into the single gate_up_proj that FusedGateUpSwitchGLU expects.
+        if weights.keys.contains(where: { $0.contains(".experts.gate_proj.weight") }) {
+            return fuseGateUpWeights(weights)
         }
 
+        // Packed (blocks + scales) format — unpack to raw tensors first.
         if weights.keys.contains(where: { $0.contains("gate_up_proj_scales") }) {
             var newWeights: [String: MLXArray] = [:]
             for (k, v) in weights {
@@ -487,26 +435,28 @@ public class GPTOSSModel: Module, LLMModel, KVCacheDimensionProvider {
             weights = newWeights
         }
 
+        // De-interleave the shipped `gate_up_proj` (stride-2 interleaved gate/up)
+        // into a concatenated [gate; up] layout along the output axis, matching
+        // what `MLX.split(gateUp, parts: 2, axis: -1)` expects in
+        // FusedGateUpSwitchGLU.
         var finalWeights: [String: MLXArray] = [:]
         for (k, v) in weights {
             if k.contains("gate_up_proj"), !k.contains("bias") {
+                let gate = v[.ellipsis, .stride(by: 2), 0...]
+                let up = v[.ellipsis, .stride(from: 1, by: 2), 0...]
                 finalWeights[
-                    k.replacingOccurrences(of: "gate_up_proj", with: "gate_proj.weight")
-                ] = contiguous(v[.ellipsis, .stride(by: 2), 0...])
-                finalWeights[
-                    k.replacingOccurrences(of: "gate_up_proj", with: "up_proj.weight")
-                ] = contiguous(v[.ellipsis, .stride(from: 1, by: 2), 0...])
+                    k.replacingOccurrences(of: "gate_up_proj", with: "gate_up_proj.weight")
+                ] = contiguous(concatenated([gate, up], axis: -2))
             } else if k.contains("down_proj"), !k.contains("bias") {
                 finalWeights[
                     k.replacingOccurrences(of: "down_proj", with: "down_proj.weight")
                 ] = contiguous(v)
             } else if k.contains("gate_up_proj_bias") {
+                let gateBias = v[.ellipsis, .stride(by: 2)]
+                let upBias = v[.ellipsis, .stride(from: 1, by: 2)]
                 finalWeights[
-                    k.replacingOccurrences(of: "gate_up_proj_bias", with: "gate_proj.bias")
-                ] = contiguous(v[.ellipsis, .stride(by: 2)])
-                finalWeights[
-                    k.replacingOccurrences(of: "gate_up_proj_bias", with: "up_proj.bias")
-                ] = contiguous(v[.ellipsis, .stride(from: 1, by: 2)])
+                    k.replacingOccurrences(of: "gate_up_proj_bias", with: "gate_up_proj.bias")
+                ] = contiguous(concatenated([gateBias, upBias], axis: -1))
             } else if k.contains("down_proj_bias") {
                 finalWeights[
                     k.replacingOccurrences(of: "down_proj_bias", with: "down_proj.bias")
@@ -517,6 +467,43 @@ public class GPTOSSModel: Module, LLMModel, KVCacheDimensionProvider {
         }
 
         return finalWeights
+    }
+
+    /// Fuse pre-quantized checkpoints' separate `.experts.gate_proj.*` and
+    /// `.experts.up_proj.*` tensors into a single `.experts.gate_up_proj.*` set
+    /// (weight, scales, biases) on the output axis. Called when the checkpoint
+    /// already has `gate_proj.weight` keys — i.e. skipped the interleaved
+    /// `gate_up_proj` packing path above.
+    private func fuseGateUpWeights(_ weights: [String: MLXArray]) -> [String: MLXArray] {
+        var result: [String: MLXArray] = [:]
+        var gateTensors: [String: MLXArray] = [:]
+        var upTensors: [String: MLXArray] = [:]
+
+        for (k, v) in weights {
+            if k.contains(".experts.gate_proj.") {
+                gateTensors[k] = v
+            } else if k.contains(".experts.up_proj.") {
+                upTensors[k] = v
+            } else {
+                result[k] = v
+            }
+        }
+
+        for (gateKey, gateVal) in gateTensors {
+            let upKey = gateKey.replacingOccurrences(of: "gate_proj", with: "up_proj")
+            guard let upVal = upTensors[upKey] else {
+                // Unpaired gate tensor — leave as-is rather than silently drop.
+                result[gateKey] = gateVal
+                continue
+            }
+            let fusedKey = gateKey.replacingOccurrences(of: "gate_proj", with: "gate_up_proj")
+            // weight: [E, outDim, packedIn] → [E, 2*outDim, packedIn]
+            // scales/biases: [E, outDim, groups] → [E, 2*outDim, groups]
+            // bias: [E, outDim] → [E, 2*outDim]
+            result[fusedKey] = concatenated([gateVal, upVal], axis: 1)
+        }
+
+        return result
     }
 
     /// Pure attention model — use larger prefill chunks (2048+) since there's no

--- a/Libraries/MLXLMCommon/SwitchLayers.swift
+++ b/Libraries/MLXLMCommon/SwitchLayers.swift
@@ -37,6 +37,14 @@ public class SwitchGLU: Module {
     let numExperts: Int
     let activation: (MLXArray) -> MLXArray
 
+    /// Min `indices.size` at which to reorder tokens by expert id before
+    /// `gatherQuantizedMM`. Above the threshold the contiguous-per-expert
+    /// fast path wins; below it the sort/unsort is pure overhead. 128 keeps
+    /// prefill on the fast path for every realistic prompt length (topK × T
+    /// is well above 128 by a few tokens in) while avoiding the 25% overhead
+    /// measured on very short prompts at threshold=64.
+    static let sortThreshold = 128
+
     public init(
         inputDims: Int,
         hiddenDims: Int,
@@ -62,7 +70,7 @@ public class SwitchGLU: Module {
     public func callAsFunction(_ x: MLXArray, _ indices: MLXArray) -> MLXArray {
         var x = MLX.expandedDimensions(x, axes: [-2, -3])
 
-        let doSort = indices.size >= 64
+        let doSort = indices.size >= Self.sortThreshold
 
         var idx = indices
         var inverseOrder = MLXArray()
@@ -88,13 +96,15 @@ public class SwitchGLU: Module {
 
 // MARK: - FusedGateUpSwitchGLU
 
-/// SwitchGLU variant with fused gate_up_proj weight — used by Gemma 4 MoE (26B) and
-/// GPT-OSS. Models ship with a single `gate_up_proj` weight of shape
-/// `[numExperts, 2*hiddenDims, inputDims]` instead of separate `gate_proj`/`up_proj`.
+/// SwitchGLU variant with a fused `gate_up_proj` weight — currently used by
+/// Gemma 4 MoE (26B A4B). Models ship with a single `gate_up_proj` weight of
+/// shape `[numExperts, 2*hiddenDims, inputDims]` instead of separate
+/// `gate_proj` / `up_proj`; a single `gatherQuantizedMM` produces both halves.
 ///
 /// Supports two activation modes:
 /// - Single-argument (default): `activation(gate) * up` — silu-gated models
-/// - Two-argument: `twoArgActivation(up, gate)` — GPT-OSS's clipped swiglu
+/// - Two-argument: `twoArgActivation(up, gate)` — for asymmetric activations
+///   (e.g. clipped swiglu variants)
 public class FusedGateUpSwitchGLU: Module {
     @ModuleInfo(key: "gate_up_proj") var gateUpProj: SwitchLinear
     @ModuleInfo(key: "down_proj") var downProj: SwitchLinear
@@ -130,8 +140,20 @@ public class FusedGateUpSwitchGLU: Module {
     public func callAsFunction(_ x: MLXArray, _ indices: MLXArray) -> MLXArray {
         var x = MLX.expandedDimensions(x, axes: [-2, -3])
 
+        // At prefill reorder tokens by expert id so each expert's rows are
+        // contiguous. Gives gatherQuantizedMM the contiguous-per-expert fast
+        // path. Matches SwitchGLU above; shares its threshold.
+        let doSort = indices.size >= SwitchGLU.sortThreshold
+
+        var idx = indices
+        var inverseOrder = MLXArray()
+
+        if doSort {
+            (x, idx, inverseOrder) = gatherSort(x: x, indices: indices)
+        }
+
         // Single gatherQuantizedMM for both gate and up projections
-        let gateUp = gateUpProj(x, indices)
+        let gateUp = gateUpProj(x, idx, sortedIndices: doSort)
 
         let activated: MLXArray
         if let twoArgActivation {
@@ -142,7 +164,12 @@ public class FusedGateUpSwitchGLU: Module {
             activated = activation(parts[0]) * parts[1]
         }
 
-        x = downProj(activated, indices)
+        x = downProj(activated, idx, sortedIndices: doSort)
+
+        if doSort {
+            x = scatterUnsort(x: x, invOrder: inverseOrder, shape: indices.shape)
+        }
+
         return MLX.squeezed(x, axis: -2)
     }
 }


### PR DESCRIPTION
Two related perf fixes in the `FusedGateUpSwitchGLU` path.

## Commit 1: restore gather-sort in `FusedGateUpSwitchGLU`

- `callAsFunction` was calling `gateUpProj` / `downProj` without reordering tokens by expert id, so `gatherQuantizedMM`'s contiguous-per-expert fast path never fired during prefill. Sibling `SwitchGLU` already does the `gatherSort` / `sortedIndices: true` / `scatterUnsort` wrap
- Lifts the threshold into a shared `SwitchGLU.sortThreshold = 128` constant. 128 keeps every realistic prompt on the fast path (`topK * T ≫ 128` after the first few tokens) while avoiding ~25% overhead on very short prompts
- Decode is unaffected — `indices.size = topK = 8` stays below the threshold

**Measured** (M1 Max 64GB, `gemma-4-26b-a4b-it-4bit`, no-quant KV, summarization):

| Ctx  | Prompt | pre-fix | **post-fix** | Δ          |
|-----:|-------:|--------:|-------------:|-----------:|
|  128 |    114 |       — |    **289.0** |          — |
| 1024 |   1012 |   242.7 |    **552.5** | **+2.28×** |
| 4096 |   4092 |       — |    **564.7** |          — |

## Commit 2: switch GPT-OSS MoE to `FusedGateUpSwitchGLU`

- Replaces `SwiGLUSwitchGLU` (2 separate `gatherQuantizedMM` per layer for gate + up) with `FusedGateUpSwitchGLU` using `twoArgActivation: compiledSwiglu` (1 fused dispatch + split). Saves ~24 Metal encoder submits per decode token across 24 layers × 1 dispatch × topK=4 experts
- `sanitize()` now de-interleaves the shipped stride-2 `gate_up_proj` tensors into concatenated `[gate; up]` on the output axis (matches `MLX.split(gateUp, parts: 2, axis: -1)`)
- New `fuseGateUpWeights` helper covers pre-quantized repos that ship separate `gate_proj` / `up_proj` — concat on `axis: 1` handles weight, scales, biases uniformly
- Drops the now-unused `SwiGLUSwitchGLU` class

**Measured** (M1 Max 64GB, GPT-OSS-20B 4bit, summarization):

| Ctx  | kv       | pre-fix | **post-fix** | tom 04-15 | vs pre |
|-----:|:---------|--------:|-------------:|----------:|-------:|
|  128 | no-quant |    48.9 |     **71.9** |      57.7 | **+47%** |
| 1024 | no-quant |    48.8 |     **69.4** |      53.1 | **+42%** |
| 4096 | no-quant |    48.5 |         49.1 |      52.1 |    +1% |
|  128 | turbo4v2 |    49.8 |         51.5 |      59.8 |    +3% |
| 1024 | turbo4v2 |    47.8 |         51.4 |      57.5 |    +8% |

At ctx=128 / 1024 no-quant the new numbers **beat `ek/tom-eric-moe-tuning`**. Output remains coherent (harmony `<|channel|>analysis<|message|>…` format verified).

## Remaining gap for turbo4v2

Turbo quantization isn't currently engaging for GPT-OSS on alpha — the cache stays as `RotatingKVCache` because `maybeQuantizeKVCache` only handles `kvBits` (not `kvScheme`) and has no `RotatingKVCache` branch (`TODO` at `KVCache.swift:1803`), and there's no `kvScheme`-driven wrapping path yet. So `kv=turbo4v2` currently runs essentially the same attention path as `kv=none`; the observed delta is partly noise and partly an unrelated overhead we should chase separately.

## Test plan

- [x] Gemma 4 26B A4B summarization at ctx=128/1024/4096 produces coherent output (Gatsby summary)
- [x] GPT-OSS-20B at ctx=128/1024 no-quant: +42–47% decode, coherent harmony output
- [x] Qwen3.5-35B-A3B unaffected (doesn't use either class): 238–491 tok/s prefill, 56–59 tok/s decode
- [x] Qwen3.5-4B unaffected (dense, not MoE): 77 tok/s decode
- [x] Gemma 4 E2B unaffected (dense): 2855 tok/s prefill, 95 tok/s decode
- [ ] M5 Max rerun for Gemma 4 26B A4B + GPT-OSS-20B
- [ ] GPT-OSS-20B 8bit quant smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)