### PR TITLE
perf(gpt-oss): clipped-swiglu C kernel — default-on (+37-45% decode)

### DIFF
--- a/Libraries/MLXLLM/Models/GPTOSS.swift
+++ b/Libraries/MLXLLM/Models/GPTOSS.swift
@@ -226,6 +226,7 @@ class MLPBlock: Module {
             hiddenDims: config.intermediateSize,
             numExperts: config.localExperts,
             twoArgActivation: compiledSwiglu,
+            activationKind: .clippedSwiglu,
             bias: true
         )
         _router.wrappedValue = Linear(config.hiddenSize, config.localExperts, bias: true)

--- a/Libraries/MLXLMCommon/FusedDenseActivation.swift
+++ b/Libraries/MLXLMCommon/FusedDenseActivation.swift
@@ -1,0 +1,59 @@
+import Foundation
+import MLX
+
+// MARK: - FusedDenseGateActivation
+//
+// Thin wrapper around the precompiled `MLXFast.fusedGateActivation`
+// Metal kernel (added upstream in mlx / mlx-c / mlx-swift on
+// `feat/fused-gate-activation-gpt-oss`). Takes a fused `gateUp` tensor of
+// shape `[..., 2*hiddenDims]` and produces `activation(gate) * up` of
+// shape `[..., hiddenDims]` in a single Metal dispatch.
+//
+// The only production caller today is `FusedGateUpSwitchGLU` for GPT-OSS's
+// clipped-swiglu activation, where the C kernel replaces a compiled-closure
+// two-arg fallback and yields +37–45% decode across contexts. Dense-MLP
+// callers are deliberately not wired — the benchmark data showed no
+// consistent win on Generation tok/s for silu / gelu_approx variants.
+// See `benchmarks/notes/fused-kernel-findings-2026-04-24.md`.
+
+/// Activation variants supported by the inline fused-gate kernel.
+public enum DenseActivationKind: Hashable, Sendable {
+    case silu
+    case geluApprox
+    /// GPT-OSS clipped swiglu: `clamp(-7,7)`, `sigmoid(1.702·g)`, `·(u+1)`.
+    case clippedSwiglu
+
+    fileprivate var fastVariant: MLXFast.DenseGateActivation {
+        switch self {
+        case .silu: return .silu
+        case .geluApprox: return .geluApprox
+        case .clippedSwiglu: return .clippedSwiglu
+        }
+    }
+}
+
+/// True when the inline kernel's fast-path preconditions are met.
+@inline(__always)
+public func canUseInlineDenseActivation(
+    gateUp: MLXArray,
+    hiddenDims: Int
+) -> Bool {
+    // Decode-only — prefill's GEMM path is already dispatch-efficient.
+    guard gateUp.dim(-2) == 1 else { return false }
+    switch gateUp.dtype {
+    case .bfloat16, .float16: break
+    default: return false
+    }
+    guard gateUp.dim(-1) == 2 * hiddenDims else { return false }
+    return true
+}
+
+/// Run the inline fused `activation(gate) * up` kernel.
+public func fusedDenseGateActivation(
+    _ gateUp: MLXArray,
+    hiddenDims: Int,
+    kind: DenseActivationKind
+) -> MLXArray {
+    MLXFast.fusedGateActivation(
+        gateUp, hiddenDims: hiddenDims, activation: kind.fastVariant)
+}

--- a/Libraries/MLXLMCommon/SwitchLayers.swift
+++ b/Libraries/MLXLMCommon/SwitchLayers.swift
@@ -115,12 +115,21 @@ public class FusedGateUpSwitchGLU: Module {
     let activation: (MLXArray) -> MLXArray
     let twoArgActivation: ((MLXArray, MLXArray) -> MLXArray)?
 
+    /// Optional hint to use the precompiled `MLXFast.fusedGateActivation`
+    /// kernel in place of the `activation` / `twoArgActivation` closure.
+    /// Only `.clippedSwiglu` ships default-on (the GPT-OSS case where the
+    /// kernel replaces a compiled-closure two-arg fallback with a clean
+    /// +37–45% decode win). `.silu` / `.geluApprox` are accepted for
+    /// future use but do not currently flip behavior.
+    public let activationKind: DenseActivationKind?
+
     public init(
         inputDims: Int,
         hiddenDims: Int,
         numExperts: Int,
         activation: @escaping (MLXArray) -> MLXArray = MLXNN.silu,
         twoArgActivation: ((MLXArray, MLXArray) -> MLXArray)? = nil,
+        activationKind: DenseActivationKind? = nil,
         bias: Bool = false
     ) {
         self.inputDims = inputDims
@@ -128,6 +137,7 @@ public class FusedGateUpSwitchGLU: Module {
         self.numExperts = numExperts
         self.activation = activation
         self.twoArgActivation = twoArgActivation
+        self.activationKind = activationKind
 
         self._gateUpProj.wrappedValue = SwitchLinear(
             inputDims: inputDims, outputDims: 2 * hiddenDims, numExperts: numExperts, bias: bias)
@@ -156,7 +166,16 @@ public class FusedGateUpSwitchGLU: Module {
         let gateUp = gateUpProj(x, idx, sortedIndices: doSort)
 
         let activated: MLXArray
-        if let twoArgActivation {
+        // Clipped-swiglu C kernel: always on when `activationKind` requests
+        // it — replaces GPT-OSS's compiled-closure two-arg path with one
+        // Metal dispatch. Preconditions (dtype, last-axis shape, T=1)
+        // gate the kernel; we still fall back otherwise.
+        if activationKind == .clippedSwiglu,
+            canUseInlineDenseActivation(gateUp: gateUp, hiddenDims: hiddenDims)
+        {
+            activated = fusedDenseGateActivation(
+                gateUp, hiddenDims: hiddenDims, kind: .clippedSwiglu)
+        } else if let twoArgActivation {
             let parts = MLX.split(gateUp, parts: 2, axis: -1)
             activated = twoArgActivation(parts[1], parts[0])
         } else {


### PR DESCRIPTION
## Summary

Wires GPT-OSS 20B's MoE experts to the new precompiled \`fast::fused_gate_activation\` Metal kernel (activation_type=2, clipped swiglu). Default-on, no env flag required.

PR chain: [ekryski/mlx#15](https://github.com/ekryski/mlx/pull/15) → [ekryski/mlx-c#7](https://github.com/ekryski/mlx-c/pull/7) → [ekryski/mlx-swift#16](https://github.com/ekryski/mlx-swift/pull/16) → **this PR**.

### Performance

| ctx | Fused tok/s | Alpha tok/s | Δ |
|---:|---:|---:|---:|
| 1024 | **71.5** | 49.3 | **+45.0%** |
| 4096 | **64.9** | 47.1 | **+37.8%** |
| 8192 | **64.0** | 45.8 | **+39.7%** |

Model: GPT-OSS 20B, 4-bit, \`--kv none\`, summarization method.

- **Memory**: essentially unchanged (+0.01 GB or less at peak).
- **Coherence**: PPL values in healthy ranges (2.4–3.6); fused-vs-alpha PPL deltas are within sampling variance (the benchmark uses temperature=0.6; each run produces a different generation and therefore a different measured PPL).
- **KLD vs bf16**: 0.456 (fused) vs 0.486 (alpha) — both measure the same 4-bit quantization cost; fused is marginally closer to bf16 than the compiled-closure path, so the kernel introduces no extra numerical drift.

### What the kernel does

Replaces the compiled-closure fallback inside \`FusedGateUpSwitchGLU\`'s two-arg activation path:

\`\`\`swift
// Before (compiled closure): split, clamp both halves, sigmoid(1.702·g)·(u+1)
let parts = MLX.split(gateUp, parts: 2, axis: -1)
activated = compiledSwiglu(parts[1], parts[0])

// After (C kernel): single Metal dispatch doing all of it
activated = fusedDenseGateActivation(gateUp, hiddenDims: hiddenDims, kind: .clippedSwiglu)
\`\`\`

The fallback remains wired — the kernel fires only when decode-shape preconditions (\`T=1\`, fp16/bf16, \`last-axis == 2·hidden\`) hold, so prefill and non-standard inputs still use the closure path.

## Scope reduction

Replaces the earlier [#70](https://github.com/ekryski/mlx-swift-lm/pull/70) (closed). Dropped from that PR:

- **Spec 003** (batched QKV projection) — flat-to-negative on \`Generation tok/s\` across dense models.
- **Spec 004** (pre-FFN RMSNorm fusion on dense MLPs) — regressed Gemma 4 E4B / Qwen3.5 4B because \`rms_norm_qgemv\` is dispatch-bound at large N. Partial fix (large-N threshold) shipped in that branch but stack effect still net-negative on user-facing Generation tok/s.
- **\`gather_rms_norm_qgemv\`** MoE fusion — infrastructure landed upstream but call-site parked; \`fast.cpp\` output-shape derivation needs more work.
- **Qwen3.5 35B A3B SwitchGLU → FusedGateUpSwitchGLU conversion** — correctness OK, speed roughly neutral, not worth the algorithmic change on its own.
- **Gemma 4 MoE \`.geluApprox\` activationKind** — flat-to-slight-regression on 26B A4B.
- **Dense-MLP wiring for \`.silu\` / \`.geluApprox\`** — steady-state wins but warmup cost dragged \`Generation tok/s\` down on all 400-token benchmarks.

The full-featured branch \`feat/dense-mlp-inline-activation\` remains in this repo for reference.

## Files

- \`Libraries/MLXLMCommon/FusedDenseActivation.swift\` (new): \`DenseActivationKind\` enum, \`canUseInlineDenseActivation\` preconditions, \`fusedDenseGateActivation\` wrapper
- \`Libraries/MLXLMCommon/SwitchLayers.swift\`: \`FusedGateUpSwitchGLU.activationKind\` field + clipped-swiglu always-on dispatch
- \`Libraries/MLXLLM/Models/GPTOSS.swift\`: \`activationKind: .clippedSwiglu\` on the experts init

## Test plan

- [x] GPT-OSS 20B: coherent output, +37-45% decode at 1k/4k/8k ctx.
- [x] All other 7 target models (Qwen3.5 0.8B/2B/4B/35B-A3B, Gemma 4 E2B/E4B/26B-A4B): unchanged from alpha (the activationKind field is opt-in and only GPT-OSS sets it).
- [x] Peak GPU memory: unchanged or slightly lower on GPT-OSS.
- [x] \`MLX_BENCH_KLD=1\` equivalence vs bf16 baseline: 0.456 fused vs 0.486 alpha — no numerical drift from the kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)