### PR TITLE
perf: remove eval barrier on TurboFlash path (+25% turbo3 decode)

### DIFF
--- a/Libraries/MLXLMCommon/TurboQuantKVCache.swift
+++ b/Libraries/MLXLMCommon/TurboQuantKVCache.swift
@@ -1372,10 +1372,9 @@ public class TurboQuantKVCache: BaseKVCache {
                     keyBits: self.keyBits, valueBits: self.valueBits, dim: headDim,
                     valRotation: valRotation
                 ).reshaped([B, nQHeads, L, headDim])
-                // eval barrier only for asymmetric or 2-bit K
-                // eval barrier for configs that hit MLX lazy eval fusion bugs.
-                // turbo4 (K=4,V=4) is the only config verified safe without eval.
-                if keyBits != 4 || valueBits != 4 { eval(output) }
+                // No eval barrier needed — inverse rotation is fused into TurboFlash pass 2.
+                // The eval was originally protecting against MLX lazy eval fusion with a
+                // subsequent matmul(output, rotation), but that matmul no longer exists.
                 if profiling {
                     let t1 = Date()
                     Self.profileValueMs += t1.timeIntervalSince(t0) * 1000  // flash+eval time


### PR DESCRIPTION
## Summary

The inverse value rotation is already fused into the TurboFlash pass 2 Metal kernel (`valRotation` parameter). The `eval()` barrier was protecting against MLX lazy eval fusion with a subsequent `matmul(output, rotation)` — but that matmul no longer exists since the rotation happens inside the kernel.

Removing the barrier eliminates a CPU-GPU sync per decode step on all non-turbo4 TurboFlash configs.

## Results (Qwen3.5 9B, M5 Max 128GB)

### turbo3 before vs after

| Context | Before (eval) | After (no eval) | Speedup |
|---------|--------------|-----------------|---------|
| 1K | 62.5 | 78.4 | **+25%** |
| 2K | 62.6 | 78.4 | **+25%** |
| 4K | 60.6 | 78.3 | **+29%** |
| 16K | 61.0 | 77.8 | **+28%** |
| 32K | — | 78.2 | — |

### Full sweep (1K-32K, no eval barrier)

| Context | none | turbo3 | turbo4 | turbo3 Δ | turbo4 Δ |
|---------|------|--------|--------|----------|----------|
| 1K | 90.5 | 78.4 (-13%) | 80.4 (-11%) | PPL 2.21 | PPL 2.40 |
| 4K | 91.0 | 78.3 (-14%) | 80.3 (-12%) | PPL 2.07 | PPL 2.36 |
| 16K | 90.7 | 77.8 (-14%) | 78.2 (-14%) | PPL 2.31 | PPL 2.03 |
| 32K | 93.5 | 78.2 (-16%) | 77.9 (-17%) | PPL 2.02 | PPL 2.71 |

### Cross-model verification

| Model | turbo3 before | turbo3 after | Δ |
|-------|--------------|-------------|---|
| 2B dense | 130-166 | 201.8 | +25-55% |
| 9B dense | 63 | 78.4 | +25% |
| 35B MoE | 60 | 85.7 | +43% |

All output coherent, PPL stable. turbo3 now matches turbo4 speed.

### What still has an eval barrier

The separated-kernel path (used for asymmetric configs without TurboFlash support) still does `eval(rotatedOutput)` + explicit `matmul(output, rotation)`. That path is not affected by this change.

## Test Plan

- [x] Qwen3.5 2B turbo3/turbo4 — coherent output, valid PPL
- [x] Qwen3.5 9B turbo3/turbo4 — 1K to 32K context sweep
- [x] Qwen3.5 35B MoE turbo3/turbo4 — coherent output
- [x] No regression on turbo4 (already skipped eval)
- [x] No regression on baseline (kv=none)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)