### PR TITLE
refactor: per-model prefillStepSize defaults via protocol property

### DIFF
--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -23,7 +23,11 @@ extension LLMModel {
     public func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws
         -> PrepareResult
     {
-        let prefillStepSize = windowSize ?? 512
+        // The iterator resolves windowSize via the model's
+        // `defaultPrefillStepSize` before calling here, so this is always
+        // a concrete value in practice. The `??` keeps the signature
+        // tolerant of direct callers that bypass the iterator.
+        let prefillStepSize = windowSize ?? defaultPrefillStepSize
         var y = input.text
 
         // Prepare the prompt in chunks, leaving exactly 1 token for the iterator.

--- a/Libraries/MLXLLM/Models/GPTOSS.swift
+++ b/Libraries/MLXLLM/Models/GPTOSS.swift
@@ -12,6 +12,16 @@ import MLX
 import MLXLMCommon
 import MLXNN
 
+// MARK: - Tunables
+// Audited optima on M1 Max (4-bit, summarization). See issue #80 for the
+// full sweep.
+private enum GPTOSSDefaults {
+    /// GPT-OSS-20B prefill chunk size. 2048 is the audited optimum;
+    /// going larger (4096+) regresses prefill at long contexts due to
+    /// activation memory pressure during the chunked forward.
+    static let prefillStepSize = 2048
+}
+
 // MARK: - Configuration
 
 public struct GPTOSSConfiguration: Codable, Sendable {
@@ -507,12 +517,16 @@ public class GPTOSSModel: Module, LLMModel, KVCacheDimensionProvider {
         return result
     }
 
-    /// Pure attention model — use larger prefill chunks (2048+) since there's no
-    /// GatedDeltaNet sequential bottleneck. Reduces TTFT by processing more tokens per step.
+    /// Per-model audited prefill chunk default.
+    public var defaultPrefillStepSize: Int { GPTOSSDefaults.prefillStepSize }
+
+    /// Pure attention model — uses larger prefill chunks (2048) since there's no
+    /// GatedDeltaNet sequential bottleneck. Reduces TTFT by processing more
+    /// tokens per step.
     public func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws
         -> PrepareResult
     {
-        let prefillStepSize = max(windowSize ?? 512, 2048)
+        let prefillStepSize = windowSize ?? defaultPrefillStepSize
         var y = input.text
 
         while y.tokens.size > 1 {

--- a/Libraries/MLXLLM/Models/Gemma4.swift
+++ b/Libraries/MLXLLM/Models/Gemma4.swift
@@ -11,6 +11,16 @@ import Foundation
 import MLX
 import MLXLMCommon
 import MLXNN
+
+// MARK: - Tunables
+// Audited optima on M1 Max (4-bit, summarization). See issue #80.
+private enum Gemma4Defaults {
+    /// Gemma 4 dense (E2B / E4B / 31B) and MoE (26B-A4B). 4096-token chunks
+    /// are the audited optimum across the family — going smaller regresses
+    /// prefill, going larger pressures activation memory at long contexts.
+    static let prefillStepSize = 4096
+}
+
 // MARK: - Gemma Prefill Bridge (C++ dylib via dlopen)
 
 /// Lazy-loaded bridge to native C++ prefill.
@@ -1175,6 +1185,9 @@ public class Gemma4TextModel: Module, LLMModel, KVCacheDimensionProvider {
         super.init()
     }
 
+    /// Per-model audited prefill chunk default.
+    public var defaultPrefillStepSize: Int { Gemma4Defaults.prefillStepSize }
+
     /// Pure attention model — use larger prefill chunks (4096) since there's no
     /// GatedDeltaNet sequential bottleneck. Reduces TTFT by processing more tokens per step.
     public func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws
@@ -1182,7 +1195,7 @@ public class Gemma4TextModel: Module, LLMModel, KVCacheDimensionProvider {
     {
         // Larger chunks reduce per-chunk overhead (graph building, eval barriers,
         // weight re-reads). 4096 balances speed and memory for pure attention models.
-        let prefillStepSize = max(windowSize ?? 512, 4096)
+        let prefillStepSize = windowSize ?? defaultPrefillStepSize
         var y = input.text
 
         // Native prefill offload (opt-in via NATIVE_PREFILL=1)

--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -9,6 +9,15 @@ import MLX
 import MLXLMCommon
 import MLXNN
 
+// MARK: - Tunables
+// Audited optima on M1 Max (4-bit, summarization). See issue #80.
+private enum NemotronHDefaults {
+    /// Nemotron Cascade 2 30B A3B (Mamba/attention/MoE hybrid). 1024-token
+    /// chunks beat 2048+ by 3–4% prefill. Sharp falloff at 4096+ — the
+    /// per-chunk activation pressure on the MoE blocks dominates.
+    static let prefillStepSize = 1024
+}
+
 // MARK: - Block Type
 
 private enum NemotronHBlockType {
@@ -737,6 +746,8 @@ public class NemotronHModel: Module, LLMModel, KVCacheDimensionProvider, LoRAMod
             self._lmHead.wrappedValue = Linear(args.hiddenSize, args.vocabSize, bias: false)
         }
     }
+
+    public var defaultPrefillStepSize: Int { NemotronHDefaults.prefillStepSize }
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
         var out = backbone(inputs, cache: cache)

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -12,6 +12,22 @@ import MLX
 import MLXLMCommon
 import MLXNN
 
+// MARK: - Tunables
+// Audited optima on M1 Max (4-bit, summarization). See
+// `benchmarks/notes/prefill-step-audit-2026-04-24.md` (local) and issue #80
+// for the full sweep. Override per checkpoint via
+// `GenerateParameters.prefillStepSize`.
+private enum Qwen35Defaults {
+    /// Qwen3.5 / 3.6 dense hybrids (0.8B / 2B / 4B / 9B / 27B). 1024-token
+    /// chunks beat 2048+ by 2–4% prefill while keeping peak memory bounded.
+    static let densePrefillStepSize = 1024
+
+    /// Qwen3.5 35B-A3B and other GDN-MoE variants. Larger chunks amortize
+    /// per-chunk dispatch overhead across the 40-layer expert routing —
+    /// 4096 wins by 12% over 1024 at ctx=4k.
+    static let moePrefillStepSize = 4096
+}
+
 // MARK: - Configuration
 
 private enum RopeParametersCodingKey: String, CodingKey {
@@ -650,6 +666,12 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider {
         }
     }
 
+    public var defaultPrefillStepSize: Int {
+        configuration.numExperts > 0
+            ? Qwen35Defaults.moePrefillStepSize
+            : Qwen35Defaults.densePrefillStepSize
+    }
+
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
         var out = model(inputs, cache: cache)
         if let lmHead {
@@ -781,6 +803,8 @@ public class Qwen35Model: Module, LLMModel, KVCacheDimensionProvider {
         self.kvHeads = textModel.kvHeads
         _languageModel.wrappedValue = textModel
     }
+
+    public var defaultPrefillStepSize: Int { languageModel.defaultPrefillStepSize }
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
         languageModel(inputs, cache: cache)

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -53,8 +53,11 @@ public protocol LogitProcessor {
 /// for the `TokenIterator`.
 public struct GenerateParameters: Sendable {
 
-    /// Step size for processing the prompt
-    public var prefillStepSize: Int
+    /// Step size (chunk size, in tokens) for processing the prompt during
+    /// prefill. When `nil`, the iterator falls back to the model's
+    /// ``LanguageModel/defaultPrefillStepSize``. A non-nil value always
+    /// wins — this is a *default*, not a clamp.
+    public var prefillStepSize: Int?
 
     /// Maximum tokens to generate
     public var maxTokens: Int?
@@ -187,7 +190,7 @@ public struct GenerateParameters: Sendable {
         presenceContextSize: Int = 20,
         frequencyPenalty: Float? = nil,
         frequencyContextSize: Int = 20,
-        prefillStepSize: Int = 512,
+        prefillStepSize: Int? = nil,
         kvScheme: String? = nil,
         turboBoundarySkip: Int = 2,
         additionalProcessors: [any LogitProcessor] = [],
@@ -859,7 +862,7 @@ public struct TokenIterator: TokenIteratorProtocol {
     ///   - maxTokens: maximum number of tokens to generate
     public init(
         input: LMInput, model: any LanguageModel, cache: [KVCache]? = nil,
-        processor: (any LogitProcessor)?, sampler: LogitSampler, prefillStepSize: Int = 512,
+        processor: (any LogitProcessor)?, sampler: LogitSampler, prefillStepSize: Int? = nil,
         maxTokens: Int? = nil
     ) throws {
         self.model = model
@@ -895,7 +898,10 @@ public struct TokenIterator: TokenIteratorProtocol {
     mutating func prepare(input: LMInput, windowSize: Int? = nil) throws {
         processor?.prompt(input.text.tokens)
 
-        switch try model.prepare(input, cache: cache, windowSize: windowSize) {
+        // Resolve once at the boundary: caller-supplied value wins, otherwise
+        // fall back to the model's audited per-architecture default.
+        let resolvedWindowSize = windowSize ?? model.defaultPrefillStepSize
+        switch try model.prepare(input, cache: cache, windowSize: resolvedWindowSize) {
         case .tokens(let tokens):
             y = tokens
 
@@ -1241,8 +1247,12 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
     mutating func prepare(input: LMInput, windowSize: Int? = nil) throws {
         processor?.prompt(input.text.tokens)
 
+        // Resolve per model — main and draft can have different defaults.
+        let mainWindowSize = windowSize ?? mainModel.defaultPrefillStepSize
+        let draftWindowSize = windowSize ?? draftModel.defaultPrefillStepSize
+
         // Prefill main model
-        switch try mainModel.prepare(input, cache: mainCache, windowSize: windowSize) {
+        switch try mainModel.prepare(input, cache: mainCache, windowSize: mainWindowSize) {
         case .tokens(let tokens):
             y = tokens
         case .logits(let result):
@@ -1255,7 +1265,7 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         }
 
         // Prefill draft model, don't call didSample here -- processor tracks main model's accepted sequence only
-        switch try draftModel.prepare(input, cache: draftCache, windowSize: windowSize) {
+        switch try draftModel.prepare(input, cache: draftCache, windowSize: draftWindowSize) {
         case .tokens(let tokens):
             draftY = tokens
         case .logits(let result):

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -152,6 +152,19 @@ public enum PrepareResult {
 /// - the ``TokenIterator`` accumulates this information into a ``GenerateResult``
 public protocol LanguageModel: Module {
 
+    /// Preferred prefill chunk size for this model.
+    ///
+    /// Resolved by the iterator when the caller passes `nil` for
+    /// ``GenerateParameters/prefillStepSize`` — at that point the model's
+    /// `defaultPrefillStepSize` is used as the chunk size for prefill. A
+    /// caller-supplied non-nil value always wins; this is a *default*, not
+    /// a clamp.
+    ///
+    /// Each concrete model declares its own audited optimum (typically as
+    /// a private constant at the top of the model file). The library-wide
+    /// fallback is `1024`.
+    var defaultPrefillStepSize: Int { get }
+
     /// Prepare the cache state and consume the ``LMInput``.
     ///
     /// This can return:
@@ -193,6 +206,10 @@ public protocol LanguageModel: Module {
 }
 
 extension LanguageModel {
+    /// Library-wide fallback. Concrete models override to declare an
+    /// audited per-architecture optimum.
+    public var defaultPrefillStepSize: Int { 1024 }
+
     public func callAsFunction(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?)
         -> LMOutput
     {

--- a/Libraries/MLXLMCommon/WiredMemoryUtils.swift
+++ b/Libraries/MLXLMCommon/WiredMemoryUtils.swift
@@ -107,7 +107,8 @@ public enum WiredMemoryUtils {
     ) throws -> [KVCache] {
         var cache = model.newCache(parameters: parameters)
 
-        switch try model.prepare(input, cache: cache, windowSize: parameters.prefillStepSize) {
+        let resolvedWindowSize = parameters.prefillStepSize ?? model.defaultPrefillStepSize
+        switch try model.prepare(input, cache: cache, windowSize: resolvedWindowSize) {
         case .tokens(let tokens):
             let result = model(
                 tokens[text: .newAxis],
@@ -186,7 +187,7 @@ public enum WiredMemoryUtils {
             workspaceBytes: workspace,
             peakActiveBytes: peakActive,
             tokenCount: tokenCount,
-            prefillStepSize: parameters.prefillStepSize
+            prefillStepSize: parameters.prefillStepSize ?? context.model.defaultPrefillStepSize
         )
     }
 
@@ -230,7 +231,7 @@ public enum WiredMemoryUtils {
             workspaceBytes: workspace,
             peakActiveBytes: peakActive,
             tokenCount: input.text.tokens.size,
-            prefillStepSize: parameters.prefillStepSize
+            prefillStepSize: parameters.prefillStepSize ?? context.model.defaultPrefillStepSize
         )
     }
 

--- a/Tests/Benchmarks/InferenceBenchmark.swift
+++ b/Tests/Benchmarks/InferenceBenchmark.swift
@@ -1185,7 +1185,7 @@ struct InferenceBenchmarks {
             minP: family.minP,
             repetitionPenalty: family.repetitionPenalty,
             presencePenalty: family.presencePenalty,
-            prefillStepSize: 2048,
+
             kvScheme: warmup ? nil : kv.kvScheme,
             additionalProcessors: additionalProcessors,
             reasoningEffort: BenchEnv.reasoningEffort ?? family.reasoningEffort,
@@ -1534,6 +1534,13 @@ struct InferenceBenchmarks {
 
         print(hr + "\n")
 
+        // Resolve the actual prefill chunk size used so the report shows
+        // the real value, not "nil". When `params.prefillStepSize` is nil,
+        // the iterator falls back to the model's `defaultPrefillStepSize`.
+        let resolvedPrefillStepSize: Int = await container.perform { ctx in
+            params.prefillStepSize ?? ctx.model.defaultPrefillStepSize
+        }
+
         // ── 9. Write to markdown file ─────────────────────────────────────────
         BenchmarkWriter.append(
             model: family.name,
@@ -1560,6 +1567,7 @@ struct InferenceBenchmarks {
             outputPreview: reportOutput,
             parameters: .init(
                 generate: params,
+                resolvedPrefillStepSize: resolvedPrefillStepSize,
                 thinkingEnabled: useThinking,
                 thinkingTokenBudget: hasThinkingBudget ? thinkingBudget : nil,
                 kldSummary: kldParameterSummary(needsKLD: needsKLD, isWikitext2: false),
@@ -1632,7 +1640,7 @@ struct InferenceBenchmarks {
             minP: family.minP,
             repetitionPenalty: family.repetitionPenalty,
             presencePenalty: family.presencePenalty,
-            prefillStepSize: 2048,
+
             kvScheme: kv.kvScheme,
             ngramSize: BenchEnv.ngramSize,
             maxNgramDraftTokens: BenchEnv.ngramSize,
@@ -1866,6 +1874,7 @@ struct InferenceBenchmarks {
             outputPreview: "WikiText-2 forced-decode perplexity evaluation",
             parameters: .init(
                 generate: params,
+                resolvedPrefillStepSize: chunkSize,
                 thinkingEnabled: false,
                 thinkingTokenBudget: nil,
                 kldSummary: kldParameterSummary(needsKLD: false, isWikitext2: true),
@@ -2079,7 +2088,7 @@ struct InferenceBenchmarks {
             minP: family.minP,
             repetitionPenalty: family.repetitionPenalty,
             presencePenalty: family.presencePenalty,
-            prefillStepSize: 2048,
+
             reasoningEffort: family.reasoningEffort,
             thinkStartTokenId: thinkStartId,
             thinkEndTokenId: thinkEndId,
@@ -2098,7 +2107,9 @@ struct InferenceBenchmarks {
             var state: LMOutput.State? = nil
             var logits: MLXArray
 
-            switch try ctx.model.prepare(sendableInput, cache: cache, windowSize: params.prefillStepSize) {
+            // Resolve to the model's audited default when params didn't set one.
+            let resolvedWindowSize = params.prefillStepSize ?? ctx.model.defaultPrefillStepSize
+            switch try ctx.model.prepare(sendableInput, cache: cache, windowSize: resolvedWindowSize) {
             case .tokens(let remaining):
                 let result = ctx.model(
                     remaining[text: .newAxis],

--- a/Tests/Benchmarks/Utils/BenchmarkWriter.swift
+++ b/Tests/Benchmarks/Utils/BenchmarkWriter.swift
@@ -22,6 +22,12 @@ enum BenchmarkWriter {
     /// Generation + runner metadata for the benchmark markdown header.
     struct BenchmarkParameters {
         let generate: GenerateParameters
+        /// Prefill chunk size actually used for this run. When the caller
+        /// passes nil for `GenerateParameters.prefillStepSize`, the
+        /// iterator falls back to the model's `defaultPrefillStepSize`.
+        /// This field captures the resolved value so the report shows
+        /// the real chunk size, not "nil".
+        let resolvedPrefillStepSize: Int
         let thinkingEnabled: Bool
         let thinkingTokenBudget: Int?
         let kldSummary: String
@@ -356,7 +362,7 @@ enum BenchmarkWriter {
 
         // Generation budget
         rows.append(contentsOf: [
-            ["Prefill step size", "\(gp.prefillStepSize)"],
+            ["Prefill step size", "\(p.resolvedPrefillStepSize)"],
             ["Max tokens", gp.maxTokens.map(String.init) ?? "nil"],
         ])
 


### PR DESCRIPTION
Closes #80.

## Summary

Today \`prefillStepSize\` can be set/altered in three places — caller's \`GenerateParameters\` (default 512), default \`LLMModel.prepare()\`, and per-model \`max()\` clamps inside specific \`prepare()\` overrides (GPT-OSS, Gemma 4) — and the benchmark harness hardcodes 2048 to compensate. Two problems with this:

1. The clamp model is a **floor**, not a **default**. Passing \`prefillStepSize=1024\` to GPT-OSS silently becomes 2048; caller intent is lost.
2. There's no single place to look up *what does this model want?* — audited values are buried inside \`prepare()\` impls.

This PR moves to a clean default-with-override model:

- \`LanguageModel\` gets a \`defaultPrefillStepSize: Int { get }\` requirement with a 1024 fallback via protocol extension.
- \`GenerateParameters.prefillStepSize\` becomes \`Int? = nil\` — nil means \"use the model's default\"; a non-nil value always wins.
- \`TokenIterator\` (Evaluate.swift) and \`WiredMemoryUtils\` resolve once at the boundary: \`windowSize ?? model.defaultPrefillStepSize\`.
- Each model file declares its constant at the top inside a private \`enum\` (\`Qwen35Defaults\`, \`GPTOSSDefaults\`, \`Gemma4Defaults\`, \`NemotronHDefaults\`) and overrides \`defaultPrefillStepSize\` on the model class.

## Per-family values (from the audit on issue #80)

| Family | \`defaultPrefillStepSize\` |
|---|---:|
| Library default (\`LanguageModel\` extension) | **1024** |
| Qwen3.5 / 3.6 dense (0.8B / 2B / 4B / 9B / 27B) | 1024 |
| Qwen3.5 MoE (35B A3B, computed from \`numExperts\`) | 4096 |
| NemotronH | 1024 |
| GPT-OSS | 2048 |
| Gemma 4 (E2B / E4B / 31B / 26B-A4B) | 4096 |

## Side cleanup

- Drop \`max(windowSize ?? 512, FLOOR)\` clamps in GPT-OSS / Gemma 4 \`prepare()\` — Evaluate.swift now resolves before the call, so \`prepare()\` trusts the value.
- Remove the 3 \`prefillStepSize: 2048\` overrides from \`InferenceBenchmark.swift\`. The benchmark now relies on per-model defaults.
- Remove the \`MLX_BENCH_PREFILL_STEP\` env var (audit-only).
- \`BenchmarkWriter\`'s \"Prefill step size\" row displays the resolved value (the actual chunk size used), not \"nil\" or the caller's raw input.

## Breaking change

\`GenerateParameters.prefillStepSize\` field type changed from \`Int\` to \`Int?\`. Setting \`GenerateParameters(..., prefillStepSize: 2048, ...)\` continues to compile (Int auto-wraps to Int?). Reading \`gp.prefillStepSize\` in caller code now returns \`Int?\` and may need a fallback. Documented as expected: callers who want a specific value should still pass it; callers who want the model default should pass nil (or omit).

## Test plan

- [x] Build passes.
- [x] Smoke test: Qwen3.5-2B resolves to 1024, GPT-OSS-20B → 2048, Gemma 4 E4B → 4096, Qwen3.5-35B-A3B (MoE) → 4096. Prefill tok/s matches audit numbers within run-to-run noise on M1 Max.
- [x] Benchmark report's \"Prefill step size\" row reflects the resolved value.
- [ ] Maintainer rerun on M5 Max / M3 Ultra to confirm constants are also optimal there (or open a follow-up to retune).

🤖 Generated with [Claude Code](https://claude.com/claude-code)