### PR TITLE
fix: Config-I per-layer quantization + TurboQuant buffer overflow + NemotronH TQ support

### DIFF
--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -760,6 +760,13 @@ public class NemotronHModel: Module, LLMModel, KVCacheDimensionProvider, LoRAMod
     }
 
     public func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        let turboScheme = parameters?.kvScheme
+        let isTurbo = turboScheme?.hasPrefix("turbo") ?? false
+        var parsed: (bits: Int, keyBits: Int?, valueBits: Int?) = (4, nil, nil)
+        if isTurbo, let scheme = turboScheme {
+            parsed = parseTurboScheme(scheme)
+        }
+
         let pattern = Array(configuration.hybridOverridePattern)
         return pattern.compactMap { char -> KVCache? in
             let blockType = NemotronHBlockType(from: char)
@@ -767,6 +774,14 @@ public class NemotronHModel: Module, LLMModel, KVCacheDimensionProvider, LoRAMod
             case .mamba:
                 return MambaCache()
             case .attention:
+                if isTurbo {
+                    return TurboQuantKVCache(
+                        bits: parsed.bits, keyBits: parsed.keyBits, valueBits: parsed.valueBits,
+                        maxSize: parameters?.maxKVSize)
+                }
+                if let maxKVSize = parameters?.maxKVSize {
+                    return RotatingKVCache(maxSize: maxKVSize, keep: 0)
+                }
                 return KVCacheSimple()
             case .mlp, .moe:
                 return nil  // No cache needed for MLP/MoE layers

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -838,14 +838,18 @@ public class Qwen35Model: Module, LLMModel, KVCacheDimensionProvider {
         -> BaseConfiguration.PerLayerQuantization?
     {
         guard let plq = perLayerQuantization else { return nil }
+        // Keep both prefixed AND stripped keys. The quantize() loop uses Swift
+        // module paths which include 'language_model.' from @ModuleInfo(key:),
+        // so both forms must be present for per-layer lookup to match.
         let prefix = "language_model."
-        var stripped: [String: BaseConfiguration.QuantizationOption] = [:]
+        var merged: [String: BaseConfiguration.QuantizationOption] = plq.perLayerQuantization
         for (key, value) in plq.perLayerQuantization {
-            let rewritten = key.hasPrefix(prefix) ? String(key.dropFirst(prefix.count)) : key
-            stripped[rewritten] = value
+            if key.hasPrefix(prefix) {
+                merged[String(key.dropFirst(prefix.count))] = value
+            }
         }
         return languageModel.sanitize(perLayerQuantization: BaseConfiguration.PerLayerQuantization(
-            quantization: plq.quantization, perLayerQuantization: stripped))
+            quantization: plq.quantization, perLayerQuantization: merged))
     }
 }
 

--- a/Libraries/MLXLMCommon/TurboQuantKVCache.swift
+++ b/Libraries/MLXLMCommon/TurboQuantKVCache.swift
@@ -861,9 +861,11 @@ public class TurboQuantKVCache: BaseKVCache {
         let (valPackedFlat, valNormsFlat) = fusedEncodeDispatch(
             input: flatVals, codec: valueMSECodec, headDim: headDim)
 
-        // For rotating caches, pre-allocate to maxSize so writes can wrap without growth
-        let minAlloc = rotatingMaxSize ?? tokenCount
-        let allocSteps = ((max(minAlloc, tokenCount) + step - 1) / step) * step
+        // Pre-allocate to at least one step beyond current tokenCount to accommodate
+        // the first decode token after compression. Without this, the buffer is exactly
+        // tokenCount slots and the first encodeNewToken write overflows.
+        let minAlloc = rotatingMaxSize ?? (tokenCount + step)
+        let allocSteps = ((max(minAlloc, tokenCount + step) + step - 1) / step) * step
         valPackedMSE = MLXArray.zeros([B, H, allocSteps, vpw], dtype: .uint32)
         valNorms = MLXArray.zeros([B, H, allocSteps])
 


### PR DESCRIPTION
## Summary

Three fixes:

### 1. Per-layer quantization path matching for Config-I models

`Qwen35Model.sanitize(perLayerQuantization:)` was stripping the `language_model.` prefix from config keys, but `quantize()` uses Swift module paths that include the prefix from `@ModuleInfo(key: "language_model")`. Per-layer overrides (8-bit boundary layers) never matched, so all layers got default 4-bit — causing shape mismatches on load.

Fix: keep both prefixed and stripped keys so path lookup works regardless.

### 2. TurboQuant compressed buffer overflow

`compressRawCacheInternal` allocated exactly `tokenCount` slots. When prefill length aligned with the step size (1024), the first decode token's `encodeNewToken` write overflowed the buffer, causing a reshape crash.

Fix: allocate `tokenCount + step` slots to ensure room for decode growth.

### 3. NemotronH TurboQuant KV support (fixes #86)

`NemotronH.newCache()` was hardcoded to `KVCacheSimple()` for attention layers, ignoring `kvScheme`. Now reads the scheme from `GenerateParameters` and creates `TurboQuantKVCache` for attention layers (Mamba layers still get `MambaCache`).

Verified via bridge: turbo4 decode runs at same speed as none (166 tok/s) with correct memory (38MB, same as fp16 — only 6 attention layers in Nemotron so KV cache is already tiny).

## Results — Qwen3.6-27B Config-I @ 4K (M5 Max 128GB)

| Scheme | Compression | PPL | Decode | PPL Δ | Decode Δ |
|--------|:-----------:|:---:|:------:|:-----:|:--------:|
| none (fp16) | 1.0x | 1.16 | 22.8 tok/s | — | — |
| turbo4 (K4V4) | 3.2x | 1.29 | 20.8 tok/s | +11% | -9% |
| turbo4v2 (K4V2) | 3.8x | 1.34 | 20.9 tok/s | +15% | -8% |
| turbo3v2 (K3V2) | 4.6x | 1.43 | 20.8 tok/s | +23% | -9% |
| turbo3 (K3V3) | 4.6x | 1.46 | 20.4 tok/s | +26% | -11% |

## Test plan

- [x] Qwen3.6-27B-ConfigI-MLX loads (was crashing with shape mismatch)
- [x] All TQ schemes produce coherent output on Qwen3.5-2B, Qwen3-4B, Qwen3.6-27B
- [x] PPL measured via benchmark.sh at 4K context
- [x] NemotronH TQ activates (KV cache uses TurboQuantKVCache)
- [x] NemotronH memory verified: 38MB with both none and turbo4 (no inflation)
- [x] NemotronH decode speed verified via bridge: 166 tok/s (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)