### PR TITLE
fix(turbo-kv): advance offset in encodeNewToken; drop dead useCompressedAttention field

### DIFF
--- a/Libraries/MLXLMCommon/TurboQuantKVCache.swift
+++ b/Libraries/MLXLMCommon/TurboQuantKVCache.swift
@@ -1017,6 +1017,14 @@ public class TurboQuantKVCache: BaseKVCache {
             valPackedMSE![.ellipsis, writeIdx..<(writeIdx + numSteps), 0...] = valPackedShaped
             valNorms![.ellipsis, writeIdx..<(writeIdx + numSteps)] = valNormsShaped
         }
+
+        // [#87 fix] Advance offset so the caller's `compressedWriteOffset =
+        // offset` line correctly captures the new write position. Without
+        // this, every decode token writes to the same slot (overwriting the
+        // prior) and slots beyond it stay zero-initialized — those zero
+        // slots cause division-by-zero NaN in the dequant path during the
+        // next attention pass.
+        offset += numSteps
     }
 
     /// Batch-encode all pending raw tokens into compressed storage.
@@ -1198,11 +1206,6 @@ public class TurboQuantKVCache: BaseKVCache {
         guard let valueMSECodec else { return rotatedOutput }
         return matmul(rotatedOutput, valueMSECodec.rotation)
     }
-
-    /// Whether to use compressed-domain Metal kernels instead of dequant + SDPA.
-    /// Default false: dequant-first is simpler and uses MLX's optimized attention.
-    /// Set true for very long contexts where FP16 materialization costs too much memory.
-    public var useCompressedAttention: Bool = true
 
     /// Compressed-domain attention via Metal kernels.
     ///


### PR DESCRIPTION
## Summary

Two cleanups in \`TurboQuantKVCache\`, surfaced while debugging #87:

### 1. \`encodeNewToken\` now advances \`self.offset\` by \`numSteps\`

The decode path in \`compressedAttention\` looks like:

\`\`\`swift
offset += newKeys.dim(2)
let savedOffset = offset
offset = compressedWriteOffset
encodeNewToken(keys: newKeys, values: newValues)
compressedWriteOffset = offset    // <-- expects encodeNewToken to have bumped self.offset
offset = savedOffset
\`\`\`

…but \`encodeNewToken\` never bumped \`self.offset\`, so \`compressedWriteOffset\` was stuck at its post-prefill value across every decode token. Every token wrote to the same slot (overwriting the prior token's K/V), and slots beyond stayed zero-initialized. Reading those zero slots in a subsequent attention pass risks division-by-zero in the TurboQuant dequant path (\`K_dequant = codebook[packed] × norm_scale / norm\`, with \`norm = 0\`).

Verified the bug with \`TQ_DEBUG=1\` on Qwen3.5-2B 4bit turbo4 ctx=1024:

\`\`\`
[TQ-ATTN] offset=1011 tokenCount=1011 compressedWriteOffset=1010   ← stuck at 1010
[TQ-ATTN] offset=1011 tokenCount=1011 compressedWriteOffset=1010   ← still 1010 next decode
[TQ-ATTN] offset=1011 tokenCount=1011 compressedWriteOffset=1010   ← still 1010 again
\`\`\`

After this fix:

\`\`\`
[TQ-ATTN] offset=1011 tokenCount=1011 compressedWriteOffset=1011
[TQ-ATTN] offset=1012 tokenCount=1012 compressedWriteOffset=1012
[TQ-ATTN] offset=1013 tokenCount=1013 compressedWriteOffset=1013
\`\`\`

### 2. Drop unused \`useCompressedAttention\` field

\`public var useCompressedAttention: Bool = true\` was declared on \`TurboQuantKVCache\` but never read anywhere — the decode path always uses \`compressedAttention()\`. Removing for clarity.

## Does NOT fix #87

The Qwen3.5-2B / 0.8B / 35B-A3B garbage-output bug has a separate root cause. With the offset fix applied, the \`!!!!!\` symptom still reproduces — NaN appears at the second full-attention layer of decode token 1 even when offsets are correct. Investigation continues in #87.

## Test plan

- [x] Build passes.
- [x] Qwen3.5-4B 4bit turbo4 ctx=1024 still produces coherent output (was working before, still working).
- [ ] Smoke run on a representative subset of (model, kv) cells to confirm no regression. Reviewers welcome to re-sweep on their hardware.

## Hardware

Verified on M1 Max 64 GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)