### PR TITLE
feat(batched-hybrid): Qwen3Next/3.5/3.6 fully batched decode + GDN contiguous fix

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -276,10 +276,8 @@ final class Qwen35GatedDeltaNet: Module {
         let convOut = silu(conv1d(convInput))
 
         let convSplit = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
-        // BUG FIX (issue #8 phase 6): GDN Metal kernel uses raw pointer
-        // arithmetic with assumed contiguous strides. Slices from MLX.split
-        // are non-contiguous; at B=1 the kernel happens to land on correct
-        // values, but at B>1 (e.g. batched prefill) it reads cross-slot.
+        // GDN Metal kernel reads q/k/v with raw pointer arithmetic and
+        // assumed contiguous strides — slices from MLX.split are not.
         let q = convSplit[0].reshaped(B, S, numKHeads, headKDim).contiguous()
         let k = convSplit[1].reshaped(B, S, numKHeads, headKDim).contiguous()
         let v = convSplit[2].reshaped(B, S, numVHeads, headVDim).contiguous()
@@ -368,12 +366,8 @@ final class Qwen35GatedDeltaNet: Module {
 
         let convOut = silu(conv1d(convInput))
         let convSplit = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
-        // BUG FIX (issue #8 phase 6): GDN Metal kernel uses raw pointer
-        // arithmetic with assumed contiguous strides for q/k/v. Slices from
-        // MLX.split have non-contiguous strides — for B=1 the kernel's pointer
-        // math happens to land on correct values (single-batch, no inter-slot
-        // confusion), but for B>1 it reads into the wrong slot's region of
-        // memory. Force contiguous so the kernel sees flat row-major buffers.
+        // GDN Metal kernel reads q/k/v with raw pointer arithmetic and
+        // assumed contiguous strides — slices from MLX.split are not.
         let q = convSplit[0].reshaped(B, S, numKHeads, headKDim).contiguous()
         let k = convSplit[1].reshaped(B, S, numKHeads, headKDim).contiguous()
         let v = convSplit[2].reshaped(B, S, numVHeads, headVDim).contiguous()

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -276,9 +276,13 @@ final class Qwen35GatedDeltaNet: Module {
         let convOut = silu(conv1d(convInput))
 
         let convSplit = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
-        let q = convSplit[0].reshaped(B, S, numKHeads, headKDim)
-        let k = convSplit[1].reshaped(B, S, numKHeads, headKDim)
-        let v = convSplit[2].reshaped(B, S, numVHeads, headVDim)
+        // BUG FIX (issue #8 phase 6): GDN Metal kernel uses raw pointer
+        // arithmetic with assumed contiguous strides. Slices from MLX.split
+        // are non-contiguous; at B=1 the kernel happens to land on correct
+        // values, but at B>1 (e.g. batched prefill) it reads cross-slot.
+        let q = convSplit[0].reshaped(B, S, numKHeads, headKDim).contiguous()
+        let k = convSplit[1].reshaped(B, S, numKHeads, headKDim).contiguous()
+        let v = convSplit[2].reshaped(B, S, numVHeads, headVDim).contiguous()
 
         var state = cache?[1]
         var out: MLXArray
@@ -364,9 +368,15 @@ final class Qwen35GatedDeltaNet: Module {
 
         let convOut = silu(conv1d(convInput))
         let convSplit = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
-        let q = convSplit[0].reshaped(B, S, numKHeads, headKDim)
-        let k = convSplit[1].reshaped(B, S, numKHeads, headKDim)
-        let v = convSplit[2].reshaped(B, S, numVHeads, headVDim)
+        // BUG FIX (issue #8 phase 6): GDN Metal kernel uses raw pointer
+        // arithmetic with assumed contiguous strides for q/k/v. Slices from
+        // MLX.split have non-contiguous strides — for B=1 the kernel's pointer
+        // math happens to land on correct values (single-batch, no inter-slot
+        // confusion), but for B>1 it reads into the wrong slot's region of
+        // memory. Force contiguous so the kernel sees flat row-major buffers.
+        let q = convSplit[0].reshaped(B, S, numKHeads, headKDim).contiguous()
+        let k = convSplit[1].reshaped(B, S, numKHeads, headKDim).contiguous()
+        let v = convSplit[2].reshaped(B, S, numVHeads, headVDim).contiguous()
 
         // Decode (S == 1) with non-nil state — use the fused kernel that
         // absorbs rmsNorm(q), rmsNorm(k), sigmoid(b)→beta, and

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -332,6 +332,64 @@ final class Qwen35GatedDeltaNet: Module {
         out = norm(out, gate: z)
         return outProj(out.reshaped(B, S, -1))
     }
+
+    /// Fully batched single-step decode against `BatchedMambaCache`. Reads
+    /// conv + recurrent state slices for the active prefix, runs the fused
+    /// GDN kernel (B>1 capable), and writes back. Mirrors
+    /// `Qwen3NextGatedDeltaNet.fullyBatchedForward` but accounts for Qwen3.5's
+    /// split QKV/Z/B/A projections.
+    public func fullyBatchedForward(
+        _ inputs: MLXArray, cache: BatchedMambaCache
+    ) -> MLXArray {
+        let B = inputs.dim(0)
+        let S = inputs.dim(1)
+        precondition(B == cache.active,
+                     "GDN fullyBatchedForward: input B (\(B)) ≠ cache.active (\(cache.active))")
+
+        let qkv = inProjQKV(inputs)
+        let z = inProjZ(inputs).reshaped(B, S, numVHeads, headVDim)
+        let b = inProjB(inputs)
+        let a = inProjA(inputs)
+
+        // Slice live conv + rec state for the active prefix. These are views.
+        let (convStateSlice, recStateSlice) = cache.slice(active: B)
+
+        // No mask in single-step decode (S == 1); skip the where().
+        let convInput = concatenated([convStateSlice, qkv], axis: 1)
+
+        // New conv state: trailing (kernel-1) tokens of the combined window.
+        // .contiguous() breaks the lazy chain so prior qkv arrays don't leak
+        // (matches the rationale in callAsFunction above).
+        let newConvState = convInput[0..., (-(convKernelSize - 1))...].contiguous()
+
+        let convOut = silu(conv1d(convInput))
+        let convSplit = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
+        let q = convSplit[0].reshaped(B, S, numKHeads, headKDim)
+        let k = convSplit[1].reshaped(B, S, numKHeads, headKDim)
+        let v = convSplit[2].reshaped(B, S, numVHeads, headVDim)
+
+        // Decode (S == 1) with non-nil state — use the fused kernel that
+        // absorbs rmsNorm(q), rmsNorm(k), sigmoid(b)→beta, and
+        // g = exp(-exp(aLog) * softplus(a + dtBias)) into one Metal dispatch.
+        // The kernel is already B>1-capable.
+        let (out, newRecState) = fusedGatedDeltaUpdate(
+            qRaw: q,
+            kRaw: k,
+            v: v,
+            a: a,
+            b: b,
+            aLog: aLog,
+            dtBias: dtBias,
+            state: recStateSlice,
+            mask: nil
+        )
+
+        // Commit both pieces of state.
+        cache.writeback(conv: newConvState, rec: newRecState)
+
+        let normalized = norm(out, gate: z)
+        return outProj(normalized.reshaped(B, S, -1))
+    }
 }
 
 // MARK: - Attention
@@ -409,6 +467,70 @@ final class Qwen35Attention: Module {
             cache: cache,
             scale: scale,
             mask: mask
+        )
+        .transposed(0, 2, 1, 3)
+        .reshaped(B, L, -1)
+
+        return oProj(sigmoidMultiply(output, gate))
+    }
+
+    /// Fully batched single-step decode against `BatchedKVCache`. Mirrors
+    /// `Qwen3NextAttention.fullyBatchedForward` — same gated-output Q split
+    /// and sigmoid-multiplied output projection. Runs the same fast/slow path
+    /// branching on whether all active slots share the same offset.
+    public func fullyBatchedForward(
+        _ x: MLXArray, cache: BatchedKVCache, mask: MLXArray
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+
+        // qProj outputs 2x heads (queries + gate). Split before the head
+        // reshape so the gate stays at hidden granularity.
+        let qProjOutput = qProj(x)
+        let qSplit = qProjOutput.reshaped(B, L, attentionHeads, -1).split(parts: 2, axis: -1)
+        var queries = qSplit[0]
+        let gate = qSplit[1].reshaped(B, L, -1)
+
+        var keys = kProj(x)
+        var values = vProj(x)
+
+        queries = qNorm(queries).transposed(0, 2, 1, 3)
+        keys = kNorm(keys.reshaped(B, L, kvHeads, -1)).transposed(0, 2, 1, 3)
+        values = values.reshaped(B, L, kvHeads, -1).transposed(0, 2, 1, 3)
+
+        // RoPE + cache update — same fast/slow path branching as Qwen3Next.
+        let allSameOffset = cache.offsets[0..<cache.active]
+            .allSatisfy { $0 == cache.offsets[0] }
+
+        if allSameOffset {
+            let offset = cache.offsets[0]
+            queries = rope(queries, offset: offset)
+            keys = rope(keys, offset: offset)
+            cache.update(newKeys: keys, newValues: values)
+        } else {
+            let qSlices = MLX.split(queries, parts: B, axis: 0)
+            let kSlices = MLX.split(keys, parts: B, axis: 0)
+            var rotQ = [MLXArray]()
+            var rotK = [MLXArray]()
+            rotQ.reserveCapacity(B)
+            rotK.reserveCapacity(B)
+            for i in 0..<B {
+                let off = cache.offsets[i]
+                rotQ.append(rope(qSlices[i], offset: off))
+                rotK.append(rope(kSlices[i], offset: off))
+            }
+            queries = concatenated(rotQ, axis: 0)
+            keys = concatenated(rotK, axis: 0)
+            cache.update(newKeys: keys, newValues: values)
+        }
+
+        let maxOffset = cache.offsets[0..<cache.active].max() ?? 0
+        let allK = cache.keys[..<cache.active, 0..., ..<maxOffset, 0...]
+        let allV = cache.values[..<cache.active, 0..., ..<maxOffset, 0...]
+
+        let output = MLXFast.scaledDotProductAttention(
+            queries: queries, keys: allK, values: allV,
+            scale: scale, mask: .array(mask)
         )
         .transposed(0, 2, 1, 3)
         .reshaped(B, L, -1)
@@ -530,6 +652,29 @@ final class Qwen35DecoderLayer: Module {
         let h = x + r
         return h + (mlp as! UnaryLayer)(postAttentionLayerNorm(h))
     }
+
+    /// Fully batched decode: dispatches by `isLinear` to the right batched
+    /// attention or GDN path. Dense MLP / SparseMoeBlock already conform to
+    /// `UnaryLayer` and run over the batched `[B, 1]` tensor without changes.
+    func fullyBatchedForward(
+        _ x: MLXArray,
+        layerCache: BatchedHybridCache.BatchedLayerCache,
+        attnMask: MLXArray
+    ) -> MLXArray {
+        let r: MLXArray
+        switch (isLinear, layerCache) {
+        case (true, .gdn(let mambaCache)):
+            r = linearAttn!.fullyBatchedForward(inputLayerNorm(x), cache: mambaCache)
+        case (false, .attention(let kvCache)):
+            r = selfAttn!.fullyBatchedForward(
+                inputLayerNorm(x), cache: kvCache, mask: attnMask)
+        default:
+            fatalError("Qwen35DecoderLayer: layer/cache type mismatch (isLinear=\(isLinear))")
+        }
+
+        let h = x + r
+        return h + (mlp as! UnaryLayer)(postAttentionLayerNorm(h))
+    }
 }
 
 // MARK: - Text Model
@@ -640,6 +785,67 @@ public class Qwen35TextModelInner: Module {
                     asyncEval(toEval)
                 }
             }
+        }
+
+        return norm(hiddenStates)
+    }
+
+    /// Fully batched single-step decode forward pass. Builds the shared
+    /// attention mask once from the first attention layer's `BatchedKVCache`
+    /// and reuses it across every attention layer. GDN layers don't take a
+    /// mask in single-step decode (S == 1).
+    func fullyBatchedForward(
+        _ inputs: MLXArray, caches: BatchedHybridCache
+    ) -> MLXArray {
+        precondition(caches.layers.count == layers.count,
+                     "fullyBatchedForward: cache layer count mismatch")
+
+        var hiddenStates = embedTokens(inputs)
+
+        // Build the shared attention mask from the first attention layer's
+        // BatchedKVCache. This is only used for attention layers; GDN passes
+        // skip it.
+        var sampleAttnCache: BatchedKVCache?
+        for layer in caches.layers {
+            if case .attention(let c) = layer {
+                sampleAttnCache = c
+                break
+            }
+        }
+
+        let attnMask: MLXArray
+        if let c = sampleAttnCache {
+            let B = c.active
+            let cacheDtype = c.keys.dtype
+            let allSame = c.offsets[0..<B].allSatisfy { $0 == c.offsets[0] }
+            // Post-update max offset (each step advances by 1).
+            let maxPostOffset = (c.offsets[0..<B].max() ?? 0) + 1
+            if allSame {
+                attnMask = MLXArray.zeros(
+                    [B, 1, 1, maxPostOffset], dtype: cacheDtype)
+            } else {
+                let positions = MLXArray(0..<maxPostOffset).reshaped(1, maxPostOffset)
+                let offsetsArr = MLXArray(c.offsets[0..<B].map { $0 + 1 }).reshaped(B, 1)
+                let valid = positions .< offsetsArr
+                attnMask = MLX.where(
+                    valid,
+                    MLXArray(Float(0)).asType(cacheDtype),
+                    MLXArray(Float(-1e9)).asType(cacheDtype)
+                ).reshaped(B, 1, 1, maxPostOffset)
+            }
+        } else {
+            // No attention layers? (Shouldn't happen for Qwen3.5 hybrid, but
+            // compose a placeholder so type-checking is straightforward.)
+            attnMask = MLXArray.zeros([0, 1, 1, 0], dtype: hiddenStates.dtype)
+        }
+
+        let modelDtype = hiddenStates.dtype
+        for (i, layer) in layers.enumerated() {
+            hiddenStates = layer.fullyBatchedForward(
+                hiddenStates, layerCache: caches.layers[i], attnMask: attnMask)
+            // Same defensive cast as the per-request path: quantized ops can
+            // promote bf16 → fp32 inside the lazy graph.
+            hiddenStates = hiddenStates.asType(modelDtype)
         }
 
         return norm(hiddenStates)
@@ -793,6 +999,66 @@ extension Qwen35TextModel: LoRAModel {
     }
 }
 
+// MARK: - BatchedHybridLLM (issue #8 — batched decode for Qwen3.5 hybrid)
+
+extension Qwen35TextModel: BatchedHybridLLM {
+    /// Fully batched decode: `[B, 1]` tokens → `[B, 1, vocab]` logits.
+    /// The bridge dispatches here when it has a `BatchedHybridCache` in hand;
+    /// the per-request `iterator.cache` path is left intact for fallback.
+    public func fullyBatchedDecode(
+        _ inputs: MLXArray, caches: BatchedHybridCache
+    ) -> MLXArray {
+        var out = model.fullyBatchedForward(inputs, caches: caches)
+        if let lmHead {
+            out = lmHead(out)
+        } else {
+            out = model.embedTokens.asLinear(out)
+        }
+        return out
+    }
+
+    /// Build a fresh `BatchedHybridCache` sized for `maxBatch` requests.
+    /// Per-layer cache type is decided by `Qwen35DecoderLayer.isLinear`. Both
+    /// dense (Qwen3.5) and MoE (Qwen3.6) checkpoints share the same hybrid
+    /// layer pattern, so this single layout serves both.
+    public func newBatchedHybridCache(
+        maxBatch: Int, parameters: GenerateParameters?
+    ) -> BatchedHybridCache {
+        // Same shape derivation as Qwen35GatedDeltaNet.init(args).
+        let cfg = configuration
+        let headDim = cfg.headDim ?? (cfg.hiddenSize / cfg.attentionHeads)
+        let kernelMinusOne = cfg.linearConvKernelDim - 1
+        let keyDim = cfg.linearKeyHeadDim * cfg.linearNumKeyHeads
+        let valueDim = cfg.linearValueHeadDim * cfg.linearNumValueHeads
+        let convDim = keyDim * 2 + valueDim
+
+        // Sequence budget: prefer parameters.maxKVSize when set, else fall
+        // back to 2048. This matches BatchedKVCache.init's default.
+        let maxSeq = parameters?.maxKVSize ?? 2048
+
+        let layers: [BatchedHybridCache.BatchedLayerCache] = model.layers.map { layer in
+            if layer.isLinear {
+                return .gdn(BatchedMambaCache(
+                    maxBatch: maxBatch,
+                    kernelMinusOne: kernelMinusOne,
+                    convDim: convDim,
+                    Hv: cfg.linearNumValueHeads,
+                    Dv: cfg.linearValueHeadDim,
+                    Dk: cfg.linearKeyHeadDim
+                ))
+            } else {
+                return .attention(BatchedKVCache(
+                    maxBatch: maxBatch,
+                    kvHeads: cfg.kvHeads,
+                    headDim: headDim,
+                    maxSeq: maxSeq
+                ))
+            }
+        }
+        return BatchedHybridCache(layers: layers)
+    }
+}
+
 // MARK: - Top-level Model
 
 public class Qwen35Model: Module, LLMModel, KVCacheDimensionProvider {
@@ -860,5 +1126,24 @@ public class Qwen35Model: Module, LLMModel, KVCacheDimensionProvider {
 extension Qwen35Model: LoRAModel {
     public var loraLayers: [Module] {
         languageModel.model.layers
+    }
+}
+
+// MARK: - BatchedHybridLLM (top-level)
+
+/// Forward batched-hybrid surface from `Qwen35Model` to its inner
+/// `Qwen35TextModel`. `Qwen35MoEModel` inherits this conformance — see
+/// `Qwen35MoE.swift` for the MoE-specific notes.
+extension Qwen35Model: BatchedHybridLLM {
+    public func fullyBatchedDecode(
+        _ inputs: MLXArray, caches: BatchedHybridCache
+    ) -> MLXArray {
+        languageModel.fullyBatchedDecode(inputs, caches: caches)
+    }
+
+    public func newBatchedHybridCache(
+        maxBatch: Int, parameters: GenerateParameters?
+    ) -> BatchedHybridCache {
+        languageModel.newBatchedHybridCache(maxBatch: maxBatch, parameters: parameters)
     }
 }

--- a/Libraries/MLXLLM/Models/Qwen35MoE.swift
+++ b/Libraries/MLXLLM/Models/Qwen35MoE.swift
@@ -35,6 +35,16 @@ public struct Qwen35Configuration: Codable, Sendable {
     }
 }
 
+/// Qwen3.6 (sparse-MoE hybrid). Shares `Qwen35Model`'s hybrid layer pattern
+/// (alternating GatedDeltaNet + attention), but the dense MLP is swapped for
+/// `Qwen35SparseMoeBlock`. The MoE block conforms to `UnaryLayer` and routes
+/// experts vectorized over the `[B, 1]` batched-decode tensor — the existing
+/// `switchMLP(x, inds)` path handles batched decode without modification.
+///
+/// `BatchedHybridLLM` conformance is **inherited** from `Qwen35Model`, so the
+/// per-block `fullyBatchedForward` paths and the cache layout produced by
+/// `newBatchedHybridCache(maxBatch:parameters:)` apply unchanged. See
+/// `Qwen35MoEBatchedHybridCacheTests` for the MoE cache lifecycle coverage.
 public class Qwen35MoEModel: Qwen35Model {
 
     override public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {

--- a/Libraries/MLXLLM/Models/Qwen3Next.swift
+++ b/Libraries/MLXLLM/Models/Qwen3Next.swift
@@ -325,10 +325,8 @@ public final class Qwen3NextGatedDeltaNet: Module {
         let convOut = silu(conv1d(convInput))
         let convSplit = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
 
-        // BUG FIX (issue #8 phase 6): GDN Metal kernel uses raw pointer
-        // arithmetic with assumed contiguous strides. Slices from MLX.split
-        // are non-contiguous; at B=1 the kernel happens to land on correct
-        // values, but at B>1 (e.g. batched prefill) it reads cross-slot.
+        // GDN Metal kernel reads q/k/v with raw pointer arithmetic and
+        // assumed contiguous strides — slices from MLX.split are not.
         var qOut = convSplit[0].reshaped(B, S, numKHeads, headKDim).contiguous()
         var kOut = convSplit[1].reshaped(B, S, numKHeads, headKDim).contiguous()
         let vOut = convSplit[2].reshaped(B, S, numVHeads, headVDim).contiguous()
@@ -397,12 +395,9 @@ public final class Qwen3NextGatedDeltaNet: Module {
         let convOut = silu(conv1d(convInput))
         let convSplit = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
 
-        // BUG FIX (issue #8 phase 6): GDN Metal kernel uses raw pointer
-        // arithmetic with assumed contiguous strides for q/k/v. Slices from
-        // MLX.split have non-contiguous strides; at B=1 the kernel happens to
-        // land on the correct values, but at B>1 it reads cross-slot. The
-        // rmsNorm + scale below also produces non-contiguous tensors when fed
-        // a non-contiguous input, so contiguify before normalising.
+        // GDN Metal kernel reads q/k/v with raw pointer arithmetic and
+        // assumed contiguous strides — slices from MLX.split are not. The
+        // rmsNorm + scale below preserves non-contiguity, so contiguify here.
         var qOut = convSplit[0].reshaped(B, S, numKHeads, headKDim).contiguous()
         var kOut = convSplit[1].reshaped(B, S, numKHeads, headKDim).contiguous()
         let vOut = convSplit[2].reshaped(B, S, numVHeads, headVDim).contiguous()

--- a/Libraries/MLXLLM/Models/Qwen3Next.swift
+++ b/Libraries/MLXLLM/Models/Qwen3Next.swift
@@ -325,9 +325,13 @@ public final class Qwen3NextGatedDeltaNet: Module {
         let convOut = silu(conv1d(convInput))
         let convSplit = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
 
-        var qOut = convSplit[0].reshaped(B, S, numKHeads, headKDim)
-        var kOut = convSplit[1].reshaped(B, S, numKHeads, headKDim)
-        let vOut = convSplit[2].reshaped(B, S, numVHeads, headVDim)
+        // BUG FIX (issue #8 phase 6): GDN Metal kernel uses raw pointer
+        // arithmetic with assumed contiguous strides. Slices from MLX.split
+        // are non-contiguous; at B=1 the kernel happens to land on correct
+        // values, but at B>1 (e.g. batched prefill) it reads cross-slot.
+        var qOut = convSplit[0].reshaped(B, S, numKHeads, headKDim).contiguous()
+        var kOut = convSplit[1].reshaped(B, S, numKHeads, headKDim).contiguous()
+        let vOut = convSplit[2].reshaped(B, S, numVHeads, headVDim).contiguous()
 
         let invScale = pow(Float(headKDim), -0.5)
         qOut =
@@ -393,9 +397,15 @@ public final class Qwen3NextGatedDeltaNet: Module {
         let convOut = silu(conv1d(convInput))
         let convSplit = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
 
-        var qOut = convSplit[0].reshaped(B, S, numKHeads, headKDim)
-        var kOut = convSplit[1].reshaped(B, S, numKHeads, headKDim)
-        let vOut = convSplit[2].reshaped(B, S, numVHeads, headVDim)
+        // BUG FIX (issue #8 phase 6): GDN Metal kernel uses raw pointer
+        // arithmetic with assumed contiguous strides for q/k/v. Slices from
+        // MLX.split have non-contiguous strides; at B=1 the kernel happens to
+        // land on the correct values, but at B>1 it reads cross-slot. The
+        // rmsNorm + scale below also produces non-contiguous tensors when fed
+        // a non-contiguous input, so contiguify before normalising.
+        var qOut = convSplit[0].reshaped(B, S, numKHeads, headKDim).contiguous()
+        var kOut = convSplit[1].reshaped(B, S, numKHeads, headKDim).contiguous()
+        let vOut = convSplit[2].reshaped(B, S, numVHeads, headVDim).contiguous()
 
         let invScale = pow(Float(headKDim), -0.5)
         qOut =

--- a/Libraries/MLXLLM/Models/Qwen3Next.swift
+++ b/Libraries/MLXLLM/Models/Qwen3Next.swift
@@ -115,6 +115,69 @@ public final class Qwen3NextAttention: Module {
 
         return oProj(sigmoidMultiply(output, gate))
     }
+
+    /// Fully batched single-step decode against `BatchedKVCache`. Mirrors
+    /// `Qwen3Attention.fullyBatchedForward` but accounts for the gate split
+    /// in `qProj` and the sigmoid-gated output projection.
+    public func fullyBatchedForward(
+        _ x: MLXArray, cache: BatchedKVCache, mask: MLXArray
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+
+        // qProj outputs 2x heads (queries + gate). Split before the head
+        // reshape so the gate stays at hidden granularity.
+        let qProjOutput = qProj(x)
+        let qSplit = qProjOutput.reshaped(B, L, args.attentionHeads, -1).split(parts: 2, axis: -1)
+        var queries = qSplit[0]
+        let gate = qSplit[1].reshaped(B, L, -1)
+
+        var keys = kProj(x)
+        var values = vProj(x)
+
+        queries = qNorm(queries).transposed(0, 2, 1, 3)
+        keys = kNorm(keys.reshaped(B, L, args.kvHeads, -1)).transposed(0, 2, 1, 3)
+        values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
+
+        // RoPE + cache update — same fast/slow path branching as Qwen3.
+        let allSameOffset = cache.offsets[0..<cache.active]
+            .allSatisfy { $0 == cache.offsets[0] }
+
+        if allSameOffset {
+            let offset = cache.offsets[0]
+            queries = rope(queries, offset: offset)
+            keys = rope(keys, offset: offset)
+            cache.update(newKeys: keys, newValues: values)
+        } else {
+            let qSlices = MLX.split(queries, parts: B, axis: 0)
+            let kSlices = MLX.split(keys, parts: B, axis: 0)
+            var rotQ = [MLXArray]()
+            var rotK = [MLXArray]()
+            rotQ.reserveCapacity(B)
+            rotK.reserveCapacity(B)
+            for i in 0..<B {
+                let off = cache.offsets[i]
+                rotQ.append(rope(qSlices[i], offset: off))
+                rotK.append(rope(kSlices[i], offset: off))
+            }
+            queries = concatenated(rotQ, axis: 0)
+            keys = concatenated(rotK, axis: 0)
+            cache.update(newKeys: keys, newValues: values)
+        }
+
+        let maxOffset = cache.offsets[0..<cache.active].max() ?? 0
+        let allK = cache.keys[..<cache.active, 0..., ..<maxOffset, 0...]
+        let allV = cache.values[..<cache.active, 0..., ..<maxOffset, 0...]
+
+        let output = MLXFast.scaledDotProductAttention(
+            queries: queries, keys: allK, values: allV,
+            scale: scale, mask: .array(mask)
+        )
+        .transposed(0, 2, 1, 3)
+        .reshaped(B, L, -1)
+
+        return oProj(sigmoidMultiply(output, gate))
+    }
 }
 
 final class Qwen3NextMLP: Module, UnaryLayer {
@@ -293,6 +356,74 @@ public final class Qwen3NextGatedDeltaNet: Module {
         let normalized = norm(out, gate: z)
         return outProj(normalized.reshaped(B, S, -1))
     }
+
+    /// Fully batched single-step decode against `BatchedMambaCache`.
+    /// Reads conv + recurrent state slices for the active prefix, runs the
+    /// shared GDN kernel (which already supports B>1), and writes back.
+    public func fullyBatchedForward(
+        _ inputs: MLXArray, cache: BatchedMambaCache
+    ) -> MLXArray {
+        let B = inputs.dim(0)
+        let S = inputs.dim(1)
+        precondition(B == cache.active,
+                     "GDN fullyBatchedForward: input B (\(B)) ≠ cache.active (\(cache.active))")
+
+        let (q, k, v, z, b, a) = fixQueryKeyValueOrdering(
+            mixedQKVZ: inProjQKVZ(inputs),
+            mixedBA: inProjBA(inputs)
+        )
+
+        let dtype = inputs.dtype
+
+        // Slice live conv + rec state for the active prefix. These are views.
+        let (convStateSlice, recStateSlice) = cache.slice(active: B)
+
+        let mixedQKV = concatenated(
+            [q.reshaped(B, S, -1), k.reshaped(B, S, -1), v.reshaped(B, S, -1)],
+            axis: -1
+        )
+        // No mask in single-step decode (S == 1); skip the where().
+
+        // Pre-pend the rolling conv window then convolve.
+        let convInput = concatenated([convStateSlice, mixedQKV], axis: 1)
+
+        // New conv state: trailing (kernel-1) tokens of the combined window.
+        let newConvState = convInput[0..., (1 - convKernelSize)..., 0...].contiguous()
+
+        let convOut = silu(conv1d(convInput))
+        let convSplit = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
+
+        var qOut = convSplit[0].reshaped(B, S, numKHeads, headKDim)
+        var kOut = convSplit[1].reshaped(B, S, numKHeads, headKDim)
+        let vOut = convSplit[2].reshaped(B, S, numVHeads, headVDim)
+
+        let invScale = pow(Float(headKDim), -0.5)
+        qOut =
+            MLXArray(invScale * invScale).asType(dtype)
+            * MLXFast.rmsNorm(qOut, weight: MLXArray.mlxNone, eps: 1e-6)
+        kOut =
+            MLXArray(invScale).asType(dtype)
+            * MLXFast.rmsNorm(kOut, weight: MLXArray.mlxNone, eps: 1e-6)
+
+        // Run the batched GDN step. Kernel already supports B>1.
+        let (out, newRecState) = gatedDeltaUpdate(
+            q: qOut,
+            k: kOut,
+            v: vOut,
+            a: a,
+            b: b,
+            aLog: aLog,
+            dtBias: dtBias,
+            state: recStateSlice,
+            mask: nil
+        )
+
+        // Commit both pieces of state.
+        cache.writeback(conv: newConvState, rec: newRecState)
+
+        let normalized = norm(out, gate: z)
+        return outProj(normalized.reshaped(B, S, -1))
+    }
 }
 
 final class Qwen3NextSparseMoeBlock: Module {
@@ -408,6 +539,33 @@ final class Qwen3NextDecoderLayer: Module {
         }
         return r + (mlp as! Qwen3NextMLP)(normed)
     }
+
+    /// Fully batched decode: dispatches by `isLinear` to the right batched
+    /// attention or GDN path. MLP / MoE already runs over the batched [B, 1]
+    /// tensor without changes.
+    func fullyBatchedForward(
+        _ x: MLXArray,
+        layerCache: BatchedHybridCache.BatchedLayerCache,
+        attnMask: MLXArray
+    ) -> MLXArray {
+        let h: MLXArray
+        switch (isLinear, layerCache) {
+        case (true, .gdn(let mambaCache)):
+            h = linearAttn!.fullyBatchedForward(inputLayerNorm(x), cache: mambaCache)
+        case (false, .attention(let kvCache)):
+            h = selfAttn!.fullyBatchedForward(
+                inputLayerNorm(x), cache: kvCache, mask: attnMask)
+        default:
+            fatalError("Qwen3NextDecoderLayer: layer/cache type mismatch (isLinear=\(isLinear))")
+        }
+
+        let r = x + h
+        let normed = postAttentionLayerNorm(r)
+        if let moe = mlp as? Qwen3NextSparseMoeBlock {
+            return r + moe(normed)
+        }
+        return r + (mlp as! Qwen3NextMLP)(normed)
+    }
 }
 
 public class Qwen3NextModelInner: Module {
@@ -455,6 +613,63 @@ public class Qwen3NextModelInner: Module {
             let attnMask = layer.isLinear ? MLXFast.ScaledDotProductAttentionMaskMode.none : faMask
             hiddenStates = layer(
                 hiddenStates, attentionMask: attnMask, ssmMask: mask, cache: cacheArray?[i])
+        }
+
+        return norm(hiddenStates)
+    }
+
+    /// Fully batched single-step decode forward pass. The mask is built once
+    /// from the first attention layer's `BatchedKVCache` and shared across
+    /// every attention layer; GDN layers don't take a mask in single-step
+    /// decode (S == 1).
+    func fullyBatchedForward(
+        _ inputs: MLXArray, caches: BatchedHybridCache
+    ) -> MLXArray {
+        precondition(caches.layers.count == layers.count,
+                     "fullyBatchedForward: cache layer count mismatch")
+
+        var hiddenStates = embedTokens(inputs)
+
+        // Build the shared attention mask from the first attention layer's
+        // BatchedKVCache. This is only used for attention layers; GDN passes
+        // skip it.
+        var sampleAttnCache: BatchedKVCache?
+        for layer in caches.layers {
+            if case .attention(let c) = layer {
+                sampleAttnCache = c
+                break
+            }
+        }
+
+        let attnMask: MLXArray
+        if let c = sampleAttnCache {
+            let B = c.active
+            let cacheDtype = c.keys.dtype
+            let allSame = c.offsets[0..<B].allSatisfy { $0 == c.offsets[0] }
+            // Post-update max offset (each step advances by 1).
+            let maxPostOffset = (c.offsets[0..<B].max() ?? 0) + 1
+            if allSame {
+                attnMask = MLXArray.zeros(
+                    [B, 1, 1, maxPostOffset], dtype: cacheDtype)
+            } else {
+                let positions = MLXArray(0..<maxPostOffset).reshaped(1, maxPostOffset)
+                let offsetsArr = MLXArray(c.offsets[0..<B].map { $0 + 1 }).reshaped(B, 1)
+                let valid = positions .< offsetsArr
+                attnMask = MLX.where(
+                    valid,
+                    MLXArray(Float(0)).asType(cacheDtype),
+                    MLXArray(Float(-1e9)).asType(cacheDtype)
+                ).reshaped(B, 1, 1, maxPostOffset)
+            }
+        } else {
+            // No attention layers? (Shouldn't happen for Qwen3Next, but
+            // compose a placeholder so type-checking is straightforward.)
+            attnMask = MLXArray.zeros([0, 1, 1, 0], dtype: hiddenStates.dtype)
+        }
+
+        for (i, layer) in layers.enumerated() {
+            hiddenStates = layer.fullyBatchedForward(
+                hiddenStates, layerCache: caches.layers[i], attnMask: attnMask)
         }
 
         return norm(hiddenStates)
@@ -679,5 +894,63 @@ public struct Qwen3NextConfiguration: Codable, Sendable {
 extension Qwen3NextModel: LoRAModel {
     public var loraLayers: [Module] {
         model.layers
+    }
+}
+
+// MARK: - BatchedHybridLLM (issue #8 — batched decode for Qwen3Next)
+
+extension Qwen3NextModel: BatchedHybridLLM {
+    /// Fully batched decode: `[B, 1]` tokens → `[B, 1, vocab]` logits.
+    /// The bridge dispatches here when it has a `BatchedHybridCache` in hand;
+    /// the per-request `iterator.cache` path is left intact for fallback.
+    public func fullyBatchedDecode(
+        _ inputs: MLXArray, caches: BatchedHybridCache
+    ) -> MLXArray {
+        var out = model.fullyBatchedForward(inputs, caches: caches)
+        if let lmHead {
+            out = lmHead(out)
+        } else {
+            out = model.embedTokens.asLinear(out)
+        }
+        return out
+    }
+
+    /// Build a fresh `BatchedHybridCache` sized for `maxBatch` requests.
+    /// Per-layer cache type is decided by `Qwen3NextDecoderLayer.isLinear`.
+    public func newBatchedHybridCache(
+        maxBatch: Int, parameters: GenerateParameters?
+    ) -> BatchedHybridCache {
+        // Same shape derivation as Qwen3NextGatedDeltaNet.init(args).
+        let cfg = configuration
+        let headDim = cfg.headDim ?? (cfg.hiddenSize / cfg.attentionHeads)
+        let kernelMinusOne = cfg.linearConvKernelDim - 1
+        let keyDim = cfg.linearKeyHeadDim * cfg.linearNumKeyHeads
+        let valueDim = cfg.linearValueHeadDim * cfg.linearNumValueHeads
+        let convDim = keyDim * 2 + valueDim
+
+        // Sequence budget: prefer parameters.maxKVSize when set, else fall
+        // back to 2048. This matches BatchedKVCache.init's default.
+        let maxSeq = parameters?.maxKVSize ?? 2048
+
+        let layers: [BatchedHybridCache.BatchedLayerCache] = model.layers.map { layer in
+            if layer.isLinear {
+                return .gdn(BatchedMambaCache(
+                    maxBatch: maxBatch,
+                    kernelMinusOne: kernelMinusOne,
+                    convDim: convDim,
+                    Hv: cfg.linearNumValueHeads,
+                    Dv: cfg.linearValueHeadDim,
+                    Dk: cfg.linearKeyHeadDim
+                ))
+            } else {
+                return .attention(BatchedKVCache(
+                    maxBatch: maxBatch,
+                    kvHeads: cfg.kvHeads,
+                    headDim: headDim,
+                    maxSeq: maxSeq
+                ))
+            }
+        }
+        return BatchedHybridCache(layers: layers)
     }
 }

--- a/Libraries/MLXLMCommon/BatchedHybridCache.swift
+++ b/Libraries/MLXLMCommon/BatchedHybridCache.swift
@@ -1,0 +1,225 @@
+// Copyright © 2026 Tom Turney. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+import MLX
+import MLXNN
+
+// MARK: - BatchedMambaCache
+
+/// Batched cache for GatedDeltaNet (and Mamba-style) layers.
+///
+/// Unlike attention KV cache where state grows with sequence length,
+/// GDN state is fixed-size per slot:
+///   - `convState`: rolling Conv1d window, `[B, kernel-1, convDim]`
+///   - `recState`:  recurrent SSM state, `[B, Hv, Dv, Dk]` in fp32
+///
+/// Pre-allocates one tensor per state shape, indexed by slot. Slot lifetime is
+/// managed by `addSlot` (returns a slot index, zero-inits state) and
+/// `removeSlot(_:)` (swap-from-end with the last active slot).
+///
+/// IMPORTANT: zero-init happens in `addSlot`, NOT in `init`. After
+/// `removeSlot` swaps a freed slot's state into the last position, the next
+/// `addSlot` must wipe stale state in that newly-allocated slot or the GDN
+/// recurrence will leak the previous request's history.
+public class BatchedMambaCache {
+    public let maxBatch: Int
+    public let kernelMinusOne: Int
+    public let convDim: Int
+    public let Hv: Int
+    public let Dv: Int
+    public let Dk: Int
+
+    /// Conv state: [maxBatch, kernel-1, convDim]
+    public var convState: MLXArray
+
+    /// Recurrent state: [maxBatch, Hv, Dv, Dk] fp32
+    public var recState: MLXArray
+
+    /// Active slot count (first `active` slots are in use)
+    public var active: Int = 0
+
+    public init(
+        maxBatch: Int,
+        kernelMinusOne: Int,
+        convDim: Int,
+        Hv: Int,
+        Dv: Int,
+        Dk: Int,
+        dtype: DType = .bfloat16
+    ) {
+        self.maxBatch = maxBatch
+        self.kernelMinusOne = kernelMinusOne
+        self.convDim = convDim
+        self.Hv = Hv
+        self.Dv = Dv
+        self.Dk = Dk
+
+        // Don't bother zeroing here — slots get zeroed lazily in addSlot.
+        // (We still allocate so the buffer exists with the right shape.)
+        self.convState = MLXArray.zeros(
+            [maxBatch, kernelMinusOne, convDim], dtype: dtype)
+        self.recState = MLXArray.zeros(
+            [maxBatch, Hv, Dv, Dk], dtype: .float32)
+        eval(self.convState, self.recState)
+    }
+
+    /// Add a new slot. Returns the slot index. **Zero-inits the new slot's
+    /// conv + rec state** so reused slot positions don't leak prior state.
+    @discardableResult
+    public func addSlot() -> Int {
+        precondition(active < maxBatch, "BatchedMambaCache: out of slots")
+        let slot = active
+        active += 1
+        zeroSlot(slot)
+        return slot
+    }
+
+    /// Remove a slot by swapping the last active slot into its position.
+    /// After the swap, `active` is decremented — the freed tail position is
+    /// effectively garbage and will be wiped on its next `addSlot`.
+    public func removeSlot(_ slot: Int) {
+        precondition(slot >= 0 && slot < active, "BatchedMambaCache: bad slot \(slot)")
+        let last = active - 1
+        if slot != last {
+            // Copy last → slot for both states (pure tensor assign, no concat)
+            convState[slot, 0..., 0...] = convState[last, 0..., 0...]
+            recState[slot, 0..., 0..., 0...] = recState[last, 0..., 0..., 0...]
+        }
+        active -= 1
+    }
+
+    /// Slice for the active prefix. Caller mutates the returned tensors only
+    /// via `writeback(...)`.
+    public func slice(active: Int) -> (conv: MLXArray, rec: MLXArray) {
+        precondition(active <= self.active, "BatchedMambaCache: slice exceeds active")
+        let conv = convState[..<active, 0..., 0...]
+        let rec = recState[..<active, 0..., 0..., 0...]
+        return (conv, rec)
+    }
+
+    /// Writeback updated conv + rec state for the first `active` slots.
+    /// `conv` shape: [active, kernel-1, convDim].
+    /// `rec` shape:  [active, Hv, Dv, Dk] (fp32).
+    public func writeback(conv: MLXArray, rec: MLXArray) {
+        let B = conv.dim(0)
+        precondition(B <= active, "writeback B (\(B)) exceeds active (\(active))")
+        convState[..<B, 0..., 0...] = conv
+        // Force fp32 to match storage; defensive — caller should already be fp32.
+        recState[..<B, 0..., 0..., 0...] =
+            (rec.dtype == .float32) ? rec : rec.asType(.float32)
+    }
+
+    /// Reset all slots.
+    public func reset() {
+        active = 0
+        // No need to wipe storage — addSlot wipes per-slot on reuse.
+    }
+
+    // MARK: - Private
+
+    /// Zero a single slot's conv + rec state in place.
+    private func zeroSlot(_ slot: Int) {
+        let convZ = MLXArray.zeros(
+            [kernelMinusOne, convDim], dtype: convState.dtype)
+        let recZ = MLXArray.zeros([Hv, Dv, Dk], dtype: .float32)
+        convState[slot, 0..., 0...] = convZ
+        recState[slot, 0..., 0..., 0...] = recZ
+    }
+}
+
+// MARK: - BatchedHybridCache
+
+/// Polymorphic per-layer batched cache for hybrid models that interleave
+/// attention layers and linear (GDN/Mamba-style) layers.
+///
+/// Layers are kept in lockstep: every `addSlot`/`removeSlot` propagates to
+/// every layer cache, so `active` is consistent across the model.
+public class BatchedHybridCache {
+    public enum BatchedLayerCache {
+        case attention(BatchedKVCache)
+        case gdn(BatchedMambaCache)
+    }
+
+    public let layers: [BatchedLayerCache]
+
+    /// All layers stay in lockstep — `active` is read from the first layer.
+    public var active: Int {
+        guard let first = layers.first else { return 0 }
+        switch first {
+        case .attention(let c): return c.active
+        case .gdn(let c): return c.active
+        }
+    }
+
+    public init(layers: [BatchedLayerCache]) {
+        precondition(!layers.isEmpty, "BatchedHybridCache: must have at least one layer")
+        self.layers = layers
+    }
+
+    /// Add a new request slot to every layer. Returns the slot index
+    /// (consistent across all layers).
+    @discardableResult
+    public func addSlot() -> Int {
+        var assigned = -1
+        for layer in layers {
+            let slot: Int
+            switch layer {
+            case .attention(let c): slot = c.addRequest()
+            case .gdn(let c): slot = c.addSlot()
+            }
+            if assigned < 0 { assigned = slot }
+            assert(slot == assigned,
+                   "BatchedHybridCache: layer slot \(slot) drifted from \(assigned)")
+        }
+        return assigned
+    }
+
+    /// Remove a slot from every layer. Swap-from-end semantics; caller is
+    /// responsible for re-mapping any external slot→request bookkeeping.
+    public func removeSlot(_ slot: Int) {
+        for layer in layers {
+            switch layer {
+            case .attention(let c):
+                // BatchedKVCache uses swap-from-end too; mirror it.
+                let last = c.active - 1
+                if slot != last {
+                    c.keys[slot, 0..., 0..., 0...] = c.keys[last, 0..., 0..., 0...]
+                    c.values[slot, 0..., 0..., 0...] = c.values[last, 0..., 0..., 0...]
+                    c.offsets[slot] = c.offsets[last]
+                }
+                c.offsets[last] = 0
+                c.active -= 1
+            case .gdn(let c):
+                c.removeSlot(slot)
+            }
+        }
+    }
+
+    /// Reset all slots across every layer.
+    public func reset() {
+        for layer in layers {
+            switch layer {
+            case .attention(let c): c.reset()
+            case .gdn(let c): c.reset()
+            }
+        }
+    }
+}
+
+// MARK: - BatchedHybridLLM
+
+/// Models that can do fully-batched decode through a hybrid (attention + GDN)
+/// stack should conform to this protocol. The bridge can `as?`-cast and
+/// dispatch fully batched if available; otherwise it falls back to the
+/// sequential per-request decode path.
+public protocol BatchedHybridLLM: AnyObject {
+    /// Single-step batched decode. `inputs` shape: `[B, 1]`. Returns
+    /// `[B, 1, vocab]` logits.
+    func fullyBatchedDecode(_ inputs: MLXArray, caches: BatchedHybridCache) -> MLXArray
+
+    /// Build a fresh `BatchedHybridCache` sized for `maxBatch` requests.
+    func newBatchedHybridCache(
+        maxBatch: Int, parameters: GenerateParameters?
+    ) -> BatchedHybridCache
+}

--- a/Tests/MLXLMTests/BatchedHybridCacheTests.swift
+++ b/Tests/MLXLMTests/BatchedHybridCacheTests.swift
@@ -1,0 +1,275 @@
+// Copyright © 2026 Tom Turney. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+import MLX
+import MLXLMCommon
+import Testing
+
+@Suite("BatchedHybridCache + BatchedMambaCache")
+struct BatchedHybridCacheTests {
+
+    // MARK: - BatchedMambaCache
+
+    @Test
+    func `addSlot increments active and zero-inits new slot`() throws {
+        let cache = BatchedMambaCache(
+            maxBatch: 4, kernelMinusOne: 3, convDim: 8, Hv: 2, Dv: 4, Dk: 4
+        )
+        #expect(cache.active == 0)
+
+        let slot0 = cache.addSlot()
+        #expect(slot0 == 0)
+        #expect(cache.active == 1)
+
+        let slot1 = cache.addSlot()
+        #expect(slot1 == 1)
+        #expect(cache.active == 2)
+
+        // Both newly-added slots must be exactly zero.
+        let convSlot0 = cache.convState[0, 0..., 0...]
+        let recSlot0 = cache.recState[0, 0..., 0..., 0...]
+        #expect(convSlot0.sum().item(Float.self) == 0)
+        #expect(recSlot0.sum().item(Float.self) == 0)
+    }
+
+    @Test
+    func `addSlot wipes stale state after slot reuse`() throws {
+        // The critical invariant from the design doc: if slot N is freed and
+        // re-allocated later (via swap-from-end), the next addSlot must
+        // zero-init it.
+        let cache = BatchedMambaCache(
+            maxBatch: 3, kernelMinusOne: 2, convDim: 4, Hv: 1, Dv: 2, Dk: 2
+        )
+
+        cache.addSlot()  // 0
+        cache.addSlot()  // 1
+        cache.addSlot()  // 2
+
+        // Stuff slot 1 with non-zero state to simulate active GDN history
+        let convFill = MLXArray.ones([2, 4], dtype: cache.convState.dtype) * 7.5
+        let recFill = MLXArray.ones([1, 2, 2], dtype: .float32) * 3.25
+        cache.convState[1, 0..., 0...] = convFill
+        cache.recState[1, 0..., 0..., 0...] = recFill
+
+        // Remove slot 0 → swap-from-end pulls slot 2 into 0; old slot 2 is
+        // now garbage. active = 2.
+        cache.removeSlot(0)
+        #expect(cache.active == 2)
+
+        // Stuff the (now garbage) tail position 2 to make sure the next
+        // addSlot wipes it.
+        cache.convState[2, 0..., 0...] =
+            MLXArray.ones([2, 4], dtype: cache.convState.dtype) * 11.0
+        cache.recState[2, 0..., 0..., 0...] =
+            MLXArray.ones([1, 2, 2], dtype: .float32) * 13.0
+
+        // Re-allocate slot 2.
+        let reused = cache.addSlot()
+        #expect(reused == 2)
+
+        let convReused = cache.convState[2, 0..., 0...]
+        let recReused = cache.recState[2, 0..., 0..., 0...]
+        #expect(convReused.sum().item(Float.self) == 0,
+                "stale conv leaked into reused slot")
+        #expect(recReused.sum().item(Float.self) == 0,
+                "stale rec leaked into reused slot")
+    }
+
+    @Test
+    func `removeSlot swaps from end and decrements active`() throws {
+        let cache = BatchedMambaCache(
+            maxBatch: 3, kernelMinusOne: 2, convDim: 4, Hv: 1, Dv: 2, Dk: 2
+        )
+        cache.addSlot()  // 0
+        cache.addSlot()  // 1
+        cache.addSlot()  // 2
+
+        // Distinguishable per-slot fills
+        for s in 0..<3 {
+            let v = Float(s + 1)
+            cache.convState[s, 0..., 0...] =
+                MLXArray.ones([2, 4], dtype: cache.convState.dtype) * v
+            cache.recState[s, 0..., 0..., 0...] =
+                MLXArray.ones([1, 2, 2], dtype: .float32) * v
+        }
+
+        // Remove slot 0 → slot 2 swaps in
+        cache.removeSlot(0)
+        #expect(cache.active == 2)
+
+        // Slot 0 should now hold the values that were at slot 2
+        let convAt0 = cache.convState[0, 0..., 0...]
+        let recAt0 = cache.recState[0, 0..., 0..., 0...]
+        #expect(MLX.allClose(convAt0,
+                             MLXArray.ones([2, 4], dtype: cache.convState.dtype) * 3.0,
+                             atol: 1e-6).item(Bool.self))
+        #expect(MLX.allClose(recAt0,
+                             MLXArray.ones([1, 2, 2], dtype: .float32) * 3.0,
+                             atol: 1e-6).item(Bool.self))
+
+        // Slot 1 untouched
+        let convAt1 = cache.convState[1, 0..., 0...]
+        #expect(MLX.allClose(convAt1,
+                             MLXArray.ones([2, 4], dtype: cache.convState.dtype) * 2.0,
+                             atol: 1e-6).item(Bool.self))
+    }
+
+    @Test
+    func `removeSlot of last slot is no-op data-wise`() throws {
+        let cache = BatchedMambaCache(
+            maxBatch: 2, kernelMinusOne: 2, convDim: 4, Hv: 1, Dv: 2, Dk: 2
+        )
+        cache.addSlot()  // 0
+        cache.addSlot()  // 1
+        cache.convState[0, 0..., 0...] =
+            MLXArray.ones([2, 4], dtype: cache.convState.dtype) * 5.0
+
+        cache.removeSlot(1)  // last
+        #expect(cache.active == 1)
+        let convAt0 = cache.convState[0, 0..., 0...]
+        #expect(MLX.allClose(convAt0,
+                             MLXArray.ones([2, 4], dtype: cache.convState.dtype) * 5.0,
+                             atol: 1e-6).item(Bool.self))
+    }
+
+    @Test
+    func `slice returns prefix views over active slots`() throws {
+        let cache = BatchedMambaCache(
+            maxBatch: 4, kernelMinusOne: 3, convDim: 8, Hv: 2, Dv: 4, Dk: 4
+        )
+        cache.addSlot()
+        cache.addSlot()
+        cache.addSlot()  // active = 3
+
+        let (conv, rec) = cache.slice(active: cache.active)
+        #expect(conv.shape == [3, 3, 8])
+        #expect(rec.shape == [3, 2, 4, 4])
+    }
+
+    @Test
+    func `writeback updates only active prefix`() throws {
+        let cache = BatchedMambaCache(
+            maxBatch: 3, kernelMinusOne: 2, convDim: 4, Hv: 1, Dv: 2, Dk: 2
+        )
+        cache.addSlot()
+        cache.addSlot()  // active = 2
+
+        let newConv = MLXArray.ones([2, 2, 4], dtype: cache.convState.dtype) * 9.0
+        let newRec = MLXArray.ones([2, 1, 2, 2], dtype: .float32) * 4.0
+
+        cache.writeback(conv: newConv, rec: newRec)
+
+        // Active prefix updated
+        let prefixConv = cache.convState[..<2, 0..., 0...]
+        #expect(MLX.allClose(prefixConv, newConv, atol: 1e-6).item(Bool.self))
+        let prefixRec = cache.recState[..<2, 0..., 0..., 0...]
+        #expect(MLX.allClose(prefixRec, newRec, atol: 1e-6).item(Bool.self))
+    }
+
+    @Test
+    func `recState is fp32 even when inputs are bf16`() throws {
+        let cache = BatchedMambaCache(
+            maxBatch: 2, kernelMinusOne: 2, convDim: 4, Hv: 1, Dv: 2, Dk: 2,
+            dtype: .bfloat16
+        )
+        #expect(cache.recState.dtype == .float32)
+        #expect(cache.convState.dtype == .bfloat16)
+    }
+
+    @Test
+    func `reset zeros active count`() throws {
+        let cache = BatchedMambaCache(
+            maxBatch: 3, kernelMinusOne: 2, convDim: 4, Hv: 1, Dv: 2, Dk: 2
+        )
+        cache.addSlot()
+        cache.addSlot()
+        #expect(cache.active == 2)
+        cache.reset()
+        #expect(cache.active == 0)
+    }
+
+    // MARK: - BatchedHybridCache lockstep
+
+    @Test
+    func `addSlot keeps every layer in lockstep`() throws {
+        let layers: [BatchedHybridCache.BatchedLayerCache] = [
+            .gdn(BatchedMambaCache(
+                maxBatch: 4, kernelMinusOne: 3, convDim: 8,
+                Hv: 2, Dv: 4, Dk: 4)),
+            .attention(BatchedKVCache(
+                maxBatch: 4, kvHeads: 2, headDim: 16, maxSeq: 32,
+                dtype: .bfloat16)),
+            .gdn(BatchedMambaCache(
+                maxBatch: 4, kernelMinusOne: 3, convDim: 8,
+                Hv: 2, Dv: 4, Dk: 4)),
+            .attention(BatchedKVCache(
+                maxBatch: 4, kvHeads: 2, headDim: 16, maxSeq: 32,
+                dtype: .bfloat16)),
+        ]
+        let hybrid = BatchedHybridCache(layers: layers)
+
+        #expect(hybrid.active == 0)
+
+        let s0 = hybrid.addSlot()
+        #expect(s0 == 0)
+        #expect(hybrid.active == 1)
+
+        let s1 = hybrid.addSlot()
+        #expect(s1 == 1)
+        #expect(hybrid.active == 2)
+
+        // Verify every layer reports the same active count
+        for layer in hybrid.layers {
+            switch layer {
+            case .attention(let c): #expect(c.active == 2)
+            case .gdn(let c): #expect(c.active == 2)
+            }
+        }
+    }
+
+    @Test
+    func `removeSlot keeps every layer in lockstep`() throws {
+        let layers: [BatchedHybridCache.BatchedLayerCache] = [
+            .gdn(BatchedMambaCache(
+                maxBatch: 3, kernelMinusOne: 2, convDim: 4,
+                Hv: 1, Dv: 2, Dk: 2)),
+            .attention(BatchedKVCache(
+                maxBatch: 3, kvHeads: 1, headDim: 8, maxSeq: 16,
+                dtype: .bfloat16)),
+        ]
+        let hybrid = BatchedHybridCache(layers: layers)
+
+        hybrid.addSlot()
+        hybrid.addSlot()
+        hybrid.addSlot()
+        #expect(hybrid.active == 3)
+
+        hybrid.removeSlot(1)
+        #expect(hybrid.active == 2)
+        for layer in hybrid.layers {
+            switch layer {
+            case .attention(let c): #expect(c.active == 2)
+            case .gdn(let c): #expect(c.active == 2)
+            }
+        }
+    }
+
+    @Test
+    func `reset clears every layer`() throws {
+        let layers: [BatchedHybridCache.BatchedLayerCache] = [
+            .gdn(BatchedMambaCache(
+                maxBatch: 2, kernelMinusOne: 2, convDim: 4,
+                Hv: 1, Dv: 2, Dk: 2)),
+            .attention(BatchedKVCache(
+                maxBatch: 2, kvHeads: 1, headDim: 8, maxSeq: 16,
+                dtype: .bfloat16)),
+        ]
+        let hybrid = BatchedHybridCache(layers: layers)
+        hybrid.addSlot()
+        hybrid.addSlot()
+        #expect(hybrid.active == 2)
+        hybrid.reset()
+        #expect(hybrid.active == 0)
+    }
+}

--- a/Tests/MLXLMTests/Qwen35BatchedHybridCacheTests.swift
+++ b/Tests/MLXLMTests/Qwen35BatchedHybridCacheTests.swift
@@ -179,6 +179,73 @@ struct Qwen35BatchedHybridCacheTests {
         }
     }
 
+    /// Regression test for issue #8 phase 6 bug 2: identical inputs and identical
+    /// per-slot state in `fullyBatchedDecode` must produce identical outputs across
+    /// every slot. The original bug: `MLX.split(convOut, axis: -1)` returns
+    /// non-contiguous slices, and the GDN Metal kernel uses raw pointer arithmetic
+    /// with assumed contiguous strides. At B=1 the wrong stride coincidentally
+    /// landed on correct data (single-slot, no inter-slot confusion), but at B>1
+    /// the kernel read into the wrong slot's region of memory. Fix: `.contiguous()`
+    /// on q/k/v after the split (Qwen35.swift, Qwen3Next.swift). This test
+    /// explicitly exercises the per-slot equivalence invariant against the live
+    /// model forward — without the fix, slots 1+ would diverge from slot 0.
+    @Test
+    func `fullyBatchedDecode produces identical outputs for identical inputs across slots`() async throws {
+        // Use a config whose GDN dims match a metallib kernel instantiation
+        // (Dk=128, Dv=128, Hk=16, Hv=16 → bfloat16). The default makeDenseConfig()
+        // uses tiny dims that aren't pre-instantiated and crashes test runs.
+        let json = """
+            {
+                "model_type": "qwen3_5",
+                "hidden_size": 64,
+                "num_hidden_layers": 4,
+                "intermediate_size": 128,
+                "num_attention_heads": 8,
+                "num_key_value_heads": 2,
+                "linear_num_value_heads": 16,
+                "linear_num_key_heads": 16,
+                "linear_key_head_dim": 128,
+                "linear_value_head_dim": 128,
+                "linear_conv_kernel_dim": 4,
+                "rms_norm_eps": 1e-6,
+                "vocab_size": 256,
+                "rope_theta": 10000.0,
+                "partial_rotary_factor": 0.25,
+                "max_position_embeddings": 512,
+                "tie_word_embeddings": true,
+                "attention_bias": false,
+                "head_dim": 8,
+                "full_attention_interval": 4
+            }
+            """.data(using: .utf8)!
+        let cfg = try JSONDecoder().decode(Qwen35TextConfiguration.self, from: json)
+
+        let model = Qwen35TextModel(cfg)
+        // Cast all parameters to bf16 so the Metal kernel finds its instantiation.
+        eval(model)
+        let bf16Params = model.parameters().mapValues { (v: MLXArray) in v.asType(.bfloat16) }
+        try model.update(parameters: bf16Params, verify: [.noUnusedKeys])
+        eval(model)
+
+        let B = 4
+        let cache = model.newBatchedHybridCache(maxBatch: B, parameters: nil)
+        for _ in 0..<B { cache.addSlot() }
+
+        // Same input token in every slot → identical inputs/state → identical
+        // outputs across slots. Any divergence is the kernel-stride bug.
+        let inputs = MLXArray.full([B, 1], values: MLXArray(Int32(7)), dtype: .int32)
+        let logits = model.fullyBatchedDecode(inputs, caches: cache)
+        eval(logits)
+
+        let lastLogits = logits[0..., -1, 0...]  // [B, vocab]
+        let slot0 = lastLogits[0]
+        for s in 1..<B {
+            let diff = (lastLogits[s] - slot0).abs().max().item(Float.self)
+            #expect(diff == 0,
+                    "slot \(s) logits diverged from slot 0 by max abs \(diff) — Metal kernel non-contiguous stride bug")
+        }
+    }
+
     @Test
     func `cache shape matches Qwen35 configuration`() throws {
         let cfg = try Self.makeDenseConfig()

--- a/Tests/MLXLMTests/Qwen35BatchedHybridCacheTests.swift
+++ b/Tests/MLXLMTests/Qwen35BatchedHybridCacheTests.swift
@@ -1,0 +1,210 @@
+// Copyright © 2026 Tom Turney. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Cache-layout / lifecycle coverage for the BatchedHybridCache produced by
+// Qwen35TextModel.newBatchedHybridCache. End-to-end forward correctness
+// against the per-request iterator path is deferred to Phase 6.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import Testing
+
+@Suite("Qwen35Model BatchedHybridLLM cache lifecycle")
+struct Qwen35BatchedHybridCacheTests {
+
+    // Constants mirror the JSON below — kept here so we don't depend on
+    // internal-access fields of Qwen35TextConfiguration.
+    fileprivate enum DenseShape {
+        static let hiddenLayers = 4
+        static let fullAttentionInterval = 4   // → layers 0,1,2 GDN; layer 3 attention
+        static let linearConvKernelDim = 4
+        static let linearKeyHeadDim = 16
+        static let linearNumKeyHeads = 2
+        static let linearValueHeadDim = 16
+        static let linearNumValueHeads = 4
+        static let kvHeads = 2
+        static let headDim = 8
+    }
+
+    /// Minimal dense Qwen3.5-style configuration. Layer count is a multiple of
+    /// `fullAttentionInterval` so we exercise both GDN and attention slots.
+    private static func makeDenseConfig() throws -> Qwen35TextConfiguration {
+        let json = """
+            {
+                "model_type": "qwen3_5",
+                "hidden_size": 64,
+                "num_hidden_layers": \(DenseShape.hiddenLayers),
+                "intermediate_size": 128,
+                "num_attention_heads": 8,
+                "num_key_value_heads": \(DenseShape.kvHeads),
+                "linear_num_value_heads": \(DenseShape.linearNumValueHeads),
+                "linear_num_key_heads": \(DenseShape.linearNumKeyHeads),
+                "linear_key_head_dim": \(DenseShape.linearKeyHeadDim),
+                "linear_value_head_dim": \(DenseShape.linearValueHeadDim),
+                "linear_conv_kernel_dim": \(DenseShape.linearConvKernelDim),
+                "rms_norm_eps": 1e-6,
+                "vocab_size": 256,
+                "rope_theta": 10000.0,
+                "partial_rotary_factor": 0.25,
+                "max_position_embeddings": 512,
+                "tie_word_embeddings": true,
+                "attention_bias": false,
+                "head_dim": \(DenseShape.headDim),
+                "full_attention_interval": \(DenseShape.fullAttentionInterval)
+            }
+            """.data(using: .utf8)!
+        return try JSONDecoder().decode(Qwen35TextConfiguration.self, from: json)
+    }
+
+    @Test
+    func `newBatchedHybridCache produces correct per-layer types`() throws {
+        let cfg = try Self.makeDenseConfig()
+        let model = Qwen35TextModel(cfg)
+        let cache = model.newBatchedHybridCache(maxBatch: 4, parameters: nil)
+
+        #expect(cache.layers.count == DenseShape.hiddenLayers)
+        #expect(cache.active == 0)
+
+        // Layer pattern: isLinear = (layerIdx + 1) % fullAttentionInterval != 0
+        // With fullAttentionInterval=4 and 4 layers: indices 0,1,2 are GDN,
+        // index 3 is attention.
+        for (i, layer) in cache.layers.enumerated() {
+            let expectAttention = ((i + 1) % DenseShape.fullAttentionInterval == 0)
+            switch layer {
+            case .attention:
+                #expect(expectAttention,
+                        "layer \(i) is attention but pattern expects GDN")
+            case .gdn:
+                #expect(!expectAttention,
+                        "layer \(i) is GDN but pattern expects attention")
+            }
+        }
+    }
+
+    @Test
+    func `addSlot keeps every Qwen35 layer in lockstep`() throws {
+        let cfg = try Self.makeDenseConfig()
+        let model = Qwen35TextModel(cfg)
+        let cache = model.newBatchedHybridCache(maxBatch: 3, parameters: nil)
+
+        let s0 = cache.addSlot()
+        #expect(s0 == 0)
+        #expect(cache.active == 1)
+
+        let s1 = cache.addSlot()
+        #expect(s1 == 1)
+        #expect(cache.active == 2)
+
+        // Every layer must report the same active count.
+        for layer in cache.layers {
+            switch layer {
+            case .attention(let c): #expect(c.active == 2)
+            case .gdn(let c): #expect(c.active == 2)
+            }
+        }
+    }
+
+    @Test
+    func `removeSlot keeps every Qwen35 layer in lockstep`() throws {
+        let cfg = try Self.makeDenseConfig()
+        let model = Qwen35TextModel(cfg)
+        let cache = model.newBatchedHybridCache(maxBatch: 3, parameters: nil)
+
+        cache.addSlot()
+        cache.addSlot()
+        cache.addSlot()
+        #expect(cache.active == 3)
+
+        cache.removeSlot(1)
+        #expect(cache.active == 2)
+        for layer in cache.layers {
+            switch layer {
+            case .attention(let c): #expect(c.active == 2)
+            case .gdn(let c): #expect(c.active == 2)
+            }
+        }
+    }
+
+    @Test
+    func `GDN slot reuse zero-inits stale state on Qwen35 cache`() throws {
+        // Mirrors the BatchedMambaCache slot-reuse invariant test, but driven
+        // through the Qwen35-shaped cache.
+        let cfg = try Self.makeDenseConfig()
+        let model = Qwen35TextModel(cfg)
+        let cache = model.newBatchedHybridCache(maxBatch: 3, parameters: nil)
+
+        cache.addSlot()
+        cache.addSlot()
+        cache.addSlot()
+
+        // Find the first GDN layer and stuff its slot 1 with non-zero state.
+        var gdnLayer: BatchedMambaCache?
+        for layer in cache.layers {
+            if case .gdn(let c) = layer { gdnLayer = c; break }
+        }
+        let gdn = try #require(gdnLayer)
+        let convFill = MLXArray.ones(
+            [gdn.kernelMinusOne, gdn.convDim], dtype: gdn.convState.dtype) * 7.5
+        gdn.convState[1, 0..., 0...] = convFill
+
+        // removeSlot(0) → slot 2 swaps in. active = 2.
+        cache.removeSlot(0)
+
+        // Now scribble garbage into the freed tail position 2 across all GDN
+        // layers, then re-allocate it. addSlot must wipe.
+        for layer in cache.layers {
+            if case .gdn(let c) = layer {
+                c.convState[2, 0..., 0...] =
+                    MLXArray.ones([c.kernelMinusOne, c.convDim],
+                                  dtype: c.convState.dtype) * 11.0
+                c.recState[2, 0..., 0..., 0...] =
+                    MLXArray.ones([c.Hv, c.Dv, c.Dk], dtype: .float32) * 13.0
+            }
+        }
+
+        let reused = cache.addSlot()
+        #expect(reused == 2)
+
+        for layer in cache.layers {
+            if case .gdn(let c) = layer {
+                let convReused = c.convState[2, 0..., 0...]
+                let recReused = c.recState[2, 0..., 0..., 0...]
+                #expect(convReused.sum().item(Float.self) == 0,
+                        "stale GDN conv leaked into reused slot")
+                #expect(recReused.sum().item(Float.self) == 0,
+                        "stale GDN rec leaked into reused slot")
+            }
+        }
+    }
+
+    @Test
+    func `cache shape matches Qwen35 configuration`() throws {
+        let cfg = try Self.makeDenseConfig()
+        let model = Qwen35TextModel(cfg)
+        let cache = model.newBatchedHybridCache(maxBatch: 2, parameters: nil)
+
+        let expectedKernelMinusOne = DenseShape.linearConvKernelDim - 1
+        let expectedKeyDim = DenseShape.linearKeyHeadDim * DenseShape.linearNumKeyHeads
+        let expectedValueDim = DenseShape.linearValueHeadDim * DenseShape.linearNumValueHeads
+        let expectedConvDim = expectedKeyDim * 2 + expectedValueDim
+
+        for layer in cache.layers {
+            switch layer {
+            case .gdn(let c):
+                #expect(c.maxBatch == 2)
+                #expect(c.kernelMinusOne == expectedKernelMinusOne)
+                #expect(c.convDim == expectedConvDim)
+                #expect(c.Hv == DenseShape.linearNumValueHeads)
+                #expect(c.Dv == DenseShape.linearValueHeadDim)
+                #expect(c.Dk == DenseShape.linearKeyHeadDim)
+            case .attention(let c):
+                #expect(c.maxBatch == 2)
+                #expect(c.kvHeads == DenseShape.kvHeads)
+                #expect(c.headDim == DenseShape.headDim)
+                #expect(c.maxSeq == 2048)  // default when parameters == nil
+            }
+        }
+    }
+}

--- a/Tests/MLXLMTests/Qwen35MoEBatchedHybridCacheTests.swift
+++ b/Tests/MLXLMTests/Qwen35MoEBatchedHybridCacheTests.swift
@@ -1,0 +1,139 @@
+// Copyright © 2026 Tom Turney. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Cache-layout / lifecycle coverage for Qwen3.6 (Qwen35MoEModel). The MoE
+// variant inherits BatchedHybridLLM conformance from Qwen35Model — the only
+// model-side diff is that dense MLP becomes Qwen35SparseMoeBlock. The cache
+// layout is identical to the dense Qwen3.5 case, so we just verify lifecycle
+// against an MoE-flavored configuration here. End-to-end forward correctness
+// is deferred to Phase 6.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import Testing
+
+@Suite("Qwen35MoEModel BatchedHybridLLM cache lifecycle")
+struct Qwen35MoEBatchedHybridCacheTests {
+
+    // Constants mirror the JSON below — kept here so we don't depend on
+    // internal-access fields of Qwen35TextConfiguration / Qwen35Configuration.
+    fileprivate enum MoEShape {
+        static let hiddenLayers = 4
+        static let fullAttentionInterval = 4   // → layers 0,1,2 GDN; layer 3 attention
+        static let linearConvKernelDim = 4
+        static let linearKeyHeadDim = 16
+        static let linearNumKeyHeads = 2
+        static let linearValueHeadDim = 16
+        static let linearNumValueHeads = 4
+        static let kvHeads = 2
+        static let headDim = 8
+    }
+
+    /// Minimal MoE Qwen3.6-style configuration. Set num_experts > 0 so the
+    /// decoder layer wires Qwen35SparseMoeBlock. Layer count is a multiple of
+    /// fullAttentionInterval so we exercise both GDN and attention slots.
+    private static func makeMoEConfig() throws -> Qwen35Configuration {
+        let json = """
+            {
+                "model_type": "qwen3_5_moe",
+                "hidden_size": 64,
+                "num_hidden_layers": \(MoEShape.hiddenLayers),
+                "intermediate_size": 128,
+                "num_attention_heads": 8,
+                "num_key_value_heads": \(MoEShape.kvHeads),
+                "linear_num_value_heads": \(MoEShape.linearNumValueHeads),
+                "linear_num_key_heads": \(MoEShape.linearNumKeyHeads),
+                "linear_key_head_dim": \(MoEShape.linearKeyHeadDim),
+                "linear_value_head_dim": \(MoEShape.linearValueHeadDim),
+                "linear_conv_kernel_dim": \(MoEShape.linearConvKernelDim),
+                "rms_norm_eps": 1e-6,
+                "vocab_size": 256,
+                "rope_theta": 10000.0,
+                "partial_rotary_factor": 0.25,
+                "max_position_embeddings": 512,
+                "tie_word_embeddings": true,
+                "attention_bias": false,
+                "head_dim": \(MoEShape.headDim),
+                "full_attention_interval": \(MoEShape.fullAttentionInterval),
+                "num_experts": 4,
+                "num_experts_per_tok": 2,
+                "decoder_sparse_step": 1,
+                "shared_expert_intermediate_size": 64,
+                "moe_intermediate_size": 64,
+                "norm_topk_prob": true
+            }
+            """.data(using: .utf8)!
+        return try JSONDecoder().decode(Qwen35Configuration.self, from: json)
+    }
+
+    @Test
+    func `Qwen35MoEModel inherits BatchedHybridLLM and exposes cache layout`() throws {
+        let cfg = try Self.makeMoEConfig()
+        let model = Qwen35MoEModel(cfg)
+        // Inherited surface is reachable from the subclass.
+        let cache = model.newBatchedHybridCache(maxBatch: 4, parameters: nil)
+
+        #expect(cache.layers.count == MoEShape.hiddenLayers)
+        #expect(cache.active == 0)
+
+        for (i, layer) in cache.layers.enumerated() {
+            let expectAttention = ((i + 1) % MoEShape.fullAttentionInterval == 0)
+            switch layer {
+            case .attention: #expect(expectAttention)
+            case .gdn: #expect(!expectAttention)
+            }
+        }
+    }
+
+    @Test
+    func `addSlot/removeSlot lockstep on Qwen35MoE cache`() throws {
+        let cfg = try Self.makeMoEConfig()
+        let model = Qwen35MoEModel(cfg)
+        let cache = model.newBatchedHybridCache(maxBatch: 3, parameters: nil)
+
+        cache.addSlot()
+        cache.addSlot()
+        cache.addSlot()
+        #expect(cache.active == 3)
+
+        cache.removeSlot(0)
+        #expect(cache.active == 2)
+        for layer in cache.layers {
+            switch layer {
+            case .attention(let c): #expect(c.active == 2)
+            case .gdn(let c): #expect(c.active == 2)
+            }
+        }
+
+        cache.reset()
+        #expect(cache.active == 0)
+    }
+
+    @Test
+    func `MoE cache shape matches Qwen3.6 configuration`() throws {
+        let cfg = try Self.makeMoEConfig()
+        let model = Qwen35MoEModel(cfg)
+        let cache = model.newBatchedHybridCache(maxBatch: 2, parameters: nil)
+
+        let expectedKernelMinusOne = MoEShape.linearConvKernelDim - 1
+        let expectedKeyDim = MoEShape.linearKeyHeadDim * MoEShape.linearNumKeyHeads
+        let expectedValueDim = MoEShape.linearValueHeadDim * MoEShape.linearNumValueHeads
+        let expectedConvDim = expectedKeyDim * 2 + expectedValueDim
+
+        for layer in cache.layers {
+            switch layer {
+            case .gdn(let c):
+                #expect(c.kernelMinusOne == expectedKernelMinusOne)
+                #expect(c.convDim == expectedConvDim)
+                #expect(c.Hv == MoEShape.linearNumValueHeads)
+                #expect(c.Dv == MoEShape.linearValueHeadDim)
+                #expect(c.Dk == MoEShape.linearKeyHeadDim)
+            case .attention(let c):
+                #expect(c.kvHeads == MoEShape.kvHeads)
+                #expect(c.headDim == MoEShape.headDim)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the throughput-flatness bug for Qwen3Next, Qwen3.5, and Qwen3.6 hybrid models (alternating GatedDeltaNet + attention layers). Today they fall back to per-request sequential decode at B>1 because `BatchedKVCache` only models attention; this PR adds a hybrid cache + per-model batched-forward + a Metal-kernel correctness fix.

Tracking: vllm-swift bug report at https://github.com/TheTom/vllm-swift/issues/8 (B=1/8/32/64 = 19 tok/s flat on Qwen3.6-27B before this work).

## Changes

### New types — `Libraries/MLXLMCommon/BatchedHybridCache.swift`

- `BatchedMambaCache` — pre-allocated `[maxBatch, kernel-1, convDim]` conv state + `[maxBatch, Hv, Dv, Dk]` fp32 recurrent state. Zero-inits per slot in `addSlot()` (not in `init`) — prevents stale state leaks across reused slots after `removeSlot` swaps.
- `BatchedHybridCache` — composes `BatchedKVCache` (attention layers) and `BatchedMambaCache` (GDN layers) per `BatchedLayerCache` enum. Lockstep `active` count across layers.
- `BatchedHybridLLM` protocol — `fullyBatchedDecode(_:caches:) -> MLXArray` + `newBatchedHybridCache(maxBatch:parameters:)`. Bridge dispatches via this protocol cast.

### Per-model batched forward

- `Libraries/MLXLLM/Models/Qwen3Next.swift` — `Qwen3NextModel: BatchedHybridLLM` + `fullyBatchedDecode` + `Qwen3NextModelInner.fullyBatchedForward` + per-block `fullyBatchedForward` on `Qwen3NextAttention`, `Qwen3NextGatedDeltaNet`, `Qwen3NextDecoderLayer`.
- `Libraries/MLXLLM/Models/Qwen35.swift` — same surface for `Qwen35TextModel` + forwarding `Qwen35Model: BatchedHybridLLM`.
- `Libraries/MLXLLM/Models/Qwen35MoE.swift` — inherits via `Qwen35MoEModel: Qwen35Model`. Existing batched MoE expert routing already shape-agnostic over leading dims; no new code needed for MoE batching.

### GDN kernel correctness fix (the load-bearing piece)

GDN Metal kernel (`gated_delta_step`, `gated_delta_step_fused`) reads q/k/v with raw pointer arithmetic and assumed contiguous strides:

```cpp
auto q_ = q + b_idx * T_val * Hk * Dk + hk_idx * Dk;
```

`MLX.split(convOut, indices: [keyDim, 2*keyDim], axis: -1)` returns non-contiguous slice views — stride along axis 1 is `convDim`, not `keyDim`/`valueDim`. At B=1 only `b_idx=0` is used so the stride mismatch never matters. At B>1 the kernel reads cross-slot → garbage tokens for slots 1+.

Fix: `.contiguous()` on q/k/v after split + reshape, in both `Qwen35GatedDeltaNet` and `Qwen3NextGatedDeltaNet` (`callAsFunction` + `fullyBatchedForward` in each). Cost is one materialisation per layer per step — negligible vs. the kernel dispatch.

## Tests

`Tests/MLXLMTests/BatchedHybridCacheTests.swift`, `Qwen35BatchedHybridCacheTests.swift`, `Qwen35MoEBatchedHybridCacheTests.swift` — 19 unit tests covering cache lifecycle (`addSlot`/`removeSlot`/`active` count/zero-init on slot reuse), per-model cache shape, and the **per-slot equivalence regression test** for the GDN contiguous fix.

The regression test (`fullyBatchedDecode produces identical outputs for identical inputs across slots`) bisects the Metal-kernel bug exactly:

**With fix:** `passed`.

**Without fix (deliberately reverted):**
```
✘ slot 1 logits diverged from slot 0 by max abs 0.046875
✘ slot 2 logits diverged from slot 0 by max abs 0.037109375
✘ slot 3 logits diverged from slot 0 by max abs 0.015625
```

All 19 hybrid tests pass under `make build-tests` + xctest. Pre-existing test suites (BaseConfiguration, ChatSession, Eval, KVCache, etc.) still pass.

## Performance verification (M5 Max 128GB)

### vllm-swift bug #8 user repro — Qwen3.6-27B-UD-MLX-4bit

| B | Reported (broken) | Now | Scaling |
|---|---:|---:|---:|
| 1 | 18.6 | 20.1 | 1.0× |
| 8 | 19.0 | 63.8 | **3.2×** |
| 32 | 19.1 | 176.3 | **9×** |
| 64 | 19.1 | **305.6** | **16×** |

### Hybrid sweep — all scale

| Model | B=1 decode | B=8 | B=32 | B=64 |
|---|---:|---:|---:|---:|
| Qwen3.5-2B-4bit | 280 | 828 | 1,549 | **2,029** |
| Qwen3.5-9B-4bit | 92 | 261 | 542 | **781** |
| Qwen3.5-35B-A3B-4bit (MoE) | 134 | 369 | 616 | **994** |
| Qwen3.6-27B-UD-MLX-4bit | 20 | 64 | 176 | **306** |

### Dense Qwen3 regression — zero regression

| Cell | Result | Baseline | Δ |
|---|---:|---:|---:|
| Qwen3-4B p18 B=64 | 1,513 | 1,492 | +1.4% |
| Qwen3-0.6B p18 B=64 | 3,362 | 3,282 | +2.4% |
| Qwen3-4B p2048 B=64 unique | 770 | 760 | +1.3% |
| Qwen3-4B p8192 B=64 unique | 273 | 269 | +1.5%, no OOM |

Dense fast path bit-identical (per-model `Qwen3Model` cast unchanged; bridge does `as? Qwen3Model` first then `as? any BatchedHybridLLM`).

## Risks

1. **fp32 recurrent state cost** — `[maxBatch=64, Hv, Dv, Dk]` fp32 ≈ 128 MB per GDN layer × ~24 layers = ~3 GB additional VRAM at B=64. Acceptable on 128 GB unified memory; tight on 64 GB for 27B-class hybrids.
2. **Slot reuse correctness** — covered by the `addSlot` zero-init + `slot 2 stale state leak` test.
3. **fp16 batch-shape sensitivity** — covered by per-slot equivalence test (zero-tolerance: max abs == 0).

## Out of scope

- Bridge integration (`vllm-swift` ships separately — see https://github.com/TheTom/vllm-swift PR for `BatchedHybridLLM` dispatch + `prefill_batched_uniform` hybrid path).
- Other hybrid families (NemotronH, MiniMax, etc.) — same pattern applies but not covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)