### PR TITLE
perf(turbo-kv): replace eval barrier with dtype round-trip in compressedAttention (closes #87 properly)

### DIFF
--- a/Libraries/MLXLMCommon/TurboQuantKVCache.swift
+++ b/Libraries/MLXLMCommon/TurboQuantKVCache.swift
@@ -1490,7 +1490,7 @@ public class TurboQuantKVCache: BaseKVCache {
             .reshaped([B * nKVHeads, tokenCount])
 
         let valRotation = valueMSECodec.rotation
-        let output: MLXArray
+        var output: MLXArray
 
         if rawKeyMode {
             // ═══ Raw-K + Compressed-V path ═══
@@ -1589,20 +1589,23 @@ public class TurboQuantKVCache: BaseKVCache {
                     valRotation: valRotation
                 ).reshaped([B, nQHeads, L, headDim])
 
-                // Sync eval barrier required on small-nKVH shapes — workaround for
-                // upstream MLX graph-compile fusion bug (#92): the lazy graph
-                // compiler fuses TurboFlash output into downstream consumer ops in a
-                // way that aliases buffers before the kernel has finished writing,
-                // producing garbage on Qwen3.5 nKVH=2 shapes (closes #87) and on
-                // Gemma 4 (text repetition collapse). Numerical A/B vs the separated
-                // path confirms the kernel itself produces correct values; the bug
-                // is in the rewriter, not in the Metal kernel. Gate keeps shapes
-                // with nKVH ≥ 4 on the fast no-barrier path (~40% decode tok/s
-                // saved). asyncEval doesn't break the fusion — must be sync.
-                // Remove this once #92 lands an upstream fix.
-                if nKVHeads < 4 {
-                    eval(output)
-                }
+                // Dtype round-trip defeats the MLX graph-compile fusion bug
+                // (#87 / #92) without forcing a sync materialization. The
+                // previous workaround was a gated `eval(output)` on
+                // `nKVHeads < 4` shapes, which serialized the per-layer
+                // decode loop and cost ~22% decode tok/s on Qwen3.5-2B and
+                // ~38% on 0.8B at 4K context. The cast also covers
+                // `nKVH >= 4` shapes (e.g. Qwen3.5-9B) that the gated
+                // barrier missed and that empirically emit `!!!!!` on
+                // B-path without it.
+                //
+                // TurboFlash outputs FP32; consuming code expects model
+                // dtype (BF16). Casting here was logically required anyway,
+                // and the explicit cast node is a fusion boundary the
+                // rewriter does not cross. No sync wait, no perf cost.
+                //
+                // Remove this once #92 lands an upstream fix to the fuser.
+                output = output.asType(queries.dtype)
                 if profiling {
                     let t1 = Date()
                     Self.profileValueMs += t1.timeIntervalSince(t0) * 1000  // flash+eval time


### PR DESCRIPTION
## Purpose

Restores TurboQuant B-path (`useCompressedAttention=true`) decode performance and fixes a coherency bug on `nKVH >= 4` shapes that the original `#87` mitigation missed.

`ac4cfc5 fix(turbo-kv): eval barrier after TurboFlash on nKVH=2 shapes (closes #87)` introduced a sync `eval(output)` after every TurboFlash kernel call, gated on `nKVHeads < 4`, to defeat the MLX graph-compile fusion bug (`#87`/`#92`). Two problems:

1. **Sync barrier serializes the per-layer decode loop.** Bisect on alpha showed B-path decode dropped 22-38% on the gated shapes between `a17e042` (Tom's parallel `ek-alpha-fixes` branch, which used a dtype-cast workaround) and `ac4cfc5` (alpha mainline, which used the eval barrier). Subsequent commits on alpha (`5ecd0e4`, `42b40cc`, `c1bc795`, `b55c199`) did not change the gated barrier, so the regression has been in place since `ac4cfc5` landed.

2. **The `nKVH < 4` gate misses `nKVH = 4` shapes.** The original assumption was that the fusion bug only affects small-`nKVH` shapes. Empirically, Qwen3.5-9B (nKVH=4) on B-path with current alpha emits `!!!!!` from the first decode token. The eval barrier never fires on 9B (gate fails), so the fusion bug corrupts every decode step.

## Fix

Replace the gated `eval(output)` with an unconditional dtype round-trip:

```diff
-                if nKVHeads < 4 {
-                    eval(output)
-                }
+                output = output.asType(queries.dtype)
```

Plus changing the `output` declaration from `let` to `var` so the reassignment compiles.

The MLX fuser does not cross an explicit cast node, so the cast defeats the fusion bug the same way the eval barrier did, but without forcing a sync wait. TurboFlash outputs FP32 and consuming code expects model dtype (BF16), so the cast was logically required anyway. The unconditional cast covers all `nKVH` values, so 9B and any other `nKVH >= 4` shape on B-path is no longer broken.

This is the same correctness mechanism Tom validated in `a17e042` on the parallel `ek-alpha-fixes` branch back in PR #93.

## Bench

Single-stream summarization, 400 decode tokens, 4K context, M5 Max 128GB. B-path forced via `useCompressedAttention=true`.

| Cell | nKVH | Before (alpha TOT) | After (this PR) | Delta tok/s | Coherency before -> after |
|---|---|---|---|---|---|
| Qwen3.5-0.8B turbo4v2 4K | 2 | 194.7 tok/s | **268.0 tok/s** | **+37.6%** | ok -> ok |
| Qwen3.5-2B turbo4v2 4K | 2 | 167.0 tok/s | **203.6 tok/s** | **+21.9%** | ok -> ok |
| Qwen3.5-9B turbo4v2 4K | 4 |  80.2 tok/s + `!!!!!` | **80.8 tok/s** | +0.7% | **broken -> ok** |

KV cache stored size unchanged across the patch on every cell (10 / 10 / 25 MB). Peak GPU unchanged (e.g. 2B at 2.26 GB before and after).

The 2B "after" number (203.6) matches Tom's `a17e042` reference on the same cell (202.9), within run-to-run noise. The patch fully restores the historical tom-eric branch performance.

## Test plan

- [x] Qwen3.5-0.8B turbo4v2 4K, B-path forced (nKVH=2)
- [x] Qwen3.5-2B turbo4v2 4K, B-path forced (nKVH=2)
- [x] Qwen3.5-9B turbo4v2 4K, B-path forced (nKVH=4) - includes coherency restoration
- [ ] Gemma 4 (e2b, e4b) B-path - the original `ac4cfc5` comment cited Gemma 4 text repetition collapse as another failure mode; validating dtype-cast covers it
- [ ] 32K context on the same cells - confirm recovery is not context-dependent
- [ ] B=16, B=64 batched decode - eval barrier cost is about pipelining, may compound at higher B

Validation in flight; will update this PR with results.

## Notes

- A path (default, `useCompressedAttention=false`) is untouched. No risk to default users.
- Public API unchanged.
- The fix is unconditional vs the original gated workaround, so it is strictly stronger correctness. If `nKVH >= 4` shapes were silently broken on B-path before, they aren't anymore.
- Underlying MLX fuser bug `#87`/`#92` is still upstream. This PR is a workaround, not a fix for the upstream bug. If MLX patches the fuser, this entire `output = output.asType(queries.dtype)` line can be deleted.

Marked draft pending the additional Gemma 4 and 32K / batched validation. Will mark ready once those land or any failures come up.

AI assistance was used in the bisect, diff analysis, and patch drafting.
