### PR TITLE
fix(turbo-kv): replace eval barrier with dtype cast in compressedAttention (#87/#92)

### DIFF
--- a/Libraries/MLXLMCommon/TurboQuantKVCache.swift
+++ b/Libraries/MLXLMCommon/TurboQuantKVCache.swift
@@ -1490,7 +1490,7 @@ public class TurboQuantKVCache: BaseKVCache {
             .reshaped([B * nKVHeads, tokenCount])
 
         let valRotation = valueMSECodec.rotation
-        let output: MLXArray
+        var output: MLXArray
 
         if rawKeyMode {
             // ═══ Raw-K + Compressed-V path ═══
@@ -1589,20 +1589,19 @@ public class TurboQuantKVCache: BaseKVCache {
                     valRotation: valRotation
                 ).reshaped([B, nQHeads, L, headDim])
 
-                // Sync eval barrier required on small-nKVH shapes — workaround for
-                // upstream MLX graph-compile fusion bug (#92): the lazy graph
-                // compiler fuses TurboFlash output into downstream consumer ops in a
-                // way that aliases buffers before the kernel has finished writing,
-                // producing garbage on Qwen3.5 nKVH=2 shapes (closes #87) and on
-                // Gemma 4 (text repetition collapse). Numerical A/B vs the separated
-                // path confirms the kernel itself produces correct values; the bug
-                // is in the rewriter, not in the Metal kernel. Gate keeps shapes
-                // with nKVH ≥ 4 on the fast no-barrier path (~40% decode tok/s
-                // saved). asyncEval doesn't break the fusion — must be sync.
-                // Remove this once #92 lands an upstream fix.
-                if nKVHeads < 4 {
-                    eval(output)
-                }
+                // Workaround for upstream MLX graph-compile fusion bug (#87/#92):
+                // the lazy graph compiler fuses TurboFlash output into downstream
+                // consumer ops in a way that aliases buffers before the kernel
+                // has finished writing, producing garbage on multiple shapes.
+                // The bug is shape-dependent in non-obvious ways — not just
+                // nKVH count: Qwen3.5-9B (nKVH=4) also emits `!!!!!` on alpha
+                // TOT B-path without this mitigation. An unconditional dtype
+                // cast (TurboFlash outputs fp32, consumer expects model dtype)
+                // creates a graph boundary that defeats the fusion without the
+                // sync wait of `eval(output)` (which cost 40-60% decode tok/s
+                // on the previously-gated `nKVH < 4` path). Same approach as
+                // a17e042 / Tom's PR #102. Remove once #92 lands upstream.
+                output = output.asType(queries.dtype)
                 if profiling {
                     let t1 = Date()
                     Self.profileValueMs += t1.timeIntervalSince(t0) * 1000  // flash+eval time


### PR DESCRIPTION
## Summary

B path correctness fix + decode tok/s recovery. Replaces the gated `eval(output)` sync barrier added in `ac4cfc5` with an unconditional `output = output.asType(queries.dtype)` cast. Same mechanism as TheTom's PR #102 / commit `a17e042`, minus the env-var bench plumbing.

The MLX graph-compile fuser does not cross an explicit cast node, so the cast defeats the upstream fusion bug (#87/#92) the same way the eval barrier did, but without forcing a sync wait. TurboFlash outputs FP32 and consuming code expects model dtype (BF16), so the cast was logically required anyway.

## Why this fixes things

### 1. The eval barrier was serializing per-layer decode

`ac4cfc5` added `if nKVHeads < 4 { eval(output) }` after every TurboFlash decode kernel call. The sync wait drops decode tok/s significantly on the gated shapes.

### 2. The `nKVHeads < 4` gate misses `nKVH = 4` shapes

Originally the assumption was the fusion bug only affects small-`nKVH`. Empirically Qwen3.5-9B (`nKVH=4`) on B path emits `!!!!!` from the first decode token on current alpha — the gate fails, eval never fires, fusion bug corrupts every step. Unconditional cast covers all `nKVH` values.

## Bench (M1 Max 64GB, summarization, 4-bit weights, 400 generated tokens, B path forced)

| Cell | nKVH | eval-barrier | dtype-cast | Δ |
|---|---:|---:|---:|---:|
| Qwen3.5-0.8B 1k turbo4v2 | 2 | 58.7 | **120.8** | +106% |
| Qwen3.5-0.8B 32k turbo4v2 | 2 | 34.3 | **52.3** | +52% |
| Nemotron 30B 1k turbo4v2 | 8 | 17.9 | **60.9** | +240% |
| Nemotron 30B 32k turbo4v2 | 8 | 15.0 | **43.2** | +188% |

The Nemotron numbers (where the `nKVHeads < 4` gate doesn't fire and no eval was happening) suggest the fusion bug is shape-dependent in non-obvious ways, not just nKVH-count-dependent — the cast helps independently. (Tom: \"depends on attention-tile or block-decomposition shape, not just nKVH.\")

## Coherency

Qwen3.5-9B turbo4v2 4K B path: was emitting `!!!!!` on alpha TOT, now produces \"Thinking Process: ...\" reasoning output. Smoke spot-checked across all cells in the bench above — coherent every cell.

## Scope

- **B path only**: `useCompressedAttention = true`. A path (alpha default) is unchanged.
- **Single-stream only**: known crash at B=16 batched decode with this same cast applied (TheTom flagged in #102 — Metal `Invalid Resource` in the prefill encoder, indirect interaction). **Tracked as #103**, not a blocker for B=1 (chat / summarization / single-doc inference).
- **No routing change**: L=1 still routes through the A default. Users wanting B opt in via `useCompressedAttention=true` per-cache.
- **No new tests**: existing summarization smoke covers the coherency + speed claims.

## What this doesn't do

- Doesn't beat A path for single-stream decode tok/s (A still wins by 15-49% across the bench above). This is a B-path *correctness fix* + *recovery*, not a routing change.
- Doesn't reduce peak GPU vs A. Peak is dominated by prefill working buffers, not the KV path — independently profiled (transient memory peak−pre-active is identical between A and B+cast on Qwen 0.8B 32k and Nemotron 30B 32k).

## Test plan

- [x] `make build-tests` clean
- [x] Smoke: Qwen3.5-0.8B / Qwen3.5-9B / Nemotron 30B-A3B at 1k/4k/32k, turbo4v2, B path forced. Coherent every cell. Decode tok/s table above.
- [ ] Reviewer to spot-check at least one decode sample per model
- [ ] B≥16 batched decode crash investigation tracked in #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)