### PR TITLE
refactor(turbo-kv): replace invasive eval-barrier profiling with os_signpost intervals

### DIFF
--- a/Libraries/MLXLMCommon/AttentionUtils.swift
+++ b/Libraries/MLXLMCommon/AttentionUtils.swift
@@ -42,26 +42,36 @@ public func attentionWithCacheUpdate(
     sinks: MLXArray? = nil
 ) -> MLXArray {
     guard let cache else {
-        return MLXFast.scaledDotProductAttention(
-            queries: queries,
-            keys: keys,
-            values: values,
-            scale: scale,
-            mask: mask,
-            sinks: sinks
-        )
+        // Cache-less path (rare). Wrap the SDPA call so it shows up in traces
+        // alongside cache-backed paths for comparability.
+        return BenchmarkSignpost.interval(BenchmarkSignpost.PhaseLabel.sdpa) {
+            MLXFast.scaledDotProductAttention(
+                queries: queries,
+                keys: keys,
+                values: values,
+                scale: scale,
+                mask: mask,
+                sinks: sinks
+            )
+        }
     }
     if let turboCache = cache as? TurboQuantKVCache {
         let L = queries.dim(2)
         if L > 1 {
             // Prefill (L>1): raw update + standard SDPA. Zero overhead.
+            let updH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.kvUpdate)
             let (cachedKeys, cachedValues) = turboCache.update(keys: keys, values: values)
-            return MLXFast.scaledDotProductAttention(
-                queries: queries, keys: cachedKeys, values: cachedValues,
-                scale: scale, mask: mask, sinks: sinks
-            )
+            BenchmarkSignpost.end(updH)
+            return BenchmarkSignpost.interval(BenchmarkSignpost.PhaseLabel.sdpa) {
+                MLXFast.scaledDotProductAttention(
+                    queries: queries, keys: cachedKeys, values: cachedValues,
+                    scale: scale, mask: mask, sinks: sinks
+                )
+            }
         }
         // B opt-in: compressed-domain Metal kernels. Sinks not supported.
+        // `compressedAttention` emits its own tq_encode/tq_score/tq_value/tq_rotate
+        // sub-phase signposts internally — don't double-wrap here.
         if turboCache.useCompressedAttention {
             if sinks != nil {
                 fatalError(
@@ -79,38 +89,50 @@ public func attentionWithCacheUpdate(
         // updateAndDequant returns raw K/V; prepareQueries/inverseRotateOutput
         // are no-ops in A — SDPA is invariant to the codec's orthogonal rotation
         // applied to both Q and K, so we skip the rotation entirely.
+        let updH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.kvUpdate)
         let (rotKeys, rotValues) = turboCache.updateAndDequant(keys: keys, values: values)
+        BenchmarkSignpost.end(updH)
         let rotQueries = turboCache.prepareQueries(queries)
-        let rotOutput = MLXFast.scaledDotProductAttention(
-            queries: rotQueries, keys: rotKeys, values: rotValues,
-            scale: scale, mask: mask, sinks: sinks
-        )
+        let rotOutput = BenchmarkSignpost.interval(BenchmarkSignpost.PhaseLabel.sdpa) {
+            MLXFast.scaledDotProductAttention(
+                queries: rotQueries, keys: rotKeys, values: rotValues,
+                scale: scale, mask: mask, sinks: sinks
+            )
+        }
         return turboCache.inverseRotateOutput(rotOutput)
     } else if let quantizedKVCache = cache as? QuantizedKVCacheProtocol {
         if sinks != nil {
             fatalError("Affine quantized attention does not support non-zero sinks.")
         }
+        let updH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.kvUpdate)
         let (quantizedKeys, quantizedValues) = quantizedKVCache.updateQuantized(
             keys: keys, values: values)
-        return quantizedScaledDotProductAttention(
-            queries: queries,
-            quantizedKeys: quantizedKeys,
-            quantizedValues: quantizedValues,
-            scale: scale,
-            mask: mask,
-            groupSize: quantizedKVCache.groupSize,
-            bits: quantizedKVCache.bits,
-            mode: quantizedKVCache.mode
-        )
+        BenchmarkSignpost.end(updH)
+        return BenchmarkSignpost.interval(BenchmarkSignpost.PhaseLabel.qsdpa) {
+            quantizedScaledDotProductAttention(
+                queries: queries,
+                quantizedKeys: quantizedKeys,
+                quantizedValues: quantizedValues,
+                scale: scale,
+                mask: mask,
+                groupSize: quantizedKVCache.groupSize,
+                bits: quantizedKVCache.bits,
+                mode: quantizedKVCache.mode
+            )
+        }
     } else {
+        let updH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.kvUpdate)
         let (cachedKeys, cachedValues) = cache.update(keys: keys, values: values)
-        return MLXFast.scaledDotProductAttention(
-            queries: queries,
-            keys: cachedKeys,
-            values: cachedValues,
-            scale: scale,
-            mask: mask,
-            sinks: sinks
-        )
+        BenchmarkSignpost.end(updH)
+        return BenchmarkSignpost.interval(BenchmarkSignpost.PhaseLabel.sdpa) {
+            MLXFast.scaledDotProductAttention(
+                queries: queries,
+                keys: cachedKeys,
+                values: cachedValues,
+                scale: scale,
+                mask: mask,
+                sinks: sinks
+            )
+        }
     }
 }

--- a/Libraries/MLXLMCommon/BenchmarkSignpost.swift
+++ b/Libraries/MLXLMCommon/BenchmarkSignpost.swift
@@ -58,17 +58,17 @@ import os
 /// fires once per generated token with metadata `(token_idx, token_id,
 /// tokens_generated_so_far)` — enough to correlate individual tokens
 /// with the CPU samples and GPU command buffers that produced them.
-enum BenchmarkSignpost {
+public enum BenchmarkSignpost {
 
     /// Fixed subsystem identifier. Filter on this in Instruments to
     /// isolate benchmark-specific signposts.
-    static let subsystem = "ai.mlx.bench"
+    public static let subsystem = "ai.mlx.bench"
 
     /// Gated activation — only true when `MLX_BENCH_PROFILE >= 2`.
     /// Checking this once at init and storing into an `OSLog` that is
     /// either `.pointsOfInterest` (active) or `.disabled` (no-op) lets
     /// the signpost API's own fast path handle zero-cost gating.
-    static let enabled: Bool = {
+    public static let enabled: Bool = {
         guard let raw = ProcessInfo.processInfo.environment["MLX_BENCH_PROFILE"],
               let level = Int(raw) else {
             return false
@@ -79,7 +79,7 @@ enum BenchmarkSignpost {
     /// Shared log handle. Resolves to `.disabled` when the env gate
     /// is off — all signpost calls against a disabled log are no-ops
     /// inside the OS and never cross into the kernel.
-    static let log: OSLog = {
+    public static let log: OSLog = {
         if enabled {
             return OSLog(subsystem: subsystem, category: .pointsOfInterest)
         } else {
@@ -91,23 +91,43 @@ enum BenchmarkSignpost {
     /// signpost intervals by name, so phases with the same label
     /// stack vertically in the timeline. Typed as `StaticString`
     /// because `os_signpost` requires a compile-time name.
-    enum PhaseLabel {
-        static let modelLoad:       StaticString = "model_load"
-        static let promptPrep:      StaticString = "prompt_prep"
-        static let prefill:         StaticString = "prefill"
-        static let decodeStep:      StaticString = "decode_step"
-        static let sampler:         StaticString = "sampler"
-        static let kldBaseline:     StaticString = "kld_baseline"
-        static let kldForcedDecode: StaticString = "kld_forced_decode"
+    public enum PhaseLabel {
+        // ── Lifecycle phases (emitted from `Tests/Benchmarks/InferenceBenchmark.swift`)
+        public static let modelLoad:       StaticString = "model_load"
+        public static let promptPrep:      StaticString = "prompt_prep"
+        public static let prefill:         StaticString = "prefill"
+        public static let decodeStep:      StaticString = "decode_step"
+        public static let sampler:         StaticString = "sampler"
+        public static let kldBaseline:     StaticString = "kld_baseline"
+        public static let kldForcedDecode: StaticString = "kld_forced_decode"
+
+        // ── Attention sub-phases (emitted from `attentionWithCacheUpdate`).
+        // Apply to all KV cache variants (KVCacheSimple, RotatingKVCache,
+        // QuantizedKVCacheProtocol, TurboQuant A path). Lets us compare
+        // phase breakdown across cache types on the same axes.
+        public static let kvUpdate:  StaticString = "kv_update"   // cache.update / updateAndDequant / updateQuantized
+        public static let sdpa:      StaticString = "sdpa"        // MLXFast.scaledDotProductAttention
+        public static let qsdpa:     StaticString = "qsdpa"       // quantizedScaledDotProductAttention (affine path)
+
+        // ── TurboQuant B path (`compressedAttention`) phase intervals.
+        // Nest inside `decode_step` (alongside `kv_update`/`sdpa` for
+        // other cache types). Correlate with MLX's per-kernel-dispatch
+        // signposts (subsystem `ai.mlx.metal`) in Metal System Trace to
+        // attribute GPU time per phase.
+        public static let tqEncode:  StaticString = "tq_encode"   // encodeNewToken
+        public static let tqScore:   StaticString = "tq_score"    // Q*K (matmul or compressed mseScore)
+        public static let tqSoftmax: StaticString = "tq_softmax"  // softmax over scores (separated path)
+        public static let tqValue:   StaticString = "tq_value"    // Attn*V (TurboFlash or mseWeightedSum)
+        public static let tqRotate:  StaticString = "tq_rotate"   // Q rotation + inverse value rotation
     }
 
     /// Interval handle — returned by `begin`, consumed by `end`.
     /// Wraps an `OSSignpostID` so the call sites read cleanly and
     /// nothing leaks when signposts are disabled (the ID is just a
     /// `UInt64` either way).
-    struct IntervalHandle {
-        let id: OSSignpostID
-        let name: StaticString
+    public struct IntervalHandle {
+        public let id: OSSignpostID
+        public let name: StaticString
     }
 
     /// Begin a labelled interval. `label` must be a `StaticString`
@@ -115,7 +135,7 @@ enum BenchmarkSignpost {
     /// dynamic format strings keeps the kernel path branch-free.
     /// Use the constants in `PhaseLabel` to get compile-time strings.
     @inline(__always)
-    static func begin(
+    public static func begin(
         _ label: StaticString,
         metadata: String = ""
     ) -> IntervalHandle {
@@ -132,7 +152,7 @@ enum BenchmarkSignpost {
     /// signposts are disabled — `handle.id` is still valid, and the
     /// disabled log's `.end` emission short-circuits.
     @inline(__always)
-    static func end(
+    public static func end(
         _ handle: IntervalHandle,
         metadata: String = ""
     ) {
@@ -153,7 +173,7 @@ enum BenchmarkSignpost {
     /// ```
     @inline(__always)
     @discardableResult
-    static func interval<T>(
+    public static func interval<T>(
         _ label: StaticString,
         metadata: String = "",
         _ body: () throws -> T
@@ -166,7 +186,7 @@ enum BenchmarkSignpost {
     /// Async variant.
     @inline(__always)
     @discardableResult
-    static func intervalAsync<T>(
+    public static func intervalAsync<T>(
         _ label: StaticString,
         metadata: String = "",
         _ body: () async throws -> T
@@ -180,7 +200,7 @@ enum BenchmarkSignpost {
     /// boundaries that don't naturally span a closure (e.g. first
     /// token arrival).
     @inline(__always)
-    static func event(
+    public static func event(
         _ label: StaticString,
         metadata: String = ""
     ) {

--- a/Libraries/MLXLMCommon/TurboQuantKVCache.swift
+++ b/Libraries/MLXLMCommon/TurboQuantKVCache.swift
@@ -707,31 +707,6 @@ public class MSECodec {
 /// algorithmic details.
 public class TurboQuantKVCache: BaseKVCache {
 
-    // Profiling accumulators (static so they accumulate across all layers).
-    // Enabled by MLX_BENCH_PROFILE=3 (forces eval per phase — invasive).
-    nonisolated(unsafe) static var profileEncodeMs: Double = 0
-    nonisolated(unsafe) static var profileScoreMs: Double = 0
-    nonisolated(unsafe) static var profileValueMs: Double = 0
-    nonisolated(unsafe) static var profileRotateMs: Double = 0
-    nonisolated(unsafe) static var profileOtherMs: Double = 0
-    nonisolated(unsafe) static var profileCount: Int = 0
-
-    /// Print and reset profiling stats.
-    public static func printProfile() {
-        guard profileCount > 0 else { return }
-        let total = profileEncodeMs + profileScoreMs + profileValueMs + profileRotateMs + profileOtherMs
-        let perToken = total / Double(profileCount)
-        print("[TURBO-PROFILE] \(profileCount) decode steps across all layers:")
-        print("[TURBO-PROFILE]   encode:  \(String(format: "%.1f", profileEncodeMs))ms (\(String(format: "%.0f", profileEncodeMs / total * 100))%)")
-        print("[TURBO-PROFILE]   score:   \(String(format: "%.1f", profileScoreMs))ms (\(String(format: "%.0f", profileScoreMs / total * 100))%)")
-        print("[TURBO-PROFILE]   value:   \(String(format: "%.1f", profileValueMs))ms (\(String(format: "%.0f", profileValueMs / total * 100))%)")
-        print("[TURBO-PROFILE]   rotate:  \(String(format: "%.1f", profileRotateMs))ms (\(String(format: "%.0f", profileRotateMs / total * 100))%)")
-        print("[TURBO-PROFILE]   other:   \(String(format: "%.1f", profileOtherMs))ms (\(String(format: "%.0f", profileOtherMs / total * 100))%)")
-        print("[TURBO-PROFILE]   total:   \(String(format: "%.1f", total))ms (\(String(format: "%.2f", perToken))ms/step)")
-        profileEncodeMs = 0; profileScoreMs = 0; profileValueMs = 0
-        profileRotateMs = 0; profileOtherMs = 0; profileCount = 0
-    }
-
     public let bits: Int         // Legacy: used when keyBits == valueBits
     public let keyBits: Int      // Bit-width for key compression (0 = raw FP16, no compression)
     public let valueBits: Int    // Bit-width for value compression (can be lower — V compression is nearly free)
@@ -1447,20 +1422,17 @@ public class TurboQuantKVCache: BaseKVCache {
             compressRawCache()
         }
 
-
-        // Level 3: per-phase TQ decode profiling (forces eval per phase — invasive)
-        let profiling = (Int(ProcessInfo.processInfo.environment["MLX_BENCH_PROFILE"] ?? "0") ?? 0) >= 3
-        var t0 = Date()
-
-        // Phase A: Encode new token directly into compressed storage.
+        // Phase: encode new token into compressed storage.
+        // Wrapped in `tqEncode` signpost interval — captured by Instruments
+        // / xctrace under `MLX_BENCH_PROFILE=2`. Zero overhead when off.
+        let encH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.tqEncode)
         offset += newKeys.dim(2)
         let savedOffset = offset
         offset = compressedWriteOffset
         encodeNewToken(keys: newKeys, values: newValues)
         compressedWriteOffset = offset
         offset = savedOffset
-        if profiling { eval(valPackedMSE!, valNorms!); if let kp = keyPackedMSE, let kn = keyNorms { eval(kp, kn) }; let t1 = Date(); Self.profileEncodeMs += t1.timeIntervalSince(t0) * 1000; t0 = t1 }
-
+        BenchmarkSignpost.end(encH)
 
         guard let valueMSECodec else {
             return queries
@@ -1496,7 +1468,6 @@ public class TurboQuantKVCache: BaseKVCache {
             // ═══ Raw-K + Compressed-V path ═══
             // Standard matmul for Q*K (raw FP16 keys, no rotation needed).
             // Compressed-domain Metal kernel for Attn*V weighted sum.
-            if profiling { eval(valPackedMSE!); let t1 = Date(); Self.profileEncodeMs += t1.timeIntervalSince(t0) * 1000; t0 = t1 }
 
             // Q*K scoring: standard matmul with raw FP16 keys
             guard let rk = rawKeys else { return queries }
@@ -1514,10 +1485,12 @@ public class TurboQuantKVCache: BaseKVCache {
             }
 
             // scores = Q * K^T * scale  → [B, nQHeads, L, T]
+            let scH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.tqScore)
             var scores = matmul(queries, expandedKeys.transposed(0, 1, 3, 2)) * scale
-            if profiling { eval(scores); let t1 = Date(); Self.profileScoreMs += t1.timeIntervalSince(t0) * 1000; t0 = t1 }
+            BenchmarkSignpost.end(scH)
 
             // Mask + softmax
+            let smH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.tqSoftmax)
             switch mask {
             case .array(let maskArray):
                 if maskArray.dtype == .bool {
@@ -1534,32 +1507,34 @@ public class TurboQuantKVCache: BaseKVCache {
             }
 
             let attnWeights = softmax(scores, axis: -1)
-            if profiling { eval(attnWeights); let t1 = Date(); Self.profileOtherMs += t1.timeIntervalSince(t0) * 1000; t0 = t1 }
+            BenchmarkSignpost.end(smH)
 
             // Metal V kernel: compressed-domain weighted sum
+            let vH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.tqValue)
             let flatWeights = attnWeights.reshaped([B * nQHeads * L, tokenCount])
             let rotatedOutput = TurboQuantKernelOps.mseWeightedSum(
                 weights: flatWeights, packed: flatValPacked, norms: flatValNorms,
                 codebook: valueMSECodec.codebook, tokenCount: tokenCount,
                 repeatCount: nRepeats, bits: self.valueBits, dim: headDim
             )
+            BenchmarkSignpost.end(vH)
 
             // Inverse value rotation
+            let rH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.tqRotate)
             output = matmul(
                 rotatedOutput.reshaped([B, nQHeads, L, headDim]),
                 valueMSECodec.rotation
             )
-
-            if profiling { eval(output); let t1 = Date(); Self.profileValueMs += t1.timeIntervalSince(t0) * 1000; t0 = t1 }
+            BenchmarkSignpost.end(rH)
         } else {
             // ═══ Standard TurboQuant path: both K and V compressed ═══
             guard let keyMSECodec else { return queries }
 
-            if profiling { eval(keyPackedMSE!, valPackedMSE!); let t1 = Date(); Self.profileEncodeMs += t1.timeIntervalSince(t0) * 1000; t0 = t1 }
-
             // Pre-rotate query for compressed-domain K scoring
+            let rH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.tqRotate)
             let qRot = keyMSECodec.prepareQueries(queries) * scale
             let flatQ = qRot.reshaped([B * nQHeads * L, headDim])
+            BenchmarkSignpost.end(rH)
 
             // K slicing
             let flatKeyPacked = keyPackedMSE![0..., 0..., ..<tokenCount, 0...]
@@ -1577,7 +1552,8 @@ public class TurboQuantKVCache: BaseKVCache {
             }()
 
             if L == 1 && hasTurboFlashKernel {
-                // TurboFlashAttention path (decode, L=1)
+                // TurboFlashAttention path (decode, L=1) — fuses score + softmax + value.
+                let vH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.tqValue)
                 output = TurboQuantKernelOps.turboFlashAttention(
                     rotatedQueries: flatQ,
                     keyPacked: flatKeyPacked, keyNorms: flatKeyNorms,
@@ -1602,21 +1578,10 @@ public class TurboQuantKVCache: BaseKVCache {
                 // on the previously-gated `nKVH < 4` path). Same approach as
                 // a17e042 / Tom's PR #102. Remove once #92 lands upstream.
                 output = output.asType(queries.dtype)
-                if profiling {
-                    let t1 = Date()
-                    Self.profileValueMs += t1.timeIntervalSince(t0) * 1000  // flash+eval time
-                    Self.profileCount += 1
-                    if Self.profileCount % 50 == 0 {
-                        let encMs = Self.profileEncodeMs / Double(Self.profileCount)
-                        let flashMs = Self.profileValueMs / Double(Self.profileCount)
-                        let totalMs = encMs + flashMs
-                        print(String(format: "[TQ-PROFILE] %d steps: encode=%.2fms flash+eval=%.2fms total=%.2fms (%.0f tok/s per-layer)",
-                            Self.profileCount, encMs, flashMs, totalMs, 1000.0/totalMs))
-                    }
-                    t0 = t1
-                }
+                BenchmarkSignpost.end(vH)
             } else if case .causal = mask, hasTurboFlashKernel {
                 // Causal TurboFlashAttention path (prefill, L>1)
+                let vH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.tqValue)
                 let queryOffset = tokenCount - L
                 output = TurboQuantKernelOps.turboFlashAttentionCausal(
                     rotatedQueries: flatQ,
@@ -1629,18 +1594,19 @@ public class TurboQuantKVCache: BaseKVCache {
                     queryChunkLength: L, queryOffset: queryOffset,
                     valRotation: valRotation
                 ).reshaped([B, nQHeads, L, headDim])
-                if profiling { eval(output); let t1 = Date(); Self.profileScoreMs += t1.timeIntervalSince(t0) * 1000; t0 = t1 }
+                BenchmarkSignpost.end(vH)
             } else {
                 // Separated path: Metal score kernel
+                let scH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.tqScore)
                 var scores = TurboQuantKernelOps.mseScore(
                     rotatedQueries: flatQ, packed: flatKeyPacked, norms: flatKeyNorms,
                     codebook: keyMSECodec.codebook, tokenCount: tokenCount,
                     repeatCount: nRepeats, bits: self.keyBits, dim: headDim
                 ).reshaped([B, nQHeads, L, tokenCount])
-
-                if profiling { eval(scores); let t1 = Date(); Self.profileScoreMs += t1.timeIntervalSince(t0) * 1000; t0 = t1 }
+                BenchmarkSignpost.end(scH)
 
                 // Mask + softmax
+                let smH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.tqSoftmax)
                 switch mask {
                 case .array(let maskArray):
                     if maskArray.dtype == .bool {
@@ -1651,25 +1617,28 @@ public class TurboQuantKVCache: BaseKVCache {
                 }
 
                 let attnWeights = softmax(scores, axis: -1)
-                if profiling { eval(attnWeights); let t1 = Date(); Self.profileOtherMs += t1.timeIntervalSince(t0) * 1000; t0 = t1 }
+                BenchmarkSignpost.end(smH)
 
                 // Metal value kernel
+                let vH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.tqValue)
                 let flatWeights2 = attnWeights.reshaped([B * nQHeads * L, tokenCount])
                 let rotatedOutput = TurboQuantKernelOps.mseWeightedSum(
                     weights: flatWeights2, packed: flatValPacked, norms: flatValNorms,
                     codebook: valueMSECodec.codebook, tokenCount: tokenCount,
                     repeatCount: nRepeats, bits: self.valueBits, dim: headDim
                 )
+                BenchmarkSignpost.end(vH)
 
                 // Inverse rotation
+                let irH = BenchmarkSignpost.begin(BenchmarkSignpost.PhaseLabel.tqRotate)
                 output = matmul(
                     rotatedOutput.reshaped([B, nQHeads, L, headDim]),
                     valueMSECodec.rotation
                 )
+                BenchmarkSignpost.end(irH)
             }
         }
 
-        Self.profileCount += 1
         return output
     }
 

--- a/Tests/Benchmarks/InferenceBenchmark.swift
+++ b/Tests/Benchmarks/InferenceBenchmark.swift
@@ -944,6 +944,11 @@ struct InferenceBenchmarks {
         //   captured by Instruments / xctrace. See
         //   `BenchmarkSignpost.swift` for the recording procedure.
         //   Overhead is ~40 ns per event when no tracer is attached.
+        //   Includes TurboQuant compressedAttention sub-phases
+        //   (`tq_encode`, `tq_score`, `tq_softmax`, `tq_value`,
+        //   `tq_rotate`) — correlate with MLX's per-kernel signposts
+        //   (subsystem `ai.mlx.metal`) in Metal System Trace to
+        //   attribute GPU time per phase.
         //
         // Level 1 only adds a few timestamps + post-run arithmetic →
         // zero measurable impact on decode throughput. Level 2 adds


### PR DESCRIPTION
## Summary

Replaces the Level-3 (`MLX_BENCH_PROFILE=3`) invasive per-phase profiler in `compressedAttention` with `os_signpost` intervals using the existing `BenchmarkSignpost` infrastructure already used for lifecycle phases. Also adds `kv_update` / `sdpa` / `qsdpa` wrapping in `attentionWithCacheUpdate` so non-turbo cache types (KVCacheSimple / RotatingKVCache / affine quantized) get the same internal-phase visibility — letting us compare A path / B path / `--kv none` / affine on the same axes in Instruments.

The Level-3 path was timing encode/score/value/rotate by inserting `eval()` sync barriers between phases. That forces GPU sync **inside the hot loop we're trying to profile** — Tom's PR #102 / #104 measured 40-60% decode tok/s loss from that synchronization on small-nKVH shapes. So the profile data was distorted by the act of profiling.

`os_signpost` intervals cost ~40 ns per `begin`/`end` pair when no tracer is attached — well under 50 µs total for a 200-token decode loop.

## Changes

| File | Change |
|---|---|
| `Tests/Benchmarks/Utils/BenchmarkSignpost.swift` → `Libraries/MLXLMCommon/BenchmarkSignpost.swift` | Move to library + make `public` so `TurboQuantKVCache` and `AttentionUtils` can emit signposts. Test call sites unchanged. |
| `Libraries/MLXLMCommon/BenchmarkSignpost.swift` | +8 phase labels: `kvUpdate`, `sdpa`, `qsdpa` (any cache type) and `tqEncode`, `tqScore`, `tqSoftmax`, `tqValue`, `tqRotate` (TurboQuant B path only). |
| `Libraries/MLXLMCommon/TurboQuantKVCache.swift` | -6 static `profile*` accumulators, -`printProfile()`, -12 `if profiling { eval(...); profileXMs += ... }` blocks, -inline `[TQ-PROFILE]` print, -dead `Self.profileCount += 1`. + `BenchmarkSignpost.begin/end` wrappers per phase. |
| `Libraries/MLXLMCommon/AttentionUtils.swift` | Wrap `cache.update`/`updateAndDequant`/`updateQuantized` with `kv_update` interval and `MLXFast.scaledDotProductAttention`/`quantizedScaledDotProductAttention` with `sdpa`/`qsdpa` interval across all four routing branches (cache-less, TurboQuant A, TurboQuant B prefill, affine quantized, default). B path's `compressedAttention` is left alone since it emits its own `tq_*` sub-phase signposts internally. |
| `Tests/Benchmarks/InferenceBenchmark.swift` | Doc-comment update mentioning the new `kv_update`/`sdpa`/`qsdpa`/`tq_*` sub-phase signposts at level 2. |

Net: +129 / -113 lines.

## Capture

```
MLX_BENCH_PROFILE=2 xctrace record --template 'Metal System Trace' \
  --launch -- swift test --skip-build -c release --filter benchmark
```

Filter the resulting `.trace` to:
- subsystem `ai.mlx.bench` → lifecycle phases + per-attention-call `kv_update`/`sdpa`/`qsdpa` (and `tq_*` on B path)
- subsystem `ai.mlx.metal` → MLX's own per-kernel-dispatch signposts (already in submodule)

Metal System Trace correlates the CPU encode windows with GPU execution windows automatically — gives accurate GPU-side per-phase timing without any synchronization cost.

## Verification

Smoke on M1 Max post-refactor with `MLX_BENCH_PROFILE=2` active:

| Run | Decode tok/s |
|---|---:|
| Qwen 0.8B 4k turbo4v2 (A path), no profile | 158.0 |
| Qwen 0.8B 4k turbo4v2 (A path), `MLX_BENCH_PROFILE=2` | 159.7 |
| Qwen 0.8B 4k --kv none, `MLX_BENCH_PROFILE=2` | 161.5 |

Within noise — signposts are zero-cost when no tracer is attached. Lifecycle `[PROFILE]` breakdown still emitted as before.

## Test plan

- [x] `make build-tests` clean
- [x] A path / `--kv none` Qwen 0.8B turbo4v2 4k unchanged from baseline
- [x] `MLX_BENCH_PROFILE=2` doesn't regress decode tok/s when no tracer attached
- [ ] Reviewer to spot-check `xctrace` capture across `--kv none` / `--kv affine4` / TurboQuant A / TurboQuant B (`useCompressedAttention=true`)

## Notes

- Removes Level 3 entirely. Level 1 (wall-clock lifecycle) and Level 2 (signposts) unchanged in behavior, expanded in coverage.
- B path opt-in still requires setting `useCompressedAttention=true` at cache construction. That's a separate concern (env-var convenience for benching B path is not part of this refactor).
- Signposts measure CPU encode time, not GPU execution time. For accurate GPU-side per-kernel attribution, capture in Metal System Trace which cross-references the signpost intervals with the GPU command buffer execution windows. That's the right tool for "which kernel dominates GPU work" questions; this PR gates the data collection at zero cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)