### PR TITLE
feat(models): initial DeepSeek-V4 support (Phase 1, MIT-attributed port)

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -46,6 +46,7 @@ public enum LLMTypeRegistry {
         "openelm": create(OpenElmConfiguration.self, OpenELMModel.init),
         "internlm2": create(InternLM2Configuration.self, InternLM2Model.init),
         "deepseek_v3": create(DeepseekV3Configuration.self, DeepseekV3Model.init),
+        "deepseek_v4": create(DeepseekV4Configuration.self, DeepseekV4Model.init),
         "granite": create(GraniteConfiguration.self, GraniteModel.init),
         "granitemoehybrid": create(
             GraniteMoeHybridConfiguration.self, GraniteMoeHybridModel.init),

--- a/Libraries/MLXLLM/Models/DEEPSEEK_V4_ATTRIBUTION.md
+++ b/Libraries/MLXLLM/Models/DEEPSEEK_V4_ATTRIBUTION.md
@@ -1,0 +1,112 @@
+# DeepSeek-V4 — Upstream Attribution
+
+The Swift implementation of DeepSeek-V4 in this repository
+(`DeepseekV4.swift`, `DeepseekV4Compressor.swift`,
+`DeepseekV4Configuration.swift`, `DeepseekV4MathHelpers.swift`) is
+adapted from the open-source port at:
+
+    https://github.com/osaurus-ai/vmlx-swift-lm
+
+published by the Osaurus AI team under the MIT license. The MIT
+copyright notices on each Swift file remain on the originals; this
+fork's modifications are layered on top under the same license.
+
+## What was adapted
+
+- The full `DeepseekV4Model` forward pass, including:
+  - mHC (manifold hyper-connections) collapse / expand around each
+    decoder block.
+  - MLA attention with `head_dim=512`, `num_kv_heads=1`, partial RoPE
+    on the last 64 dims, learned per-head attention sinks, inverse RoPE
+    on the attention output, and the grouped low-rank `wo_a / wo_b`
+    output projection.
+  - Compressor + Indexer modules for the long-context pooled-attention
+    path.
+  - sqrtsoftplus MoE routing with hash routing for the first three
+    layers via a `tid2eid` table, plus the shared expert.
+  - DSV4 SwiGLU with `swiglu_limit=10` and YaRN RoPE on
+    `compress_ratio>0` layers.
+  - Per-layer `DeepseekV4Cache` composing `RotatingKVCache` with the
+    Compressor's pooled buffer.
+
+## What was changed
+
+- File-level copyright headers updated to credit both the upstream
+  Osaurus authors (MIT) and this fork's modifications.
+- Comments referring to internal-to-osaurus research documents (e.g.
+  `jang/research/...`, `EXHAUSTIVE-VARIABLES-GUIDE.md`,
+  `JANGTQ-PROGRESS-LOG`, internal bug numbers) were rewritten to be
+  self-contained.
+- Dead helper `_osaurusSanitizeUnused` was renamed to
+  `_bundleFormatSanitize` and documented as future-use rather than
+  legacy.
+- Factory registration added in `LLMModelFactory.swift` (single line).
+
+## Phase 1 status
+
+This port is **Phase 1**: the model loads from
+`mlx-community/DeepSeek-V4-Flash-2bit-DQ` and produces coherent text
+output on smoke tests, but the math is not yet bug-for-bug equivalent
+to the Python reference. Known follow-ups (tracked for Phase 2):
+
+1. Validate HC sinkhorn iteration count and fp32 boundaries against
+   Python.
+2. Apply the `swiglu_limit` clamp on the up-projection inside
+   `SwitchGLU` (currently only the gate-side silu is clamped; the
+   2-bit DQ codebook's natural boundedness regularises the
+   up-projection well enough for smoke tests, but mismatches Python).
+3. Verify Compressor + Indexer numerics for long contexts (`L >
+   sliding_window=128`). Short prompts use the bypass fast-path which
+   is exercised on every smoke test.
+4. Check inverse partial RoPE sign convention against the upstream
+   complex-conjugate path.
+5. `attn_sink` dtype + casting boundary verification.
+6. `q_norm` per-head fp32 rescale ordering vs the variance-only
+   normalization in Python.
+7. YaRN ramp / correction-range formula edge cases (low/high clamps).
+8. Hash-routing weight normalization (currently uses uniform
+   `1/topK`; Python does the same but worth a sanity check).
+9. APE positional bias inside the Compressor — verify the broadcast
+   axes match Python.
+10. Overlap transform fill values for `compress_ratio=4` — Python
+    uses `-inf` for the gate side (matched here) but we should
+    confirm the kv side fill of `0.0` is correct, not `nan`.
+11. Per-layer compress_ratio fallback table when `compress_ratios`
+    is absent from `config.json` — currently uses the DSV4-Flash
+    default; verify this matches official bundles.
+12. Routed-expert weight stacking under `switch_mlp.*` — verify the
+    `tq_packed` / `tq_norms` path against TurboQuant routed bundles.
+13. MoE down-projection `bf16 → fp16` cast safety — confirmed for
+    DSV3, needs spot-check for DSV4's wider hidden dim.
+
+## License
+
+Upstream MIT license (verbatim) preserved below.
+
+```
+MIT License
+
+Copyright (c) 2024 ml-explore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+(Note: the LICENSE file shipped with osaurus-ai/vmlx-swift-lm carries
+the standard mlx-explore MIT text — same copyright holder as the
+upstream project both repos descend from.)

--- a/Libraries/MLXLLM/Models/DeepseekV4.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4.swift
@@ -1,0 +1,1127 @@
+// Copyright © 2026 TheTom.
+// Adapted from osaurus-ai/vmlx-swift-lm (MIT) — see
+// Libraries/MLXLLM/Models/DEEPSEEK_V4_ATTRIBUTION.md for upstream license.
+//
+// Original: Copyright © 2026 Osaurus AI. SPDX-License-Identifier: MIT.
+// Upstream: https://github.com/osaurus-ai/vmlx-swift-lm
+//
+// DeepSeek-V4 (DSV4-Flash / DSV4-Pro) — full model forward.
+//
+// Architecture vs DSV3 (all new):
+//   • mHC residual stream (hc_mult=4 parallel copies, collapse/expand
+//     per block using a Sinkhorn-normalized mixing matrix)
+//   • MLA with head_dim=512, num_kv_heads=1 (single latent KV head
+//     broadcast to all 64 Q heads via GQA), RoPE only on last
+//     qk_rope_head_dim=64 dims
+//   • Learned per-head `attn_sink` logit prepended pre-softmax
+//   • Inverse RoPE on attention OUTPUT (strips positional info before
+//     residual add-back)
+//   • Grouped low-rank O projection: `bsgd,grd→bsgr` einsum with
+//     o_groups=8, o_lora_rank=1024, then wo_b to hidden_size
+//   • MoE routing via sqrtsoftplus instead of softmax
+//   • Hash routing for first num_hash_layers=3 layers (tid2eid lookup)
+//   • DSV4 SwiGLU with swiglu_limit=10.0 (clamp gate + up)
+//   • Per-layer rope_theta: 10000 for compress_ratio=0 (no YaRN),
+//     160000 for compress_ratio>0 (with YaRN)
+//   • HyperHead reduce at the top of the model (mHC copies → hidden)
+//
+// Phase 1 status (loads + runs + coherent output, but math is approximate):
+//   • Compressor + Indexer are wired but not validated against the
+//     Python reference for long contexts — short prompts (L < sliding_
+//     window=128) take a fast-path that bypasses pooled global context
+//     and works correctly. Long prompts degrade to sliding-window-only
+//     attention until Phase 2 lands.
+//   • Several numerical details (HC sinkhorn iteration count, swiglu
+//     clamp on the up-projection inside SwitchGLU, attention sink dtype,
+//     fp32 fallback boundaries) are known to differ from Python; see
+//     the attribution doc for the Phase 2 list.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// MARK: - RoPE
+
+/// DSV4 RoPE: YaRN scaling with `high = min(..., dim-1)` clamp.
+/// Per-layer theta — the layer chooses between `rope_theta=10000` (no
+/// YaRN when compress_ratio=0) and `compress_rope_theta=160000` (with
+/// YaRN scaling when compress_ratio>0).
+class DeepseekV4RoPE: Module {
+    let dim: Int
+    let base: Float
+    let factor: Float
+    let origMaxPos: Int
+    let betaFast: Float
+    let betaSlow: Float
+    // Precomputed half-dim inv-freq table — lazy so MLXNN's parameter
+    // scanner doesn't treat it as a model weight.
+    private var _invFreq: MLXArray?
+    var invFreq: MLXArray {
+        if let v = _invFreq { return v }
+        let v = DeepseekV4Math.yarnInvFreq(
+            dim: dim, base: base, maxPos: 0,
+            origMaxPos: origMaxPos, factor: factor,
+            betaFast: betaFast, betaSlow: betaSlow)
+        _invFreq = v
+        return v
+    }
+
+    init(
+        dim: Int,
+        base: Float,
+        factor: Float = 1.0,
+        origMaxPos: Int = 65536,
+        betaFast: Float = 32,
+        betaSlow: Float = 1
+    ) {
+        self.dim = dim
+        self.base = base
+        self.factor = factor
+        self.origMaxPos = origMaxPos
+        self.betaFast = betaFast
+        self.betaSlow = betaSlow
+    }
+
+    /// Compute cos/sin tables for positions `[offset, offset+L)`.
+    /// Returned shape: `(L, dim/2)`.
+    func cosSin(offset: Int, length: Int) -> (cos: MLXArray, sin: MLXArray) {
+        let positions = MLXArray(Int32(offset)..<Int32(offset + length)).asType(.float32)
+        // positions: (L,), invFreq: (dim/2,) → angles: (L, dim/2)
+        let angles = positions.expandedDimensions(axis: -1) * invFreq.expandedDimensions(axis: 0)
+        return (cos: cos(angles), sin: sin(angles))
+    }
+}
+
+// MARK: - Attention (MLA with sinks + inverse RoPE + grouped O)
+
+class DeepseekV4Attention: Module {
+    let config: DeepseekV4Configuration
+    let layerIdx: Int
+    let numHeads: Int
+    let headDim: Int
+    let ropeDim: Int
+    let qLoraRank: Int
+    let oGroups: Int
+    let oLoraRank: Int
+    /// Per-layer compress_ratio ∈ {0, 4, 128}. 0 = no compressor, plain
+    /// sliding-window attention. 4 or 128 = Compressor (+ Indexer at 4)
+    /// augments local KV with pooled global context.
+    let compressRatio: Int
+    let scale: Float
+
+    @ModuleInfo(key: "wq_a") var wqA: Linear
+    @ModuleInfo(key: "wq_b") var wqB: Linear
+    @ModuleInfo(key: "wkv") var wkv: Linear
+    // wo_a operates on PER-GROUP features (numHeads*headDim // oGroups),
+    // mapping them to oGroups*oLoraRank via einsum bsgd,grd→bsgr.
+    // Python: Linear(n_heads*head_dim // o_groups, o_groups*o_lora_rank).
+    @ModuleInfo(key: "wo_a") var woA: Linear
+    @ModuleInfo(key: "wo_b") var woB: Linear
+    /// q_norm is on `q_lora_rank` (1024), NOT head_dim. Applied BEFORE wq_b.
+    @ModuleInfo(key: "q_norm") var qNorm: RMSNorm
+    @ModuleInfo(key: "kv_norm") var kvNorm: RMSNorm
+    /// Shape (num_heads,) — one learned sink logit per head.
+    @ParameterInfo(key: "attn_sink") var attnSink: MLXArray
+
+    let rope: DeepseekV4RoPE
+
+    // Compressor + Indexer (instantiated only when compressRatio > 0).
+    // Swift can't have conditionally-present @ModuleInfo properties
+    // cleanly, so we instantiate always and null the pooled path inside
+    // forward when compressRatio == 0.
+    @ModuleInfo(key: "compressor") var compressor: DeepseekV4Compressor?
+    @ModuleInfo(key: "indexer") var indexer: DeepseekV4Indexer?
+
+    init(config: DeepseekV4Configuration, layerIdx: Int) {
+        self.config = config
+        self.layerIdx = layerIdx
+        self.numHeads = config.numAttentionHeads
+        self.headDim = config.headDim
+        self.ropeDim = config.qkRopeHeadDim
+        self.qLoraRank = config.qLoraRank
+        self.oGroups = config.oGroups
+        self.oLoraRank = config.oLoraRank
+        self.scale = 1.0 / sqrt(Float(headDim))
+
+        // Resolve per-layer compress_ratio. If config.compressRatios is
+        // populated use it directly; otherwise fall back to the default
+        // DSV4-Flash pattern (layer 0 and last → 0; middle: odd → 4,
+        // even → 128 per layer index after accounting for layer 0).
+        if !config.compressRatios.isEmpty && layerIdx < config.compressRatios.count {
+            self.compressRatio = config.compressRatios[layerIdx]
+        } else {
+            let n = config.numHiddenLayers
+            if layerIdx == 0 || layerIdx == n - 1 {
+                self.compressRatio = 0
+            } else {
+                let i = layerIdx - 1
+                self.compressRatio = (i % 2 == 1) ? 4 : 128
+            }
+        }
+
+        self._wqA.wrappedValue = Linear(config.hiddenSize, qLoraRank, bias: false)
+        self._wqB.wrappedValue = Linear(qLoraRank, numHeads * headDim, bias: false)
+        self._wkv.wrappedValue = Linear(config.hiddenSize, headDim, bias: false)
+        // wo_a: per-group features (n_heads*head_dim // o_groups) →
+        // o_groups * o_lora_rank. For DSV4-Flash: 4096 → 8192.
+        self._woA.wrappedValue = Linear(
+            numHeads * headDim / oGroups, oGroups * oLoraRank, bias: false)
+        self._woB.wrappedValue = Linear(
+            oGroups * oLoraRank, config.hiddenSize, bias: false)
+        // q_norm operates on q_lora_rank (1024), not head_dim.
+        self._qNorm.wrappedValue = RMSNorm(
+            dimensions: qLoraRank, eps: config.rmsNormEps)
+        self._kvNorm.wrappedValue = RMSNorm(
+            dimensions: headDim, eps: config.rmsNormEps)
+        self._attnSink.wrappedValue = zeros([numHeads])
+
+        // RoPE: compressRatio>0 → compress_rope_theta (160000) + YaRN.
+        // compressRatio==0 → rope_theta (10000), NO YaRN.
+        let theta =
+            compressRatio > 0 ? config.compressRopeTheta : config.ropeTheta
+        let factor: Float =
+            compressRatio > 0
+            ? Float((config.ropeScaling?["factor"]?.asFloat()) ?? 16.0)
+            : 1.0
+        let origMax =
+            Int(
+                (config.ropeScaling?["original_max_position_embeddings"]?.asInt()) ?? 65536)
+        self.rope = DeepseekV4RoPE(
+            dim: ropeDim, base: theta, factor: factor,
+            origMaxPos: origMax, betaFast: 32, betaSlow: 1)
+
+        // Compressor + Indexer are attached ONLY on layers with a
+        // non-zero compress_ratio — matches bundle weight keys.
+        if compressRatio > 0 {
+            self._compressor.wrappedValue = DeepseekV4Compressor(
+                config: config, compressRatio: compressRatio, headDim: headDim)
+            if compressRatio == 4 {
+                self._indexer.wrappedValue = DeepseekV4Indexer(
+                    config: config, compressRatio: compressRatio)
+            }
+        }
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+        let offset = cache?.offset ?? 0
+
+        // --- Q projection ---
+        // wq_a(x): (B, L, qLoraRank) → q_norm on qLoraRank → wq_b:
+        // (B, L, numHeads*headDim). Keep the post-qnorm residual — the
+        // Indexer uses it as its own Q source.
+        let qResidual = qNorm(wqA(x))
+        var q = wqB(qResidual)
+        q = q.reshaped(B, L, numHeads, headDim)
+        // Per-head fp32 RMSNorm-like rescale (NOT a learned norm — just
+        // variance normalization). Essential or middle layers drift
+        // exponentially. Python: q * rsqrt((q^2).mean(-1) + eps).
+        let qF32 = q.asType(.float32)
+        let qRescale = rsqrt(
+            (qF32 * qF32).mean(axis: -1, keepDims: true)
+                + MLXArray(config.rmsNormEps))
+        q = (qF32 * qRescale).asType(x.dtype)
+        q = q.transposed(0, 2, 1, 3)
+
+        // --- KV projection (single latent head) ---
+        var kv = kvNorm(wkv(x))
+        kv = kv.reshaped(B, L, 1, headDim).transposed(0, 2, 1, 3)
+
+        // --- Partial RoPE on last ropeDim dims of Q and K ---
+        let (cosT, sinT) = rope.cosSin(offset: offset, length: L)
+        let cosQ = cosT.expandedDimensions(axes: [0, 1])
+        let sinQ = sinT.expandedDimensions(axes: [0, 1])
+        q = DeepseekV4Math.applyPartialRoPE(q, cos: cosQ, sin: sinQ, ropeDim: ropeDim)
+        kv = DeepseekV4Math.applyPartialRoPE(kv, cos: cosQ, sin: sinQ, ropeDim: ropeDim)
+
+        // --- Cache update (sliding-window local) ---
+        // DSV4 has only one latent KV head broadcast to all Q heads, so
+        // K and V share the same tensor; SDPA below uses `fullKV` for
+        // both the keys and values arguments.
+        var keys = kv
+        if let cache = cache {
+            (keys, _) = cache.update(keys: kv, values: kv)
+        }
+        var fullKV = keys
+
+        // --- Compressor + Indexer global context (compressRatio > 0 layers) ---
+        // Fast path: plain sliding-window cache has no persistent
+        // buffer, so for L < compressRatio the compressor produces an
+        // empty pool and we short-circuit. Saves ~150 matmuls per token
+        // across the 41 compress_ratio>0 layers during short-prompt
+        // decode.
+        if compressRatio > 0 {
+            let v4Cache = cache as? DeepseekV4Cache
+            if v4Cache != nil || L >= compressRatio {
+                if let comp = compressor {
+                    var pooled = comp(x, rope: rope, v4Cache: v4Cache, startPos: offset)
+                    // pooled shape: (B, W, headDim) where W = pooled count.
+                    let W = pooled.dim(1)
+                    if W > 0 {
+                        if compressRatio == 4, let idx = indexer,
+                            let topK = idx(
+                                x, qResidual: qResidual, rope: rope,
+                                positionRope: rope, v4Cache: v4Cache, startPos: offset)
+                        {
+                            // topK shape: (B, L, k). Gather `k` rows from
+                            // `pooled` per query position. For SDPA we
+                            // need keys broadcast to (B, 1, allSelected,
+                            // headDim) — we flatten (L*k) into the
+                            // "time" axis so all queries see all their
+                            // selected pooled keys.
+                            let k = topK.dim(-1)
+                            // pooled: (B, W, D) → (B, 1, 1, W, D)
+                            let expanded = pooled.expandedDimensions(axes: [1, 2])
+                            let pooledBroad = broadcast(
+                                expanded, to: [B, 1, L, W, headDim])
+                            // idx: (B, L, k) → (B, 1, L, k, 1) broadcast over D
+                            let idxExp = topK.expandedDimensions(axes: [1, 4])
+                            let idxBroad = broadcast(
+                                idxExp, to: [B, 1, L, k, headDim])
+                            let gathered = takeAlong(
+                                pooledBroad, idxBroad, axis: 3)
+                            // (B, 1, L*k, D)
+                            pooled = gathered.reshaped(B, 1, L * k, headDim)
+                        } else {
+                            pooled = pooled.expandedDimensions(axis: 1)  // (B, 1, W, D)
+                        }
+                        if pooled.dim(2) > 0 {
+                            fullKV = concatenated([fullKV, pooled], axis: 2)
+                        }
+                    }
+                }
+            }
+        }
+
+        // --- Mask extension for extra pooled keys ---
+        var adjustedMask = mask
+        if case .array(let maskArr) = mask,
+            fullKV.dim(2) > maskArr.dim(-1)
+        {
+            let padShape =
+                Array(maskArr.shape.dropLast()) + [fullKV.dim(2) - maskArr.dim(-1)]
+            let pad = MLXArray.ones(padShape, dtype: maskArr.dtype)
+            adjustedMask = .array(concatenated([maskArr, pad], axis: -1))
+        }
+
+        // --- SDPA with attention sinks (fp32 accum for head_dim=512) ---
+        var output = MLXFast.scaledDotProductAttention(
+            queries: q, keys: fullKV, values: fullKV,
+            scale: scale, mask: adjustedMask,
+            sinks: config.useAttnSink ? attnSink.asType(q.dtype) : nil)
+        // output shape: (B, numHeads, L, headDim)
+
+        // --- Inverse RoPE on the output's head-major layout ---
+        let cosI = cosT.expandedDimensions(axes: [0, 1])
+        let sinI = sinT.expandedDimensions(axes: [0, 1])
+        output = DeepseekV4Math.applyPartialRoPE(
+            output, cos: cosI, sin: sinI, ropeDim: ropeDim, inverse: true)
+        output = output.transposed(0, 2, 1, 3)  // (B, L, numHeads, headDim)
+            .reshaped(B, L, numHeads * headDim)
+
+        // --- Grouped low-rank O projection ---
+        // Reshape to (B, L, oGroups, groupFeat) then per-group matmul
+        // through `wo_a`, producing (B, L, oGroups, oLoraRank) → concat
+        // groups → wo_b. Mirrors Python `_grouped_output_projection`
+        // (mlx_model.py:700) — separate dispatch for QuantizedLinear vs
+        // plain Linear because the quantized packed weight cannot be
+        // reshaped element-wise.
+        let groupFeat = (numHeads * headDim) / oGroups
+        let oReshape = output.reshaped(B, L, oGroups, groupFeat)
+        let oA: MLXArray
+        if let qwo = woA as? QuantizedLinear {
+            // Python ref:
+            //   out = out.transpose(2, 0, 1, 3)               # (oGroups, B, L, gf)
+            //   weight  = wo_a.weight.reshape(oGroups, oLoraRank, -1)[:, None]
+            //   scales  = wo_a.scales.reshape(oGroups, oLoraRank, -1)[:, None]
+            //   biases  = wo_a.biases.reshape(oGroups, oLoraRank, -1)[:, None]
+            //   out = mx.quantized_matmul(out, weight, scales, biases,
+            //                              transpose=True, group_size, bits, mode)
+            //   out = out.transpose(1, 2, 0, 3).reshape(B, L, oGroups*oLoraRank)
+            let xT = oReshape.transposed(2, 0, 1, 3)
+            // Each per-group weight slab keeps its original packed-in
+            // dim (last axis) — `-1` lets MLX work out 1024 → 128 for
+            // 8-bit g=32 packing.
+            let wPacked = qwo.weight.reshaped(oGroups, oLoraRank, -1)
+                .expandedDimensions(axis: 1)
+            let wScales = qwo.scales.reshaped(oGroups, oLoraRank, -1)
+                .expandedDimensions(axis: 1)
+            let wBiases = qwo.biases?.reshaped(oGroups, oLoraRank, -1)
+                .expandedDimensions(axis: 1)
+            let outQ = MLX.quantizedMM(
+                xT, wPacked, scales: wScales, biases: wBiases,
+                transpose: true, groupSize: qwo.groupSize, bits: qwo.bits)
+            oA = outQ.transposed(1, 2, 0, 3).reshaped(
+                B, L, oGroups * oLoraRank)
+        } else {
+            // Non-quantized path: keep the einsum.
+            // wo_a.weight has shape (oGroups*oLoraRank, groupFeat) per
+            // MLX Linear convention (out, in).
+            let woaW = woA.weight.reshaped(oGroups, oLoraRank, groupFeat)
+            oA = einsum("bsgd,grd->bsgr", oReshape, woaW)
+                .reshaped(B, L, oGroups * oLoraRank)
+        }
+        return woB(oA)
+    }
+}
+
+// MARK: - MoE gate (sqrtsoftplus + hash routing)
+
+class DeepseekV4MoEGate: Module {
+    let config: DeepseekV4Configuration
+    let topK: Int
+    let nRoutedExperts: Int
+    let routedScalingFactor: Float
+    let normTopkProb: Bool
+    let isHashLayer: Bool
+    /// Gate projection weight: (nRoutedExperts, hiddenSize). Stored as a
+    /// raw parameter (loaded via sanitize) rather than a Linear to allow
+    /// the matmul to run in fp32 per the authoritative reference.
+    @ParameterInfo(key: "weight") var weight: MLXArray
+    /// Optional noaux bias added to scores for selection only. When
+    /// absent the bias term is skipped. Official safetensors key is
+    /// `e_score_correction_bias`; osaurus's bundle stripped it to `bias`.
+    @ParameterInfo(key: "e_score_correction_bias") var bias: MLXArray
+    /// Hash routing lookup table (token_id → expert_id), shape (vocab,).
+    /// Only populated for hash layers.
+    @ParameterInfo(key: "tid2eid") var tid2eid: MLXArray
+
+    init(config: DeepseekV4Configuration, layerIdx: Int) {
+        self.config = config
+        self.topK = config.numExpertsPerTok
+        self.nRoutedExperts = config.nRoutedExperts
+        self.routedScalingFactor = config.routedScalingFactor
+        self.normTopkProb = config.normTopkProb
+        self.isHashLayer = config.isHashLayer(layerIdx)
+        self._weight.wrappedValue = zeros([nRoutedExperts, config.hiddenSize])
+        self._bias.wrappedValue = zeros([nRoutedExperts])
+        // Hash routing table: bundle ships (vocab, topK) — already
+        // pre-stamped with which `topK` experts each token id should
+        // route to, so the gate just gathers without computing scores.
+        // Non-hash layers don't have this tensor, so we still allocate
+        // a placeholder slot.
+        self._tid2eid.wrappedValue =
+            zeros([isHashLayer ? config.vocabSize : 1, isHashLayer ? topK : 1])
+    }
+
+    /// Returns (indices, weights) where indices has shape (B, L, topK)
+    /// and weights has shape (B, L, topK). For hash layers, weights is
+    /// a synthetic uniform 1/topK so the downstream SwitchGLU gets the
+    /// same contract as softmax-routed layers.
+    func callAsFunction(_ x: MLXArray, inputIds: MLXArray?) -> (MLXArray, MLXArray) {
+        if isHashLayer, let ids = inputIds {
+            // Hash routing: tid2eid is (vocab, topK) — pre-stamped at
+            // convert time with which topK experts each token id
+            // routes to. `tid2eid[ids]` for ids shape (B, L) returns
+            // (B, L, topK) directly via fancy index.
+            let (B, L) = (x.dim(0), x.dim(1))
+            let indices = tid2eid[ids]  // (B, L, topK)
+            // Uniform weights — every selected expert contributes
+            // equally, scaled by the routed factor / topK.
+            let weights = MLXArray.ones([B, L, topK], dtype: .float32)
+                * (routedScalingFactor / Float(topK))
+            return (indices.asType(.uint32), weights)
+        }
+
+        // Non-hash: compute scores via sqrt(softplus(logits))
+        // The matmul is performed in fp32 per the bug-fix contract.
+        let xF32 = x.asType(.float32)
+        let wF32 = weight.asType(.float32)
+        let logits = xF32.matmul(wF32.transposed())
+        let scores = DeepseekV4Math.sqrtSoftplus(logits)
+
+        let (indices, weights) = DeepseekV4Math.sqrtSoftplusSelect(
+            scores: scores,
+            noauxBias: bias,  // zeros-initialized — effectively no bias unless loaded
+            k: topK,
+            normalize: normTopkProb,
+            scalingFactor: routedScalingFactor
+        )
+        return (indices.asType(.uint32), weights)
+    }
+}
+
+// MARK: - MoE (SwitchGLU routed + shared expert)
+
+class DeepseekV4MoE: Module, UnaryLayer {
+    let config: DeepseekV4Configuration
+    let topK: Int
+    @ModuleInfo(key: "switch_mlp") var switchMLP: SwitchGLU
+    var gate: DeepseekV4MoEGate
+    @ModuleInfo(key: "shared_experts") var sharedExperts: DeepseekV4MLP
+    /// Hack to thread the input token ids down into the gate when this
+    /// layer is hash-routed. Set by the outer model before each layer
+    /// call when hash routing applies.
+    var currentInputIds: MLXArray? = nil
+
+    init(config: DeepseekV4Configuration, layerIdx: Int) {
+        self.config = config
+        self.topK = config.numExpertsPerTok
+        let limit = config.swigluLimit
+        // Activation: silu(min(gate, limit)) * clip(up, ±limit).
+        // SwitchGLU accepts a scalar activation applied to gate, with
+        // up multiplied after. Our helper fuses both legs.
+        self._switchMLP.wrappedValue = SwitchGLU(
+            inputDims: config.hiddenSize,
+            hiddenDims: config.moeIntermediateSize,
+            numExperts: config.nRoutedExperts,
+            activation: { gate in
+                // SwitchGLU computes act(gate) * up. Our "activation" is
+                // applied to gate only — so we return the limited silu
+                // branch here. Up clamping happens inside ops that form
+                // gate*up — but SwitchGLU multiplies AFTER activation,
+                // so the `up` side escapes our clamp. Acceptable for
+                // now (the dominant overflow came from the silu(gate)
+                // blowing up, not up).
+                return silu(minimum(gate, MLXArray(limit)))
+            })
+        self.gate = DeepseekV4MoEGate(config: config, layerIdx: layerIdx)
+        self._sharedExperts.wrappedValue = DeepseekV4MLP(
+            hiddenSize: config.hiddenSize,
+            intermediateSize: config.moeIntermediateSize * config.nSharedExperts,
+            swigluLimit: limit)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let (indices, scores) = gate(x, inputIds: currentInputIds)
+        var y = switchMLP(x, indices)
+        y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        y = y + sharedExperts(x)
+        return y
+    }
+}
+
+// MARK: - Dense MLP (shared expert) with DSV4 SwiGLU clamp
+
+class DeepseekV4MLP: Module, UnaryLayer {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+    let swigluLimit: Float
+
+    init(hiddenSize: Int, intermediateSize: Int, swigluLimit: Float) {
+        self._gateProj.wrappedValue = Linear(hiddenSize, intermediateSize, bias: false)
+        self._upProj.wrappedValue = Linear(hiddenSize, intermediateSize, bias: false)
+        self._downProj.wrappedValue = Linear(intermediateSize, hiddenSize, bias: false)
+        self.swigluLimit = swigluLimit
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let g = gateProj(x)
+        let u = upProj(x)
+        return downProj(DeepseekV4Math.dsv4SwiGLU(gate: g, up: u, limit: swigluLimit))
+    }
+}
+
+// MARK: - mHC Hyper-Connection (per-block collapse + expand)
+
+class DeepseekV4HyperConnection: Module {
+    let hcMult: Int
+    let hcIters: Int
+    let hcEps: Float
+    let hiddenSize: Int
+    let mixHc: Int  // (2 + hcMult) * hcMult — bundle stores params at this width
+    /// `hc_{attn,ffn}_fn`: shape `((2+hc)*hc, hc*hidden)`. Bundle stores
+    /// `(24, 16384)` for hc=4, hidden=4096.
+    @ParameterInfo(key: "fn") var fn: MLXArray
+    /// `hc_{attn,ffn}_scale`: shape `(3,)` per-field scalar.
+    @ParameterInfo(key: "scale") var scale: MLXArray
+    /// `hc_{attn,ffn}_base`: shape `((2+hc)*hc,)` per-field bias.
+    @ParameterInfo(key: "base") var base: MLXArray
+    /// Constant ones-vector reused as the RMSNorm weight inside the
+    /// per-block collapse (Python sets up `_hc_rms_ones = mx.ones(...)`).
+    private var _hcRMSOnes: MLXArray?
+    var hcRMSOnes: MLXArray {
+        if let v = _hcRMSOnes { return v }
+        let v = MLXArray.ones([hcMult * hiddenSize])
+        _hcRMSOnes = v
+        return v
+    }
+
+    init(config: DeepseekV4Configuration) {
+        self.hcMult = config.hcMult
+        self.hcIters = config.hcSinkhornIters
+        self.hcEps = config.hcEps
+        self.hiddenSize = config.hiddenSize
+        self.mixHc = (2 + config.hcMult) * config.hcMult
+        self._fn.wrappedValue = zeros([mixHc, hcMult * hiddenSize])
+        self._scale.wrappedValue = zeros([3])
+        self._base.wrappedValue = zeros([mixHc])
+    }
+
+    /// Collapse: `h` shape (B, L, hcMult, hiddenSize) → collapsed x
+    /// (B, L, hiddenSize) plus `post` (B, L, hcMult) and `comb`
+    /// (B, L, hcMult, hcMult) for the expand step.
+    ///
+    /// Mirrors Python `DeepseekV4DecoderLayer._hc_pre`:
+    ///   x_flat   = flatten(h, axis=2)              # (B, L, hc*hidden)
+    ///   x_normed = rms_norm(x_flat, ones, eps)
+    ///   mixes    = x_normed @ fn.T                 # (B, L, mix_hc)
+    ///   pre, post, comb = hc_split_sinkhorn(mixes, scale, base, hc, iters, eps)
+    ///   y = sum(pre[..., None] * x_flat.reshape(B,L,hc,D), axis=2)
+    func collapse(_ h: MLXArray) -> (x: MLXArray, post: MLXArray, comb: MLXArray) {
+        let dtype = h.dtype
+        let B = h.dim(0)
+        let L = h.dim(1)
+
+        // Flatten the (hcMult, hidden) tail into one axis.
+        let xFlat = h.reshaped(B, L, hcMult * hiddenSize)
+        // Variance-only RMS norm with weight = ones.
+        //
+        // Force fp32 internals: the reduction `mean(square(x))` runs over
+        // `hcMult * hiddenSize` (≈16384 for DSV4-Flash) elements per row
+        // and bf16 rounding compounds aggressively across that axis. On
+        // M3 Ultra this saturates and the rsqrt produces garbage logits
+        // ("17 plus plus plus" failure mode). M4 happens to keep fp32 in
+        // SIMD lanes for this reduction so MacBook tests pass — but the
+        // bug is real on Mac Studio. Mirrors the upstream Python fix.
+        let xNormed = MLXFast.rmsNorm(
+            xFlat.asType(.float32),
+            weight: hcRMSOnes.asType(.float32),
+            eps: hcEps
+        ).asType(xFlat.dtype)
+        // mixes = x_normed @ fn.T  → (B, L, mix_hc)
+        let mixes = xNormed.asType(.float32)
+            .matmul(fn.asType(.float32).transposed())
+
+        let (pre, post, comb) = DeepseekV4Math.hcSplitSinkhorn(
+            mixes: mixes, scale: scale, base: base,
+            hcMult: hcMult, iters: hcIters, eps: hcEps)
+
+        // y = sum(pre[..., None] * x_flat.reshape(B, L, hc, D), axis=2)
+        let preCast = pre.asType(dtype)
+        let xReshape = xFlat.reshaped(B, L, hcMult, hiddenSize)
+        let y = (preCast.expandedDimensions(axis: -1) * xReshape).sum(axis: -2)
+        return (x: y, post: post, comb: comb)
+    }
+
+    /// Expand: given attn/ffn output `blockOut` (B, L, hiddenSize),
+    /// residual (B, L, hcMult, hiddenSize), and the (post, comb) from
+    /// the matching collapse, return new h (B, L, hcMult, hiddenSize).
+    ///
+    /// Mirrors Python `_hc_post`:
+    ///   y = post[..., None] * x[..., None, :] + matmul(comb, residual)
+    func expand(
+        blockOut: MLXArray, residual: MLXArray, post: MLXArray, comb: MLXArray
+    ) -> MLXArray {
+        let dtype = blockOut.dtype
+        let postCast = post.asType(dtype)
+        let combCast = comb.asType(dtype)
+        // matmul(comb, residual) — comb is (B,L,hc,hc), residual is
+        // (B,L,hc,D); broadcast over leading dims. MLX matmul handles
+        // this directly.
+        let combResid = combCast.matmul(residual)
+        // post: (B,L,hc) → (B,L,hc,1); blockOut: (B,L,D) → (B,L,1,D).
+        let y = postCast.expandedDimensions(axis: -1)
+            * blockOut.expandedDimensions(axis: -2) + combResid
+        return y
+    }
+}
+
+// MARK: - HyperHead (top-of-model mHC reduce)
+
+class DeepseekV4HyperHead: Module {
+    let hcMult: Int
+    let hiddenSize: Int
+    let hcEps: Float
+    /// Bundle stores `hc_head_fn` at `(hcMult, hcMult*hiddenSize)`.
+    @ParameterInfo(key: "hc_head_fn") var fn: MLXArray
+    @ParameterInfo(key: "hc_head_base") var base: MLXArray
+    @ParameterInfo(key: "hc_head_scale") var scale: MLXArray
+    /// Constant ones-vector for the RMS norm in `_hc_head_reduce`. Computed
+    /// lazily so MLXNN's parameter scanner doesn't try to load it from
+    /// safetensors as a model weight.
+    private var _hcHeadRMSOnes: MLXArray?
+    var hcHeadRMSOnes: MLXArray {
+        if let v = _hcHeadRMSOnes { return v }
+        let v = MLXArray.ones([hcMult * hiddenSize])
+        _hcHeadRMSOnes = v
+        return v
+    }
+
+    init(config: DeepseekV4Configuration) {
+        self.hcMult = config.hcMult
+        self.hiddenSize = config.hiddenSize
+        self.hcEps = config.rmsNormEps
+        self._fn.wrappedValue = zeros([hcMult, hcMult * hiddenSize])
+        self._base.wrappedValue = zeros([hcMult])
+        self._scale.wrappedValue = zeros([1])
+    }
+
+    /// Reduce (B, L, hcMult, hiddenSize) → (B, L, hiddenSize). Mirrors
+    /// Python `_hc_head_reduce`:
+    ///   x_flat   = flatten(x, axis=2)            # (B, L, hc*hidden)
+    ///   x_normed = rms_norm(x_flat, ones, eps)
+    ///   mixes    = x_normed @ hc_head_fn.T       # (B, L, hc)
+    ///   pre      = sigmoid(mixes * scale + base) + hc_eps
+    ///   y        = sum(pre[..., None] * x_flat.reshape(B,L,hc,D), axis=2)
+    /// NO sum-to-1 normalization — match the Python reference exactly.
+    func reduce(_ h: MLXArray) -> MLXArray {
+        let dtype = h.dtype
+        let B = h.dim(0)
+        let L = h.dim(1)
+        let xFlat = h.reshaped(B, L, hcMult * hiddenSize)
+        let xNormed = MLXFast.rmsNorm(
+            xFlat, weight: hcHeadRMSOnes.asType(xFlat.dtype), eps: hcEps)
+        let mixes = xNormed.matmul(fn.transposed())  // (B, L, hcMult)
+        let pre = sigmoid(mixes * scale + base) + MLXArray(hcEps)
+        let xReshape = xFlat.reshaped(B, L, hcMult, hiddenSize)
+        return (pre.expandedDimensions(axis: -1) * xReshape).sum(axis: -2)
+            .asType(dtype)
+    }
+}
+
+// MARK: - Decoder layer (mHC wrap over attn + MoE)
+
+class DeepseekV4DecoderLayer: Module {
+    // V4 safetensors keys: `attn`/`ffn`/`attn_norm`/`ffn_norm` (no `self_`
+    // prefix, no `_layernorm` suffix). Matches official mlx-community layout.
+    @ModuleInfo(key: "attn") var selfAttn: DeepseekV4Attention
+    @ModuleInfo(key: "ffn") var mlp: DeepseekV4MoE
+    @ModuleInfo(key: "attn_norm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "ffn_norm") var postAttentionLayerNorm: RMSNorm
+    @ModuleInfo(key: "attn_hc") var attnHC: DeepseekV4HyperConnection
+    @ModuleInfo(key: "ffn_hc") var ffnHC: DeepseekV4HyperConnection
+
+    let layerIdx: Int
+
+    init(config: DeepseekV4Configuration, layerIdx: Int) {
+        self.layerIdx = layerIdx
+        self._selfAttn.wrappedValue = DeepseekV4Attention(config: config, layerIdx: layerIdx)
+        self._mlp.wrappedValue = DeepseekV4MoE(config: config, layerIdx: layerIdx)
+        self._inputLayerNorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._postAttentionLayerNorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._attnHC.wrappedValue = DeepseekV4HyperConnection(config: config)
+        self._ffnHC.wrappedValue = DeepseekV4HyperConnection(config: config)
+    }
+
+    /// Forward. `h` shape: (B, L, hcMult, hiddenSize).
+    func callAsFunction(
+        _ h: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode,
+        cache: KVCache?,
+        inputIds: MLXArray?
+    ) -> MLXArray {
+        // ---- Attention HC ----
+        let residualA = h
+        let (xA, postA, combA) = attnHC.collapse(h)
+        let normedA = inputLayerNorm(xA)
+        let attnOut = selfAttn(normedA, mask: mask, cache: cache)
+        let hA = attnHC.expand(
+            blockOut: attnOut, residual: residualA, post: postA, comb: combA)
+
+        // ---- FFN HC ----
+        let residualF = hA
+        let (xF, postF, combF) = ffnHC.collapse(hA)
+        let normedF = postAttentionLayerNorm(xF)
+        mlp.currentInputIds = inputIds
+        let ffnOut = mlp(normedF)
+        mlp.currentInputIds = nil
+        let hF = ffnHC.expand(
+            blockOut: ffnOut, residual: residualF, post: postF, comb: combF)
+        return hF
+    }
+}
+
+// MARK: - Inner model
+
+public class DeepseekV4ModelInner: Module {
+    let config: DeepseekV4Configuration
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    var layers: [DeepseekV4DecoderLayer]
+    @ModuleInfo(key: "hc_head") var hcHead: DeepseekV4HyperHead
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+
+    init(config: DeepseekV4Configuration) {
+        self.config = config
+        self._embedTokens.wrappedValue = Embedding(
+            embeddingCount: config.vocabSize, dimensions: config.hiddenSize)
+        self.layers = (0..<config.numHiddenLayers).map {
+            DeepseekV4DecoderLayer(config: config, layerIdx: $0)
+        }
+        self._hcHead.wrappedValue = DeepseekV4HyperHead(config: config)
+        self._norm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        // embed: (B, L) → (B, L, hiddenSize)
+        var h = embedTokens(inputs)
+        // Tile to mHC copies: (B, L, hiddenSize) → (B, L, hcMult, hiddenSize).
+        // Python tiles via broadcast; Swift uses `repeated` along axis -2.
+        h = h.expandedDimensions(axis: -2)  // (B, L, 1, H)
+        h = repeated(h, count: config.hcMult, axis: -2)  // (B, L, hcMult, H)
+
+        let firstCache = cache?.first
+        let hFlat2 = h.reshaped(h.dim(0), h.dim(1), -1)  // for createAttentionMask
+        let mask = createAttentionMask(h: hFlat2, cache: firstCache)
+
+        for (i, layer) in layers.enumerated() {
+            h = layer(
+                h,
+                mask: mask,
+                cache: cache?[i],
+                inputIds: inputs)
+        }
+
+        // HyperHead reduce: (B, L, hcMult, H) → (B, L, H)
+        var out = hcHead.reduce(h)
+        out = norm(out)
+        return out
+    }
+}
+
+// MARK: - Outer model
+
+public class DeepseekV4Model: Module, LLMModel, KVCacheDimensionProvider, LoRAModel {
+    public var kvHeads: [Int]
+    var config: DeepseekV4Configuration
+    public var model: DeepseekV4ModelInner
+    @ModuleInfo(key: "lm_head") var lmHead: Linear
+
+    public init(_ config: DeepseekV4Configuration) {
+        self.config = config
+        // Single latent KV head per layer — report kvHeads as [1]*L so
+        // the cache allocator sizes per-layer caches correctly.
+        self.kvHeads = Array(repeating: 1, count: config.numHiddenLayers)
+        self.model = DeepseekV4ModelInner(config: config)
+        self._lmHead.wrappedValue = Linear(
+            config.hiddenSize, config.vocabSize, bias: false)
+    }
+
+    /// Build per-layer caches.
+    ///
+    /// **Default (safe) path** — plain `RotatingKVCache` for every
+    /// layer. Long prompts work because during prefill the attention's
+    /// compressor fast-path triggers on `L >= compress_ratio`
+    /// (cache=nil branch in the Compressor) and pools global context
+    /// into full_kv before SDPA. During decode (L=1), the compressor
+    /// auto-skips (L < compress_ratio) and local sliding-window
+    /// attention proceeds. No state needs to persist across calls.
+    ///
+    /// **Opt-in (`DSV4_LONG_CTX=1`)** — `DeepseekV4Cache` on
+    /// compress_ratio>0 layers so the compressor/indexer state
+    /// PERSISTS across decode steps (extends pooled context
+    /// incrementally as new tokens arrive). Python reference warns
+    /// this path has unresolved edge cases in the prefill→decode
+    /// transition; keep behind the flag until hardened.
+    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        let env = ProcessInfo.processInfo.environment
+        let longCtxEnabled = env["DSV4_LONG_CTX"] == "1"
+
+        // Two runtime knobs the caller can pick between when reasoning
+        // traces or chat outputs exceed sliding_window=128 tokens:
+        //
+        //   - "sliding" (default): RotatingKVCache(maxSize=128). Decode
+        //     only sees the last 128 tokens locally; works in-distribution
+        //     for short outputs (<= 128 new tokens). Reasoning traces past
+        //     128 tokens lose visibility into the original prompt and the
+        //     model drifts off-topic — confirmed on HumanEval+ chat mode
+        //     long traces (2026-04-25). Use for FIM / short Q&A.
+        //
+        //   - "full": KVCacheSimple. No rotation, no compression — the
+        //     model attends to ALL prior tokens. Memory grows linearly
+        //     with sequence length. Local-attention layers see more than
+        //     their trained window so it's OOD for those layers, but in
+        //     practice attention naturally focuses on nearby tokens and
+        //     long outputs stay coherent. Use when memory permits.
+        //
+        //   - "tq": KVCacheSimple at construction; the caller passes
+        //     `GenerateParameters.kvMode = .turboQuant(3, 3)` so the
+        //     BatchEngine's `BatchQuantize.maybeCompress` swaps each
+        //     layer to `TurboQuantKVCache` once the offset crosses the
+        //     min-tokens threshold. Best of both — full context, ~26x
+        //     less memory than full f16 KV. Use for long reasoning.
+        //
+        // `DSV4_KV_MODE` env var overrides; otherwise auto-promote to
+        // full-context when the caller explicitly asks for TurboQuant.
+        let envMode = env["DSV4_KV_MODE"]?.lowercased()
+        // Phase 1 port: kvMode field doesn't exist on this fork's
+        // GenerateParameters. Default to "sliding" unless env var set.
+        let mode: String = envMode ?? "sliding"
+
+        return (0..<config.numHiddenLayers).map { layerIdx in
+            switch mode {
+            case "full", "tq":
+                // Full-context cache. For "tq" the BatchEngine will swap
+                // this for TurboQuantKVCache once enough tokens accumulate.
+                return KVCacheSimple()
+            default:
+                // "sliding" or unrecognized → status-quo path.
+                if longCtxEnabled {
+                    let cr =
+                        config.compressRatios.count > layerIdx
+                        ? config.compressRatios[layerIdx] : 0
+                    if cr > 0 {
+                        return DeepseekV4Cache(slidingWindow: config.slidingWindow)
+                    }
+                }
+                // Default path. Note: `RotatingKVCache(maxSize:, keep:)`
+                // rotates once the window fills during prefill, but the
+                // compressor branch has already pooled the older tokens
+                // into `full_kv` before SDPA sees them — so no context
+                // is actually lost on compress_ratio>0 layers during
+                // PREFILL. Decode (L=1) does lose the older tokens.
+                return RotatingKVCache(maxSize: config.slidingWindow, keep: 0)
+            }
+        }
+    }
+
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
+        let h = model(inputs, cache: cache)
+        return lmHead(h)
+    }
+
+    /// Weight sanitize — remap DSV4 bundle key names to match module
+    /// attribute paths, stack per-expert weights, drop MTP + unused
+    /// compressor/indexer keys.
+    ///
+    /// Remap rules:
+    ///   model.embed.weight            → model.embed_tokens.weight
+    ///   layers.{L}.attn.*             → model.layers.{L}.self_attn.*
+    ///   layers.{L}.ffn.*              → model.layers.{L}.mlp.*
+    ///   layers.{L}.attn_norm.weight   → model.layers.{L}.input_layernorm.weight
+    ///   layers.{L}.ffn_norm.weight    → model.layers.{L}.post_attention_layernorm.weight
+    ///   layers.{L}.hc_attn_*          → model.layers.{L}.attn_hc.{fn,scale,base}
+    ///   layers.{L}.hc_ffn_*           → model.layers.{L}.ffn_hc.{fn,scale,base}
+    ///   hc_head_*                     → model.hc_head.{hc_head_fn,hc_head_base,hc_head_scale}
+    ///   norm.weight                   → model.norm.weight
+    ///   head.weight                   → lm_head.weight
+    ///   ffn.experts.{E}.{w1|w2|w3}.*  → mlp.switch_mlp.{gate|down|up}_proj.* (stacked)
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        // Minimal sanitize for the official mlx-community DSv4 safetensors
+        // layout. After matching @ModuleInfo names directly to file keys
+        // (attn/ffn/attn_norm/ffn_norm/switch_mlp/embed_tokens/norm),
+        // most weights pass through unchanged. We only need to:
+        //   1. Drop the multi-token-prediction (MTP) layer at index
+        //      `numHiddenLayers` (one extra layer beyond the 43 we model).
+        //   2. Drop any rotary inv_freq buffers (computed at runtime).
+        //   3. Map official `model.hc_head.{base,fn,scale}` → bundle-style
+        //      `hc_head_{base,fn,scale}` keys for the HyperHead's
+        //      @ParameterInfo names.
+        var out = weights.filter { (key, _) in
+            !key.hasPrefix("model.layers.\(self.config.numHiddenLayers)")
+                && !key.contains("rotary_emb.inv_freq")
+                && !key.hasPrefix("mtp.")
+        }
+        for src in ["base", "fn", "scale"] {
+            let from = "model.hc_head.\(src)"
+            if let v = out.removeValue(forKey: from) {
+                out["model.hc_head.hc_head_\(src)"] = v
+            }
+        }
+        // Hash layers (first num_hash_layers=3) carry `tid2eid` instead of
+        // `e_score_correction_bias`. Non-hash layers carry the bias and no
+        // tid2eid. The Swift gate declares both @ParameterInfo slots, so
+        // fill the absent half with a zero placeholder of the right shape.
+        for layerIdx in 0..<self.config.numHiddenLayers {
+            let pfx = "model.layers.\(layerIdx).ffn.gate"
+            if out["\(pfx).e_score_correction_bias"] == nil {
+                out["\(pfx).e_score_correction_bias"] =
+                    zeros([self.config.nRoutedExperts])
+            }
+            if out["\(pfx).tid2eid"] == nil {
+                out["\(pfx).tid2eid"] = zeros([1, 1]).asType(.int32)
+            }
+        }
+        return out
+    }
+
+    /// Bundle-format sanitize for the legacy osaurus / jang weight
+    /// layout (`embed.weight`, `head.*`, `layers.N.attn.*`, per-expert
+    /// stacking under `ffn.experts.E.{w1|w2|w3}.*`). Currently unused —
+    /// the official `mlx-community/DeepSeek-V4-Flash-2bit-DQ` bundle
+    /// matches our `@ModuleInfo` names directly, so the simpler
+    /// `sanitize` above suffices. Kept (private) for the day a
+    /// bundle in the older format shows up.
+    private func _bundleFormatSanitize(_ weights: [String: MLXArray])
+        -> [String: MLXArray]
+    {
+        var out: [String: MLXArray] = [:]
+        // First pass: direct rename + drop MTP (training head only).
+        // Compressor + Indexer weights are KEPT — they're wired into
+        // DeepseekV4Attention for long-context (L > sliding_window)
+        // attention. Layers with compress_ratio == 0 carry no such
+        // weights; layers with >0 carry `self_attn.compressor.*` and
+        // (for ratio=4) `self_attn.indexer.*`.
+        // Per-prefix structural matching — avoids over-broad string
+        // replace bugs (e.g. ".w1." colliding outside MLP contexts).
+        let projForW = ["w1": "gate_proj", "w2": "down_proj", "w3": "up_proj"]
+        for (rawKey, value) in weights {
+            if rawKey.hasPrefix("mtp.") { continue }
+
+            // Top-level (no `layers.N.` prefix).
+            if rawKey == "embed.weight" || rawKey == "embed.scales"
+                || rawKey == "embed.biases"
+            {
+                let suffix = String(rawKey.dropFirst("embed.".count))
+                out["model.embed_tokens.\(suffix)"] = value
+                continue
+            }
+            if rawKey.hasPrefix("head.") {
+                // head.{weight,scales,biases} → lm_head.*
+                let suffix = String(rawKey.dropFirst("head.".count))
+                out["lm_head.\(suffix)"] = value
+                continue
+            }
+            if rawKey == "norm.weight" {
+                out["model.norm.weight"] = value
+                continue
+            }
+            if rawKey == "hc_head_fn" || rawKey == "hc_head_base"
+                || rawKey == "hc_head_scale"
+            {
+                // Bundle-style key `hc_head_fn` → official `model.hc_head.fn`.
+                let suffix = String(rawKey.dropFirst("hc_head_".count))
+                out["model.hc_head.\(suffix)"] = value
+                continue
+            }
+
+            // layers.N.{...} branch
+            guard rawKey.hasPrefix("layers.") else {
+                out["model.\(rawKey)"] = value
+                continue
+            }
+            let afterLayers = rawKey.dropFirst("layers.".count)
+            guard let dotIdx = afterLayers.firstIndex(of: ".") else { continue }
+            let layerStr = String(afterLayers[..<dotIdx])
+            guard Int(layerStr) != nil else { continue }
+            let rest = String(afterLayers[afterLayers.index(after: dotIdx)...])
+            let pfx = "model.layers.\(layerStr)"
+
+            // Norms
+            if rest == "attn_norm.weight" {
+                out["\(pfx).input_layernorm.weight"] = value
+                continue
+            }
+            if rest == "ffn_norm.weight" {
+                out["\(pfx).post_attention_layernorm.weight"] = value
+                continue
+            }
+
+            // mHC per-layer (hc_attn_*, hc_ffn_*).
+            if rest.hasPrefix("hc_attn_") {
+                let field = String(rest.dropFirst("hc_attn_".count))
+                out["\(pfx).attn_hc.\(field)"] = value
+                continue
+            }
+            if rest.hasPrefix("hc_ffn_") {
+                let field = String(rest.dropFirst("hc_ffn_".count))
+                out["\(pfx).ffn_hc.\(field)"] = value
+                continue
+            }
+
+            // Attention subtree (q_norm / kv_norm / wq_a / wq_b / wkv /
+            // wo_a / wo_b / attn_sink / compressor.* / indexer.*).
+            if rest.hasPrefix("attn.") {
+                let inner = String(rest.dropFirst("attn.".count))
+                out["\(pfx).self_attn.\(inner)"] = value
+                continue
+            }
+
+            // FFN subtree.
+            if rest.hasPrefix("ffn.") {
+                let inner = String(rest.dropFirst("ffn.".count))
+                if inner.hasPrefix("gate.") {
+                    let f = String(inner.dropFirst("gate.".count))
+                    out["\(pfx).mlp.gate.\(f)"] = value
+                    continue
+                }
+                if inner.hasPrefix("shared_experts.") {
+                    let f = String(inner.dropFirst("shared_experts.".count))
+                    if let firstDot = f.firstIndex(of: "."),
+                        let proj = projForW[String(f[..<firstDot])]
+                    {
+                        let suffix = String(f[f.index(after: firstDot)...])
+                        out["\(pfx).mlp.shared_experts.\(proj).\(suffix)"] = value
+                        continue
+                    }
+                    out["\(pfx).mlp.shared_experts.\(f)"] = value
+                    continue
+                }
+                if inner.hasPrefix("experts.") {
+                    let after = String(inner.dropFirst("experts.".count))
+                    guard let eDot = after.firstIndex(of: ".") else { continue }
+                    let eStr = String(after[..<eDot])
+                    let tail = String(after[after.index(after: eDot)...])
+                    if let firstDot = tail.firstIndex(of: "."),
+                        let proj = projForW[String(tail[..<firstDot])]
+                    {
+                        let suffix = String(tail[tail.index(after: firstDot)...])
+                        out["\(pfx).mlp.experts.\(eStr).\(proj).\(suffix)"] = value
+                        continue
+                    }
+                    out["\(pfx).mlp.experts.\(eStr).\(tail)"] = value
+                    continue
+                }
+                out["\(pfx).mlp.\(inner)"] = value
+                continue
+            }
+
+            out["\(pfx).\(rest)"] = value
+        }
+
+        // Second pass: stack per-expert weights into switch_mlp.{gate,
+        // up,down}_proj.*. Two formats supported:
+        //
+        // Affine (JANG_2L / JANG4): suffixes weight / scales / biases.
+        //   Source per expert: (out, in) [+ (out, in/group)] [+ (out, in/group)]
+        //   Stacked shape: (n_experts, ...).
+        //
+        // TurboQuant routed experts: suffixes tq_packed / tq_norms.
+        // tq_bits is a per-tensor int constant — we drop it
+        // (TurboQuantSwitchLinear configures bits at construction
+        // time from the model_factory).
+        //   Source per expert: tq_packed (out, packed_cols), tq_norms (out,)
+        //   Stacked shape: (n_experts, out, packed_cols) / (n_experts, out)
+        // The first pass already rewrote `.w1.` → `.gate_proj.` (etc.)
+        // globally, so per-expert keys live at
+        // `model.layers.L.mlp.experts.E.gate_proj.{suffix}`. Stack into
+        // `model.layers.L.mlp.switch_mlp.{gate,down,up}_proj.{suffix}`.
+        let suffixes = ["weight", "scales", "biases", "tq_packed", "tq_norms"]
+        for layerIdx in 0..<config.numHiddenLayers {
+            let prefix = "model.layers.\(layerIdx).mlp.experts"
+            for projName in ["gate_proj", "down_proj", "up_proj"] {
+                for suffix in suffixes {
+                    let first = "\(prefix).0.\(projName).\(suffix)"
+                    guard out[first] != nil else { continue }
+                    var tensors: [MLXArray] = []
+                    for e in 0..<config.nRoutedExperts {
+                        let key = "\(prefix).\(e).\(projName).\(suffix)"
+                        guard let t = out[key] else {
+                            tensors = []
+                            break
+                        }
+                        tensors.append(t)
+                    }
+                    if tensors.count == config.nRoutedExperts {
+                        let stackedKey =
+                            "model.layers.\(layerIdx).mlp.switch_mlp.\(projName).\(suffix)"
+                        out[stackedKey] = stacked(tensors)
+                        for e in 0..<config.nRoutedExperts {
+                            out.removeValue(
+                                forKey: "\(prefix).\(e).\(projName).\(suffix)")
+                        }
+                    }
+                }
+                // Drop per-expert tq_bits scalars — TurboQuantSwitchLinear
+                // gets bit width from config, not from weights.
+                for e in 0..<config.nRoutedExperts {
+                    out.removeValue(
+                        forKey: "\(prefix).\(e).\(projName).tq_bits")
+                }
+            }
+        }
+        return out
+    }
+
+    public var loraLayers: [Module] {
+        model.layers
+    }
+}

--- a/Libraries/MLXLLM/Models/DeepseekV4Compressor.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4Compressor.swift
@@ -1,0 +1,387 @@
+// Copyright © 2026 TheTom.
+// Adapted from osaurus-ai/vmlx-swift-lm (MIT) — see
+// Libraries/MLXLLM/Models/DEEPSEEK_V4_ATTRIBUTION.md for upstream license.
+//
+// Original: Copyright © 2026 Osaurus AI. SPDX-License-Identifier: MIT.
+// Upstream: https://github.com/osaurus-ai/vmlx-swift-lm
+//
+// DSV4 Compressor + Indexer + per-layer DeepseekV4Cache.
+//
+// These power the "compressed global context" path that augments the
+// 128-token local sliding window with pooled summaries of older tokens.
+// Every decoder layer with `compress_ratio > 0` (~41 of 43 layers in
+// DSV4-Flash) carries a Compressor; layers with `compress_ratio == 4`
+// ALSO carry an Indexer that picks the top-k most relevant pooled
+// entries per query position.
+//
+// Phase 1 caveat: long-context paths are wired but not yet validated
+// against the Python reference. Short prompts take a bypass fast-path.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// MARK: - DeepseekV4Cache
+//
+// Per-layer composite cache. Wraps a `RotatingKVCache` for the local
+// sliding window plus persistent buffer state for the compressor and
+// indexer. Multi-call stateful: on each prefill step it accumulates
+// raw-token windows until a full `compress_ratio`-sized chunk is ready,
+// then pools and stores. The pooled sequence grows across calls so
+// turn 2 and beyond see the full history summary.
+//
+// For short prompts (L < compress_ratio) and no V4Cache provided, the
+// attention forward takes a fast-path that skips the compressor
+// entirely (Python mirror: `if v4_cache is None and L < compress_ratio
+// → skip`).
+public final class DeepseekV4Cache: KVCache {
+    /// Expose the inner rotating cache so `TQDiskSerializer` and
+    /// `restoreRotatingLayer` can round-trip the sliding-window state.
+    /// Compressor/Indexer pool buffers are NOT serialized — they get
+    /// recomputed from prompt tokens on the next prefill.
+    public var rotating: RotatingKVCache { local }
+    /// Local sliding-window cache (compress_ratio-agnostic).
+    public let local: RotatingKVCache
+    let slidingWindow: Int
+    /// Compressor buffer state (raw kv/gate not yet ready to pool)
+    /// and pooled summary so far.
+    fileprivate var compBufferKV: MLXArray?
+    fileprivate var compBufferGate: MLXArray?
+    fileprivate var compPooled: MLXArray?
+    /// Indexer's own buffer state (separate branch — compressor inside
+    /// the indexer uses its own buffers).
+    fileprivate var idxBufferKV: MLXArray?
+    fileprivate var idxBufferGate: MLXArray?
+    fileprivate var idxPooled: MLXArray?
+
+    public init(slidingWindow: Int) {
+        self.slidingWindow = slidingWindow
+        self.local = RotatingKVCache(maxSize: slidingWindow, keep: 0)
+    }
+
+    // KVCache protocol implementation — delegate everything to `local`.
+    public var offset: Int { local.offset }
+    public var maxSize: Int? { local.maxSize }
+
+    public func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        local.update(keys: keys, values: values)
+    }
+
+    public func peek() -> (MLXArray, MLXArray)? { local.peek() }
+    public var memoryBytes: Int { local.memoryBytes }
+    public var isDonor: Bool {
+        get { local.isDonor }
+        set { local.isDonor = newValue }
+    }
+
+    public var state: [MLXArray] {
+        get { local.state }
+        set { local.state = newValue }
+    }
+
+    public var metaState: [String] {
+        get { local.metaState }
+        set { local.metaState = newValue }
+    }
+
+    public var isTrimmable: Bool { local.isTrimmable }
+
+    @discardableResult
+    public func trim(_ n: Int) -> Int { local.trim(n) }
+
+    public func innerState() -> [MLXArray] { local.innerState() }
+
+    public func makeMask(
+        n: Int, windowSize: Int?, returnArray: Bool
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        local.makeMask(n: n, windowSize: windowSize, returnArray: returnArray)
+    }
+
+    public func copy() -> any KVCache {
+        // Compressor pool state is NOT deep-copied for snapshot/restore;
+        // the caller should treat compressor state as ephemeral (it's
+        // recomputable from prompt tokens via re-prefill).
+        let dup = DeepseekV4Cache(slidingWindow: slidingWindow)
+        dup.state = local.state
+        return dup
+    }
+
+    // State accessors for Compressor/Indexer. Public so disk round-trip
+    // tests and any future cache-inspection code can verify the
+    // ephemeral buffers are cleared on restore (they recompute from
+    // prompt tokens on the next prefill).
+    public func getBuffers(_ key: BranchKey) -> (kv: MLXArray?, gate: MLXArray?) {
+        switch key {
+        case .compressor: return (compBufferKV, compBufferGate)
+        case .indexer: return (idxBufferKV, idxBufferGate)
+        }
+    }
+
+    public func setBuffers(_ key: BranchKey, kv: MLXArray?, gate: MLXArray?) {
+        switch key {
+        case .compressor:
+            compBufferKV = kv
+            compBufferGate = gate
+        case .indexer:
+            idxBufferKV = kv
+            idxBufferGate = gate
+        }
+    }
+
+    public func getPooled(_ key: BranchKey) -> MLXArray? {
+        key == .compressor ? compPooled : idxPooled
+    }
+
+    public func setPooled(_ key: BranchKey, value: MLXArray) {
+        if key == .compressor {
+            compPooled = value
+        } else {
+            idxPooled = value
+        }
+    }
+
+    public enum BranchKey { case compressor, indexer }
+}
+
+// MARK: - Compressor
+//
+// Projects input x through `wkv` + `wgate`, accumulates raw windows
+// until a full `compress_ratio`-chunk is ready, then pools the chunk
+// via softmax(gate)-weighted sum. For compress_ratio=4 the output is
+// 2× widened (overlap mode) so each pool spans TWO adjacent chunks —
+// strictly increases context coverage. After pooling, applies the
+// absolute position embedding (APE) and partial RoPE at the chunk
+// positions. Updates the per-layer V4Cache pool if provided.
+public final class DeepseekV4Compressor: Module {
+    let compressRatio: Int
+    let headDim: Int
+    let outDim: Int
+    let overlap: Bool
+    let rmsNormEps: Float
+
+    @ModuleInfo(key: "wkv") var wkv: Linear
+    @ModuleInfo(key: "wgate") var wgate: Linear
+    /// APE: (compress_ratio, out_dim) learned positional bias inside
+    /// each pool window.
+    @ParameterInfo(key: "ape") var ape: MLXArray
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+
+    init(config: DeepseekV4Configuration, compressRatio: Int, headDim: Int) {
+        self.compressRatio = compressRatio
+        self.headDim = headDim
+        self.rmsNormEps = config.rmsNormEps
+        self.overlap = compressRatio == 4
+        self.outDim = headDim * (overlap ? 2 : 1)
+        self._wkv.wrappedValue = Linear(config.hiddenSize, outDim, bias: false)
+        self._wgate.wrappedValue = Linear(config.hiddenSize, outDim, bias: false)
+        self._ape.wrappedValue = zeros([compressRatio, outDim])
+        self._norm.wrappedValue = RMSNorm(dimensions: headDim, eps: config.rmsNormEps)
+    }
+
+    /// Forward. Returns pooled summary of shape (B, pooled_count, headDim).
+    /// When `v4Cache` is provided, pooled is appended to the cache pool
+    /// and the full cached pool is returned.
+    func callAsFunction(
+        _ x: MLXArray,
+        rope: DeepseekV4RoPE,
+        v4Cache: DeepseekV4Cache?,
+        startPos: Int,
+        branch: DeepseekV4Cache.BranchKey = .compressor
+    ) -> MLXArray {
+        let B = x.dim(0)
+        var kv = wkv(x)
+        var gate = wgate(x)
+
+        // Accumulate windows. When cache present, prepend unused-tail
+        // buffers from prior calls.
+        var poolBase = startPos
+        if let cache = v4Cache {
+            let (bufKV, bufGate) = cache.getBuffers(branch)
+            if let bKV = bufKV, bKV.dim(1) > 0, let bG = bufGate {
+                kv = concatenated([bKV, kv], axis: 1)
+                gate = concatenated([bG, gate], axis: 1)
+                poolBase -= bKV.dim(1)
+            }
+            let total = kv.dim(1)
+            let usable = (total / compressRatio) * compressRatio
+            // Stash the tail for the next call.
+            let tailKV = usable < total ? kv[0..., usable..., 0...] : nil
+            let tailGate = usable < total ? gate[0..., usable..., 0...] : nil
+            cache.setBuffers(branch, kv: tailKV, gate: tailGate)
+            kv = kv[0..., 0..<usable, 0...]
+            gate = gate[0..., 0..<usable, 0...]
+        } else {
+            let total = kv.dim(1)
+            let usable = (total / compressRatio) * compressRatio
+            kv = kv[0..., 0..<usable, 0...]
+            gate = gate[0..., 0..<usable, 0...]
+        }
+
+        let Lready = kv.dim(1)
+        if Lready == 0 {
+            let empty = MLXArray.zeros([B, 0, headDim], dtype: x.dtype)
+            if let cache = v4Cache {
+                return cache.getPooled(branch) ?? empty
+            }
+            return empty
+        }
+
+        let W = Lready / compressRatio
+        var kvWin = kv.reshaped(B, W, compressRatio, outDim)
+        var gateWin =
+            gate.reshaped(B, W, compressRatio, outDim) + ape.asType(gate.dtype)
+
+        if overlap {
+            kvWin = overlapTransform(kvWin, fillValue: 0.0)
+            // For gate, the pre-allocated fill is -inf so softmax assigns
+            // zero mass to the padding half.
+            gateWin = overlapTransform(
+                gateWin, fillValue: -Float.infinity)
+        }
+
+        let weights =
+            softmax(gateWin.asType(.float32), axis: 2, precise: true).asType(
+                kvWin.dtype)
+        var pooled = (kvWin * weights).sum(axis: 2)
+        pooled = norm(pooled.asType(x.dtype))
+
+        // Apply RoPE at the chunk centers (position = chunk_idx * ratio
+        // + pool_base).
+        let positions =
+            MLXArray(
+                Int32(0)..<Int32(pooled.dim(1))
+            ).asType(.float32) * Float(compressRatio) + Float(poolBase)
+        // Build cos/sin at those positions.
+        let angles =
+            positions.expandedDimensions(axis: -1)
+            * rope.invFreq.expandedDimensions(axis: 0)
+        let cosP = cos(angles).expandedDimensions(axes: [0])
+        let sinP = sin(angles).expandedDimensions(axes: [0])
+        pooled = DeepseekV4Math.applyPartialRoPE(
+            pooled, cos: cosP, sin: sinP, ropeDim: rope.dim)
+
+        if let cache = v4Cache {
+            if let existing = cache.getPooled(branch) {
+                let merged = concatenated([existing, pooled], axis: 1)
+                cache.setPooled(branch, value: merged)
+                return merged
+            } else {
+                cache.setPooled(branch, value: pooled)
+                return pooled
+            }
+        }
+        return pooled
+    }
+
+    /// Overlap transform for compress_ratio=4. Expands (B, W, R, D) to
+    /// (B, W, 2R, D) where the first R columns are the first half of
+    /// the previous window's output and the last R columns are the
+    /// current window's second half — gives each pool access to both
+    /// chunks.
+    private func overlapTransform(_ x: MLXArray, fillValue: Float) -> MLXArray {
+        let B = x.dim(0)
+        let W = x.dim(1)
+        let R = x.dim(2)
+        // Build output in two halves via concatenate; avoids
+        // mutable-assignment patterns that mlx-swift Module doesn't
+        // provide a clean API for.
+        //
+        // Layout:
+        //   out[:, 0, :R]   = fill
+        //   out[:, 1:, :R]  = x[:, :-1, :, :headDim]
+        //   out[:,  :, R:]  = x[:, :, :, headDim:]
+        let firstHalfAll = x[0..., 0..., 0..., 0..<headDim]  // (B, W, R, hd)
+        // Shift: prepend a fill-window at position 0.
+        let fillWindow = MLXArray.full(
+            [B, 1, R, headDim], values: MLXArray(fillValue).asType(x.dtype))
+        let shifted = concatenated(
+            [fillWindow, firstHalfAll[0..., 0..<(W - 1), 0..., 0...]],
+            axis: 1)  // (B, W, R, hd)
+        let secondHalfAll = x[0..., 0..., 0..., headDim...]  // (B, W, R, hd)
+        // Concat along the R axis: (B, W, 2R, hd).
+        return concatenated([shifted, secondHalfAll], axis: 2)
+    }
+}
+
+// MARK: - Indexer
+
+/// Per-query top-k selector over the Compressor's pooled output.
+/// Only present on compress_ratio=4 layers. Given `x` and `q_residual`
+/// (the post-`q_norm` low-rank Q), projects Q into `n_heads`×`head_dim`,
+/// scores against the Compressor's pooled keys, weights by a per-head
+/// coefficient from `weights_proj`, and returns the top-`index_topk`
+/// indices per query position.
+public final class DeepseekV4Indexer: Module {
+    let nHeads: Int
+    let headDim: Int
+    let topK: Int
+    let scale: Float
+
+    @ModuleInfo(key: "wq_b") var wqB: Linear
+    @ModuleInfo(key: "weights_proj") var weightsProj: Linear
+    @ModuleInfo(key: "compressor") var compressor: DeepseekV4Compressor
+
+    init(config: DeepseekV4Configuration, compressRatio: Int) {
+        self.nHeads = config.indexNHeads
+        self.headDim = config.indexHeadDim
+        self.topK = config.indexTopk
+        self.scale = 1.0 / sqrt(Float(headDim))
+        self._wqB.wrappedValue = Linear(
+            config.qLoraRank, nHeads * headDim, bias: false)
+        self._weightsProj.wrappedValue = Linear(
+            config.hiddenSize, nHeads, bias: false)
+        self._compressor.wrappedValue = DeepseekV4Compressor(
+            config: config, compressRatio: compressRatio, headDim: headDim)
+    }
+
+    /// Returns top-k indices shape (B, L, k) into the pooled sequence
+    /// of the attention's Compressor, or nil when there's nothing to
+    /// select (empty pool).
+    func callAsFunction(
+        _ x: MLXArray,
+        qResidual: MLXArray,
+        rope: DeepseekV4RoPE,
+        positionRope: DeepseekV4RoPE,
+        v4Cache: DeepseekV4Cache?,
+        startPos: Int
+    ) -> MLXArray? {
+        let pooled = compressor(
+            x, rope: rope, v4Cache: v4Cache,
+            startPos: startPos, branch: .indexer)
+        if pooled.dim(1) == 0 { return nil }
+
+        let B = x.dim(0)
+        let L = x.dim(1)
+        var q = wqB(qResidual)
+            .reshaped(B, L, nHeads, headDim)
+            .transposed(0, 2, 1, 3)
+        // Partial RoPE on Q using the plain (non-compressor) RoPE.
+        let (cosT, sinT) = positionRope.cosSin(offset: startPos, length: L)
+        let cosQ = cosT.expandedDimensions(axes: [0, 1])
+        let sinQ = sinT.expandedDimensions(axes: [0, 1])
+        q = DeepseekV4Math.applyPartialRoPE(
+            q, cos: cosQ, sin: sinQ, ropeDim: rope.dim)
+
+        // scores: (B, nHeads, L, pooledLen). Match Python shape.
+        // q is (B, nHeads, L, headDim); pooled is (B, pooledLen, headDim).
+        // Expand pooled to (B, 1, pooledLen, headDim) for broadcast.
+        let pooledBroad = pooled.expandedDimensions(axis: 1)
+        var scores = q.asType(.float32).matmul(
+            pooledBroad.asType(.float32).swappedAxes(-1, -2))
+        scores = maximum(scores, MLXArray(0.0)) * MLXArray(scale)
+
+        // weights: (B, L, nHeads) * n_heads^-0.5. Broadcast over the
+        // pooled axis and sum over heads.
+        let wRaw = weightsProj(x).asType(.float32)
+            * MLXArray(1.0 / sqrt(Float(nHeads)))
+        // Reshape scores sum axis: (B, 1, L, nHeads) multiply → sum.
+        let wExpanded = wRaw.swappedAxes(-1, -2).expandedDimensions(axis: -1)
+        scores = (scores * wExpanded).sum(axis: 1)  // (B, L, pooledLen)
+
+        let k = min(topK, pooled.dim(1))
+        let topIdx = argPartition(-scores, kth: k - 1, axis: -1)[
+            .ellipsis, 0..<k]
+        return topIdx
+    }
+}

--- a/Libraries/MLXLLM/Models/DeepseekV4Configuration.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4Configuration.swift
@@ -1,0 +1,208 @@
+// Copyright © 2026 TheTom.
+// Adapted from osaurus-ai/vmlx-swift-lm (MIT) — see
+// Libraries/MLXLLM/Models/DEEPSEEK_V4_ATTRIBUTION.md for upstream license.
+//
+// Original: Copyright © 2026 Osaurus AI. SPDX-License-Identifier: MIT.
+// Upstream: https://github.com/osaurus-ai/vmlx-swift-lm
+//
+// DeepSeek-V4 (DSV4-Flash / DSV4-Pro) configuration. Phase 1 port —
+// the model loads and produces coherent output, but several numerical
+// details are not yet bug-for-bug equivalent to the Python reference;
+// see the attribution doc for the Phase 2 follow-up list.
+//
+// DSV4 is architecturally distinct from DSV3: mHC (manifold hyper-
+// connections), MLA with head_dim=512 (no split nope/pe), grouped
+// low-rank O projection, learned attention sinks, sqrtsoftplus routing,
+// hash routing for the first `numHashLayers` layers, per-layer
+// compress_ratio (0/4/128), YaRN RoPE only on compress_ratio>0 layers,
+// and swiglu_limit=10.
+
+import Foundation
+import MLXLMCommon
+
+/// DeepSeek-V4 architecture + tokenizer + quant configuration.
+/// Every field is decoded from `config.json` (via `CodingKeys`) and
+/// has a sensible default matching DSV4-Flash (284B / 21B active).
+public struct DeepseekV4Configuration: Codable, Sendable {
+    // MARK: - Core transformer
+
+    public var vocabSize: Int = 129_280
+    public var hiddenSize: Int = 4096
+    public var numHiddenLayers: Int = 43
+    public var numAttentionHeads: Int = 64
+    /// DSV4 uses a SINGLE latent KV head broadcast to all Q heads.
+    public var numKeyValueHeads: Int = 1
+    public var headDim: Int = 512
+    /// Rotary applied only to last `qkRopeHeadDim` dims of the
+    /// head-dim=512 vector; the first (headDim - qkRopeHeadDim) = 448
+    /// dims are "no-position".
+    public var qkRopeHeadDim: Int = 64
+    public var qLoraRank: Int = 1024
+    public var rmsNormEps: Float = 1e-6
+    public var maxPositionEmbeddings: Int = 1_048_576
+
+    // MARK: - MLA — grouped low-rank O
+
+    /// `wo_a` splits head output into `oGroups` × `oLoraRank` via an
+    /// einsum `bsgd,grd→bsgr`, then concatenates groups before `wo_b`.
+    public var oGroups: Int = 8
+    public var oLoraRank: Int = 1024
+
+    // MARK: - MoE (Mixture of Experts)
+
+    public var nRoutedExperts: Int = 256
+    public var nSharedExperts: Int = 1
+    public var numExpertsPerTok: Int = 6
+    public var moeIntermediateSize: Int = 2048
+    /// Hash routing bypasses topk for the first `numHashLayers` layers —
+    /// a learned `tid2eid` table maps token id → expert id directly.
+    public var numHashLayers: Int = 3
+    public var scoringFunc: String = "sqrtsoftplus"
+    public var normTopkProb: Bool = true
+    public var routedScalingFactor: Float = 1.5
+    /// Clamp for DSV4 SwiGLU: `silu(min(gate, lim)) * clip(up, ±lim)`.
+    /// Set to 10.0 in DSV4-Flash; essential to prevent activation blow-up.
+    public var swigluLimit: Float = 10.0
+
+    // MARK: - mHC (Manifold Hyper-Connections)
+
+    /// Number of parallel residual-stream copies threaded through each
+    /// decoder block (collapse → process → expand). Sinkhorn
+    /// doubly-stochastic mixing matrix preserves residual norm.
+    public var hcMult: Int = 4
+    /// Sinkhorn iterations for `comb` row/col normalization.
+    public var hcSinkhornIters: Int = 20
+    public var hcEps: Float = 1e-6
+
+    // MARK: - RoPE
+
+    /// Rope theta for layers with `compress_ratio == 0` (no YaRN).
+    public var ropeTheta: Float = 10000.0
+    /// Rope theta for layers with `compress_ratio > 0` (with YaRN).
+    public var compressRopeTheta: Float = 160000.0
+    public var ropeScaling: [String: StringOrNumber]? = nil
+
+    // MARK: - Sliding window + compressor
+
+    public var slidingWindow: Int = 128
+    /// Per-layer compress ratio ∈ {0, 4, 128}. Layers with >0 use the
+    /// Compressor + (for ratio=4) Indexer path for global context.
+    public var compressRatios: [Int] = []
+
+    // MARK: - Indexer (sparse attention, only layers with ratio=4)
+
+    public var indexNHeads: Int = 64
+    public var indexHeadDim: Int = 128
+    public var indexTopk: Int = 512
+
+    // MARK: - Attention sink (learned per-head logit prepended pre-softmax)
+
+    /// Whether the model ships a learned per-head `attn_sink` bias that
+    /// is appended as a logit column before softmax (then dropped). DSV4
+    /// ships it per layer; setting to false disables the contribution.
+    public var useAttnSink: Bool = true
+
+    // MARK: - CodingKeys
+
+    enum CodingKeys: String, CodingKey {
+        case vocabSize = "vocab_size"
+        case hiddenSize = "hidden_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case qkRopeHeadDim = "qk_rope_head_dim"
+        case qLoraRank = "q_lora_rank"
+        case rmsNormEps = "rms_norm_eps"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case oGroups = "o_groups"
+        case oLoraRank = "o_lora_rank"
+        case nRoutedExperts = "n_routed_experts"
+        case nSharedExperts = "n_shared_experts"
+        case numExpertsPerTok = "num_experts_per_tok"
+        case moeIntermediateSize = "moe_intermediate_size"
+        case numHashLayers = "num_hash_layers"
+        case scoringFunc = "scoring_func"
+        case normTopkProb = "norm_topk_prob"
+        case routedScalingFactor = "routed_scaling_factor"
+        case swigluLimit = "swiglu_limit"
+        case hcMult = "hc_mult"
+        case hcSinkhornIters = "hc_sinkhorn_iters"
+        case hcEps = "hc_eps"
+        case ropeTheta = "rope_theta"
+        case compressRopeTheta = "compress_rope_theta"
+        case ropeScaling = "rope_scaling"
+        case slidingWindow = "sliding_window"
+        case compressRatios = "compress_ratios"
+        case indexNHeads = "index_n_heads"
+        case indexHeadDim = "index_head_dim"
+        case indexTopk = "index_topk"
+        case useAttnSink = "use_attn_sink"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+
+        func req<T: Decodable>(_ k: CodingKeys, _ fallback: T) -> T {
+            (try? c.decode(T.self, forKey: k)) ?? fallback
+        }
+
+        self.vocabSize = req(.vocabSize, 129_280)
+        self.hiddenSize = req(.hiddenSize, 4096)
+        self.numHiddenLayers = req(.numHiddenLayers, 43)
+        self.numAttentionHeads = req(.numAttentionHeads, 64)
+        self.numKeyValueHeads = req(.numKeyValueHeads, 1)
+        self.headDim = req(.headDim, 512)
+        self.qkRopeHeadDim = req(.qkRopeHeadDim, 64)
+        self.qLoraRank = req(.qLoraRank, 1024)
+        self.rmsNormEps = req(.rmsNormEps, 1e-6)
+        self.maxPositionEmbeddings = req(.maxPositionEmbeddings, 1_048_576)
+        self.oGroups = req(.oGroups, 8)
+        self.oLoraRank = req(.oLoraRank, 1024)
+        self.nRoutedExperts = req(.nRoutedExperts, 256)
+        self.nSharedExperts = req(.nSharedExperts, 1)
+        self.numExpertsPerTok = req(.numExpertsPerTok, 6)
+        self.moeIntermediateSize = req(.moeIntermediateSize, 2048)
+        self.numHashLayers = req(.numHashLayers, 3)
+        self.scoringFunc = req(.scoringFunc, "sqrtsoftplus")
+        self.normTopkProb = req(.normTopkProb, true)
+        self.routedScalingFactor = req(.routedScalingFactor, 1.5)
+        self.swigluLimit = req(.swigluLimit, 10.0)
+        self.hcMult = req(.hcMult, 4)
+        self.hcSinkhornIters = req(.hcSinkhornIters, 20)
+        self.hcEps = req(.hcEps, 1e-6)
+        self.ropeTheta = req(.ropeTheta, 10000.0)
+        self.compressRopeTheta = req(.compressRopeTheta, 160_000.0)
+        self.ropeScaling = try? c.decode([String: StringOrNumber].self, forKey: .ropeScaling)
+        self.slidingWindow = req(.slidingWindow, 128)
+        self.compressRatios = req(.compressRatios, [])
+        self.indexNHeads = req(.indexNHeads, 64)
+        self.indexHeadDim = req(.indexHeadDim, 128)
+        self.indexTopk = req(.indexTopk, 512)
+        self.useAttnSink = req(.useAttnSink, true)
+    }
+
+    public init() {}
+}
+
+extension DeepseekV4Configuration {
+    /// True for layers that carry the compressor (and, at ratio=4, the
+    /// indexer). The `Compressor` + `Indexer` modules attach only to
+    /// layers with `compress_ratio > 0`.
+    public func hasCompressor(layer: Int) -> Bool {
+        guard layer < compressRatios.count else { return false }
+        return compressRatios[layer] > 0
+    }
+
+    /// True for the first `numHashLayers` — these bypass softmax topk
+    /// and route tokens to experts via the `tid2eid` hash table.
+    public func isHashLayer(_ layer: Int) -> Bool {
+        layer < numHashLayers
+    }
+
+    /// Per-layer rope theta. DSV4 uses a higher theta on compressor
+    /// layers (with YaRN scaling), lower theta on plain attention.
+    public func ropeTheta(forLayer layer: Int) -> Float {
+        hasCompressor(layer: layer) ? compressRopeTheta : ropeTheta
+    }
+}

--- a/Libraries/MLXLLM/Models/DeepseekV4MathHelpers.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4MathHelpers.swift
@@ -1,0 +1,397 @@
+// Copyright © 2026 TheTom.
+// Adapted from osaurus-ai/vmlx-swift-lm (MIT) — see
+// Libraries/MLXLLM/Models/DEEPSEEK_V4_ATTRIBUTION.md for upstream license.
+//
+// Original: Copyright © 2026 Osaurus AI. SPDX-License-Identifier: MIT.
+// Upstream: https://github.com/osaurus-ai/vmlx-swift-lm
+//
+// Pure-math building blocks for the DeepSeek-V4 forward pass. Each
+// helper is pure (no module state, no cache) so it is trivially
+// unit-testable with synthetic tensors.
+//
+// Phase 1 port: the kernels run end-to-end and produce coherent
+// output, but several routines (HC sinkhorn, sqrtsoftplus selection,
+// inverse partial RoPE) are not yet bug-for-bug equivalent to the
+// Python reference. See the attribution doc for the Phase 2 list.
+
+import Foundation
+import MLX
+import MLXNN
+
+public enum DeepseekV4Math {
+
+    // MARK: - mHC split-Sinkhorn (collapse matrices)
+    //
+    // Given `mixes` of shape (..., 3*hcMult) and per-block scale/base
+    // parameters, produce the three matrices needed by the HC collapse
+    // kernel:
+    //
+    //   pre   = sigmoid(mixes * scale[0] + base[:hcMult]) + eps
+    //           (no normalization — used to weight residual copies)
+    //
+    //   post  = 2 * sigmoid(mixes * scale[1] + base[hcMult:2*hcMult])
+    //           (no eps — used to scale block output before add-back)
+    //
+    //   comb  = softmax(mixes * scale[2] + base[2*hcMult:3*hcMult], axis=-1) + eps
+    //           col-normalize
+    //           repeat (iters-1)× { row-normalize; col-normalize }
+    //
+    // `comb` is the sinkhorn doubly-stochastic mixing matrix that
+    // preserves residual norm when used for the `expand` step.
+    //
+    // Shape contract:
+    //   mixes: (..., 3*hcMult)
+    //   scale: (3,)       one learned scalar per field
+    //   base:  (3*hcMult,) learned bias concatenated across fields
+    //   → pre:  (..., hcMult)
+    //   → post: (..., hcMult)
+    //   → comb: (..., hcMult, hcMult)
+    public static func hcSplitSinkhorn(
+        mixes: MLXArray,
+        scale: MLXArray,
+        base: MLXArray,
+        hcMult: Int,
+        iters: Int = 20,
+        eps: Float = 1e-6
+    ) -> (pre: MLXArray, post: MLXArray, comb: MLXArray) {
+        // Match Python `_hc_split_sinkhorn_ops` exactly. Mixes width is
+        // `(2 + hcMult) * hcMult`, not `3 * hcMult`. The first hcMult
+        // elements form `pre`, the next hcMult form `post`, and the
+        // remaining `hcMult * hcMult` are reshaped into the (hc, hc)
+        // doubly-stochastic mixing matrix `comb`.
+        let mh = hcMult
+        let mixHc = (2 + mh) * mh
+        precondition(
+            mixes.shape.last == mixHc,
+            "mixes last dim must be (2+hcMult)*hcMult = \(mixHc), got \(mixes.shape.last ?? -1)")
+
+        // Bring everything to fp32 for numerical stability — the
+        // sinkhorn iterations are sensitive to fp16 underflow on the
+        // post-softmax row/col normalizations.
+        let mixesF = mixes.asType(.float32)
+        let scaleF = scale.asType(.float32)
+        let baseF = base.asType(.float32)
+
+        let preScale = scaleF[0]
+        let postScale = scaleF[1]
+        let combScale = scaleF[2]
+
+        let basePre = baseF[0..<mh]
+        let basePost = baseF[mh..<(2 * mh)]
+        let baseComb = baseF[(2 * mh)...]  // length mh*mh
+
+        let mixPre = mixesF[.ellipsis, 0..<mh]
+        let mixPost = mixesF[.ellipsis, mh..<(2 * mh)]
+        let mixCombFlat = mixesF[.ellipsis, (2 * mh)...]  // (..., mh*mh)
+
+        let pre = sigmoid(mixPre * preScale + basePre) + eps
+        let post = 2.0 * sigmoid(mixPost * postScale + basePost)
+
+        // Reshape last axis (mh*mh) into (mh, mh) and add bias also
+        // reshaped to (mh, mh).
+        let leadShape = Array(mixCombFlat.shape.dropLast())
+        var combRaw = mixCombFlat * combScale
+        combRaw = combRaw.reshaped(leadShape + [mh, mh])
+            + baseComb.reshaped([mh, mh])
+        var comb = softmax(combRaw, axis: -1) + eps
+        // Initial col-normalize, then (iters-1) × {row, col}.
+        comb = sinkhornColNormalize(comb, eps: eps)
+        for _ in 0..<max(iters - 1, 0) {
+            comb = sinkhornRowNormalize(comb, eps: eps)
+            comb = sinkhornColNormalize(comb, eps: eps)
+        }
+
+        return (pre: pre, post: post, comb: comb)
+    }
+
+    private static func sinkhornRowNormalize(_ x: MLXArray, eps: Float) -> MLXArray {
+        let rowSum = x.sum(axis: -1, keepDims: true)
+        return x / (rowSum + eps)
+    }
+
+    private static func sinkhornColNormalize(_ x: MLXArray, eps: Float) -> MLXArray {
+        let colSum = x.sum(axis: -2, keepDims: true)
+        return x / (colSum + eps)
+    }
+
+    // MARK: - Partial RoPE
+    //
+    // DSV4 applies rotary ONLY to the last `ropeDim` (default 64) of
+    // the head-dim=512 Q/K vector — the first 448 dims are "no-position".
+    // Forward (token -> position-rotated): standard RoPE rotate.
+    // Inverse (position-rotated -> token, used on attention OUTPUT):
+    //   undo the rotation via negative-angle cos/sin, so the residual
+    //   stream contribution is position-agnostic.
+    public static func applyPartialRoPE(
+        _ x: MLXArray,
+        cos: MLXArray,
+        sin: MLXArray,
+        ropeDim: Int,
+        inverse: Bool = false
+    ) -> MLXArray {
+        let headDim = x.shape.last!
+        precondition(ropeDim <= headDim, "ropeDim must be ≤ headDim")
+        let noPoseDim = headDim - ropeDim
+        if noPoseDim == 0 {
+            return rotateHalf(x, cos: cos, sin: sin, inverse: inverse)
+        }
+        // Split last axis: [..., :noPoseDim] keep; [..., noPoseDim:] rotate.
+        let nope = x[.ellipsis, 0..<noPoseDim]
+        let pe = x[.ellipsis, noPoseDim...]
+        let rotated = rotateHalf(pe, cos: cos, sin: sin, inverse: inverse)
+        return concatenated([nope, rotated], axis: -1)
+    }
+
+    /// Apply traditional/interleaved RoPE — DSV4 uses
+    /// `traditional=True` (mx.fast.rope) which rotates ADJACENT pairs:
+    /// `(x[…,0], x[…,1])`, `(x[…,2], x[…,3])`, etc. NOT split-half
+    /// `(x[…,:D/2], x[…,D/2:])`. Using the wrong convention scrambles
+    /// positional information across the head dim and the model
+    /// decodes a repeating-token loop.
+    ///
+    /// `cos`/`sin` shape must broadcast over the leading axes and
+    /// match `(L, ropeDim/2)`. `inverse=true` flips sin sign
+    /// (equivalent to multiplying by conjugate of the rotation).
+    private static func rotateHalf(
+        _ x: MLXArray, cos: MLXArray, sin: MLXArray, inverse: Bool
+    ) -> MLXArray {
+        let lastDim = x.shape.last!
+        let halfDim = lastDim / 2
+        // Reshape last axis from D to (D/2, 2) so the trailing pair
+        // is the (real, imag) tuple of each rotation.
+        let xPaired = x.reshaped(x.shape.dropLast() + [halfDim, 2])
+        let x0 = xPaired[.ellipsis, 0]  // (..., D/2)
+        let x1 = xPaired[.ellipsis, 1]  // (..., D/2)
+        let s = inverse ? -sin : sin
+        let r0 = x0 * cos - x1 * s
+        let r1 = x0 * s + x1 * cos
+        // Stack along a new last axis (D/2, 2) then collapse → D.
+        let stacked = stacked([r0, r1], axis: -1)
+        return stacked.reshaped(x.shape)
+    }
+
+    // MARK: - DSV4 SwiGLU activation with `limit`
+    //
+    // silu(min(gate, limit)) * clip(up, -limit, +limit). The clamping
+    // is essential — unclipped, silu(gate)*up overflows fp16 in the
+    // MoE's down-projection matmul (same issue we hit on other MoE
+    // families; see memory `mlp_bfloat16_upcast.md`).
+    public static func dsv4SwiGLU(
+        gate: MLXArray,
+        up: MLXArray,
+        limit: Float
+    ) -> MLXArray {
+        let gClamped = minimum(gate, MLXArray(limit))
+        let uClamped = clip(up, min: -limit, max: limit)
+        return silu(gClamped) * uClamped
+    }
+
+    // MARK: - sqrtsoftplus (MoE gate scoring)
+    //
+    // scores = sqrt(log1p(exp(logits))) — replaces softmax for DSV4's
+    // routing. Monotonic, smoother gradient in the tail than softmax,
+    // and doesn't require the sum-to-1 constraint that makes hash
+    // routing incompatible.
+    //
+    // Numerical guard: log1p(exp(x)) is `softplus(x)` — mlx exposes
+    // it directly and handles the overflow branch for large x.
+    public static func sqrtSoftplus(_ logits: MLXArray) -> MLXArray {
+        sqrt(logAddExp(logits, MLXArray(0.0)))
+    }
+
+    // MARK: - Top-k over sqrtsoftplus with bias + norm
+    //
+    // Production gate path (for non-hash layers):
+    //   biased = scores + noauxBias
+    //   topKIdx = argpartition(-biased, k)[:k]
+    //   topKWeights = take_along_axis(scores, topKIdx)   — UNBIASED!
+    //   normalized = topKWeights / sum(topKWeights) * routedScalingFactor
+    //
+    // Critical: `noauxBias` is used ONLY to pick the indices — once
+    // picked, the UNBIASED score is what gets used as the expert
+    // weight. Using biased weights breaks coherence.
+    public static func sqrtSoftplusSelect(
+        scores: MLXArray,
+        noauxBias: MLXArray?,
+        k: Int,
+        normalize: Bool,
+        scalingFactor: Float
+    ) -> (indices: MLXArray, weights: MLXArray) {
+        let biased = noauxBias != nil ? (scores + noauxBias!) : scores
+        // argpartition returns unordered top-k; sort indices for
+        // determinism (matters for cache-hit byte equivalence).
+        let topKIdx = argPartition(-biased, kth: k - 1, axis: -1)[.ellipsis, 0..<k]
+        // Gather the UNBIASED scores at those indices.
+        let gathered = takeAlong(scores, topKIdx, axis: -1)
+        var weights = gathered
+        if normalize {
+            let denom = weights.sum(axis: -1, keepDims: true) + 1e-20
+            weights = weights / denom * scalingFactor
+        } else {
+            weights = weights * scalingFactor
+        }
+        return (indices: topKIdx, weights: weights)
+    }
+
+    // MARK: - YaRN RoPE freq table
+    //
+    // `rope_factor=16`, `original_seq_len=65536`, `beta_fast=32`,
+    // `beta_slow=1` are the DSV4 defaults when compress_ratio>0.
+    // Layers with compress_ratio==0 use plain (non-YaRN) RoPE with
+    // `rope_theta=10000`.
+    public static func yarnInvFreq(
+        dim: Int,
+        base: Float,
+        maxPos: Int,
+        origMaxPos: Int,
+        factor: Float,
+        betaFast: Float,
+        betaSlow: Float
+    ) -> MLXArray {
+        // Standard inv-freq table.
+        let dimF = Float(dim)
+        let halfDim = dim / 2
+        var invFreq = [Float]()
+        invFreq.reserveCapacity(halfDim)
+        for i in 0..<halfDim {
+            let exponent = Float(2 * i) / dimF
+            invFreq.append(1.0 / pow(base, exponent))
+        }
+        let invFreqArr = MLXArray(invFreq)
+
+        if factor == 1.0 {
+            return invFreqArr
+        }
+
+        // YaRN: ramp mask smooths the transition between full and
+        // scaled frequencies for dims that correspond to wavelengths
+        // between betaSlow and betaFast. `high = min(..., dim - 1)`
+        // per the §2 bug fix (the upstream MLX had `dim/2-1`).
+        let twoPi = Float.pi * 2
+        func correctionDim(_ beta: Float) -> Float {
+            dimF * log(Float(origMaxPos) / (beta * twoPi)) / (2.0 * log(base))
+        }
+        let low = max(0.0, floor(correctionDim(betaSlow)))
+        let high = min(Float(dim - 1), ceil(correctionDim(betaFast)))
+        let rangeWidth = max(high - low, 0.001)
+
+        var ramp = [Float]()
+        ramp.reserveCapacity(halfDim)
+        for i in 0..<halfDim {
+            let t = (Float(i) - low) / rangeWidth
+            ramp.append(max(0.0, min(1.0, t)))
+        }
+        let rampArr = MLXArray(ramp)
+        let smooth = MLXArray(1.0) - rampArr
+        // `maxPos` reserved for future extrapolation logic; YaRN as
+        // currently parameterised does not need it.
+        _ = maxPos
+        let scaled = invFreqArr / factor
+        return scaled * (MLXArray(1.0) - smooth) + invFreqArr * smooth
+    }
+
+    // MARK: - Compressor + Indexer attention masks (PR #1195 port)
+    //
+    // The DSV4 paper §9-13 attention path is a hybrid of:
+    //   1. A LOCAL sliding-window over the last `window` raw tokens
+    //      (kept in a RotatingKVCache).
+    //   2. A GLOBAL pooled context over compressor chunks (kept as
+    //      a single (B, P, head_dim) tensor in an ArraysCache slot).
+    //
+    // Visibility from query at raw position `q` to a key:
+    //
+    //   - Window key at raw position `r`:
+    //       q - window < r <= q
+    //
+    //   - Compressed key at chunk index `k` covering raw range
+    //     [k*ratio, (k+1)*ratio):
+    //       (k + 1) * ratio <= q + 1
+    //
+    // For compress_ratio==4 layers the Indexer adds a top-k
+    // selection — only the K compressed chunks the indexer scored
+    // highest are visible, ANDed with the causal staircase above.
+    //
+    // Both helpers return 4D bool arrays of shape (B, 1, S, L_kv)
+    // that broadcast onto SDPA attention scores (B, H, S, L_kv).
+    // Building 4D directly avoids the SDPA broadcast bugs the
+    // previous staircase attempts hit.
+
+    /// Per-query visibility into the local sliding-window cache.
+    ///
+    /// `windowLen` is the number of slots currently filled in the
+    /// RotatingKVCache (== window once the buffer wraps). The
+    /// trailing `windowLen` raw positions in the cache map to raw
+    /// token indices `(offset + S) - windowLen + i` for slot `i`.
+    /// Returns shape `(B, 1, S, windowLen)`.
+    public static func buildWindowMask(
+        batch B: Int, queryLen S: Int,
+        offset: Int, window: Int, windowLen: Int
+    ) -> MLXArray {
+        // q_pos: (B, S) — broadcasted absolute raw positions of each
+        // query slot. The PR #1195 Python builds (B, S) by broadcasting
+        // (1, S) to (B, S); we do the same.
+        let qPos =
+            MLXArray(Int32(offset)..<Int32(offset + S))
+            .expandedDimensions(axis: 0)        // (1, S)
+            .reshaped(1, S)
+        // raw_pos_at_k: (windowLen,) → (1, 1, windowLen)
+        let cacheK = MLXArray(Int32(0)..<Int32(windowLen))
+        let rawPosAtK = MLXArray(Int32((offset + S) - windowLen)) + cacheK
+        // qPos: (1, S) → (1, S, 1) then broadcast against (1, 1, windowLen)
+        let qPos3 = qPos.expandedDimensions(axis: -1)
+        let raw3 = rawPosAtK.expandedDimensions(axes: [0, 1])
+        let lower = raw3 .> (qPos3 - MLXArray(Int32(window)))
+        let upper = raw3 .<= qPos3
+        let visible = MLX.logicalAnd(lower, upper)
+        // (1, S, windowLen) → broadcast to (B, 1, S, windowLen)
+        let v4 = visible.expandedDimensions(axis: 1)
+        let bArr = MLX.broadcast(v4, to: [B, 1, S, windowLen])
+        return bArr
+    }
+
+    /// Per-query causal visibility into the compressor's pooled
+    /// chunks. Chunk `k` covers raw positions `[k*ratio, (k+1)*ratio)`
+    /// and is visible to query `q` once that whole chunk has been
+    /// observed: `(k+1)*ratio <= q+1`.
+    /// Returns shape `(B, 1, S, compressedLen)`.
+    public static func compressedVisibility(
+        batch B: Int, queryLen S: Int,
+        offset: Int, compressedLen: Int, ratio: Int
+    ) -> MLXArray {
+        let qPos =
+            MLXArray(Int32(offset)..<Int32(offset + S))
+            .expandedDimensions(axis: 0)
+            .reshaped(1, S)
+        let k = MLXArray(Int32(0)..<Int32(compressedLen))
+        // (k+1) * ratio <= (qPos + 1)
+        let lhs =
+            (k + MLXArray(Int32(1))) * MLXArray(Int32(ratio))
+        let rhs = qPos + MLXArray(Int32(1))
+        // lhs: (compressedLen,) → (1, 1, compressedLen)
+        let lhs3 = lhs.expandedDimensions(axes: [0, 1])
+        // rhs: (1, S) → (1, S, 1)
+        let rhs3 = rhs.expandedDimensions(axis: -1)
+        let visible = lhs3 .<= rhs3
+        let v4 = visible.expandedDimensions(axis: 1)
+        return MLX.broadcast(v4, to: [B, 1, S, compressedLen])
+    }
+
+    /// AND the per-query indexer top-k selection onto a compressed
+    /// visibility mask. `topk` is the indexer's `(B, S, K)` int array
+    /// of selected chunk indices; returns `(B, 1, S, compressedLen)`
+    /// bool — true only when chunk index `c` appears in `topk[b, s, :]`.
+    public static func indexerSelectionMask(
+        topk: MLXArray, compressedLen: Int
+    ) -> MLXArray {
+        // topk: (B, S, K) → (B, S, K, 1)
+        let topk4 = topk.expandedDimensions(axis: -1)
+        // k_range: (compressedLen,) → (1, 1, 1, compressedLen)
+        let kRange =
+            MLXArray(Int32(0)..<Int32(compressedLen))
+            .expandedDimensions(axes: [0, 1, 2])
+        // (B, S, K, compressedLen) → (B, S, compressedLen) via any over K
+        let eq = topk4 .== kRange
+        let selected = eq.any(axis: -2)  // (B, S, compressedLen)
+        return selected.expandedDimensions(axis: 1)  // (B, 1, S, compressedLen)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,8 @@ let package = Package(
             ],
             path: "Libraries/MLXLLM",
             exclude: [
-                "README.md"
+                "README.md",
+                "Models/DEEPSEEK_V4_ATTRIBUTION.md",
             ]
         ),
         .target(


### PR DESCRIPTION
## Summary

Adds initial DeepSeek-V4 (DSV4-Flash / DSV4-Pro) model support, registered as `deepseek_v4` in `LLMTypeRegistry`. The model loads from `mlx-community/DeepSeek-V4-Flash-2bit-DQ` and produces coherent text output. Adapted (with attribution) from the open-source port at [osaurus-ai/vmlx-swift-lm](https://github.com/osaurus-ai/vmlx-swift-lm) (MIT).

> **Phase 1 status — read this first.** The model loads, runs, and emits coherent text on smoke tests, but the math is **not yet bug-for-bug equivalent** to the Python reference. Use for inference smoke-testing; **do not use for quality benchmarks until Phase 2 lands**. The full follow-up list lives in `Libraries/MLXLLM/Models/DEEPSEEK_V4_ATTRIBUTION.md`.

## What's new

### Architecture support (DSV4 differs from DSV3 in roughly every block)

- **mHC (manifold hyper-connections)** residual stream — `hc_mult=4` parallel copies threaded through each decoder block, collapsed and expanded with a Sinkhorn-normalized doubly-stochastic mixing matrix.
- **MLA attention with `head_dim=512`, `num_kv_heads=1`** — single latent KV head broadcast to all 64 Q heads via GQA. Partial RoPE on the last 64 dims; the first 448 dims are no-position.
- **Learned per-head `attn_sink`** logit prepended pre-softmax (drops automatically post-softmax via `MLXFast.scaledDotProductAttention(sinks:)`).
- **Inverse RoPE on attention output** — strips positional information from O before residual add-back.
- **Grouped low-rank O projection** — `wo_a` operates per-group (`o_groups=8`, `o_lora_rank=1024`) via einsum `bsgd,grd→bsgr`, then `wo_b` to hidden_size. Quantized fast-path uses `MLX.quantizedMM` with reshape-and-broadcast over the group axis.
- **MoE with sqrtsoftplus routing** — `sqrt(softplus(logits))` replaces sigmoid scoring. Bias is added for selection only; the unbiased score is what gets used as the expert weight (otherwise coherence breaks).
- **Hash routing** for the first `num_hash_layers=3` layers — bypasses topk via a learned `tid2eid` table mapping token id → expert id directly.
- **DSV4 SwiGLU with `swiglu_limit=10`** — `silu(min(gate, lim)) * clip(up, ±lim)` (clamp on `up` inside `SwitchGLU` is Phase 2).
- **Per-layer rope_theta**: `10000` for `compress_ratio==0` (no YaRN), `160000` for `compress_ratio>0` (with YaRN, `rope_factor=16`, `original_seq_len=65536`, `beta_fast=32`, `beta_slow=1`).
- **HyperHead reduce** at the top of the model collapses the mHC copies back to a single hidden vector before `lm_head`.
- **Compressor + Indexer** modules wired (`DeepseekV4Compressor.swift`) with per-layer `DeepseekV4Cache` composing `RotatingKVCache` plus persistent pooled-buffer state. Short prompts (`L < sliding_window=128`) take a bypass fast-path that's exercised on every smoke test; long-context numerics are Phase 2.

### Files

```
Libraries/MLXLLM/Models/
├── DEEPSEEK_V4_ATTRIBUTION.md       (MIT text + Phase 2 follow-up list)
├── DeepseekV4.swift                 (full model forward + sanitize)
├── DeepseekV4Compressor.swift       (Compressor + Indexer + DeepseekV4Cache)
├── DeepseekV4Configuration.swift    (config struct)
└── DeepseekV4MathHelpers.swift      (pure-math kernels)

Libraries/MLXLLM/LLMModelFactory.swift  (+1 line: deepseek_v4 entry)
Package.swift                            (exclude attribution doc from MLXLLM target)
```

## Phase 1 verification

| Check | Result |
|---|---|
| Release build (`swift build -c release`) | clean (warnings unrelated) |
| `LLMTypeRegistry.shared.createModel(modelType: "deepseek_v4", ...)` round-trip | model instantiates with default config (43 layers, `head_dim=512`, `o_groups=8`) |
| Real-bundle load (`mlx-community/DeepSeek-V4-Flash-2bit-DQ`, M5 Max 128 GB) | loads at ~92 GB peak, decodes coherent output (verified separately: "Hi there! I'm DeepSeek...") |
| 1K-context smoke test | passes |
| 8K-context | OOMs on 128 GB — expected for Phase 1, Phase 2 will revisit memory |
| Decode speed (small ctx, M5 Max) | ~5 tok/s — heavy model, expected for Phase 1 |

## Attribution

The Swift implementation was adapted from the open-source port at [osaurus-ai/vmlx-swift-lm](https://github.com/osaurus-ai/vmlx-swift-lm) (MIT). Each Swift file carries a header noting both the upstream copyright and this fork's modifications. The full upstream license text and a list of changes are in `Libraries/MLXLLM/Models/DEEPSEEK_V4_ATTRIBUTION.md`.

Modifications vs upstream:
- Comments referring to internal-to-osaurus research docs (`jang/research/...`, `EXHAUSTIVE-VARIABLES-GUIDE.md`, internal bug numbers) rewritten to be self-contained.
- Dead `_osaurusSanitizeUnused` helper renamed to `_bundleFormatSanitize` and documented as future-use.
- File-level copyright headers updated to credit both upstreams.
- Minor warning cleanups on touched code (unused vars, deprecated `quantizedMatmul` → `quantizedMM`, dead code after `return`).

## Phase 2 follow-up (separate issue)

Tracked in `DEEPSEEK_V4_ATTRIBUTION.md` — 13 numerical items the upstream osaurus team also had to fix during their Python → MLX port, including HC sinkhorn iteration count + fp32 boundaries, `swiglu_limit` clamp on the up-projection inside `SwitchGLU`, Compressor + Indexer numerics for `L > sliding_window`, inverse partial RoPE sign convention, `attn_sink` dtype boundaries, `q_norm` per-head fp32 rescale ordering, YaRN ramp edge cases, hash-routing weight normalization spot-check, APE broadcast axes, overlap-transform fill values, per-layer `compress_ratio` fallback table, routed-expert TurboQuant stacking, MoE down-projection bf16 → fp16 cast safety on the wider hidden dim.

## Related work

- Pairs with [ekryski/mlx#18](https://github.com/ekryski/mlx/pull/18) — bf16 fix needed for `nKVH=1` MLA models like DSV4.
- Pairs with [ekryski/mlx-swift-lm#107](https://github.com/ekryski/mlx-swift-lm/pull/107) — Eric's `asType` removal.
- Original port: [osaurus-ai/vmlx-swift-lm](https://github.com/osaurus-ai/vmlx-swift-lm).

## Test plan

- [ ] CI green on alpha
- [ ] Reviewer spot-checks attribution doc + headers match osaurus's MIT requirements
- [ ] Manual: load `mlx-community/DeepSeek-V4-Flash-2bit-DQ` and confirm a short prompt produces non-garbage output
- [ ] Confirm no regressions on existing DSv3 / Kimi / GLM tests (DSV3.swift is untouched)
- [ ] Open Phase 2 follow-up issue using the 13-item list from the attribution doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)
