### PR TITLE
ci(alpha): bump checkout@v6 and cache@v5 (Node 24)

### DIFF
--- a/.github/workflows/alpha-ci.yml
+++ b/.github/workflows/alpha-ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -38,7 +38,7 @@ jobs:
           uname -a
 
       - name: Cache SwiftPM build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .build


### PR DESCRIPTION
## Summary

GitHub deprecated Node.js 20 actions ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). `actions/checkout@v4` and `actions/cache@v4` both run on Node 20 and will be forced to Node 24 by **June 2, 2026** and removed by **September 16, 2026**.

Bump to the current Node 24 releases:

- `actions/checkout@v4` → `actions/checkout@v6` ([Jan 2026](https://github.com/actions/checkout/releases/tag/v6.0.2))
- `actions/cache@v4` → `actions/cache@v5` ([Apr 2026](https://github.com/actions/cache/releases/tag/v5.0.5))

Identical bump going up across the four-fork stack: ekryski/mlx-swift-lm, mlx-swift, mlx, mlx-c.