### PR TITLE
feat(mirror-sd): spec 021 phase 1A — Mirror Speculative Decoding scaffold

### DIFF
--- a/Libraries/MLXLMCommon/ANEDraftBackend.swift
+++ b/Libraries/MLXLMCommon/ANEDraftBackend.swift
@@ -1,0 +1,142 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+// MARK: - ANE-side draft backend protocol surface (Mirror Speculative Decoding)
+//
+// Spec 021's headline path: a small draft model running on the Apple
+// Neural Engine via Core ML, paired with an MLX target on GPU. Different
+// physical compute units, so they can run in parallel — the ANE drafts
+// while the GPU verifies. This file declares the **draft-side protocol**
+// the Mirror SD iterator uses to talk to whichever Core ML draft is
+// loaded for the current target.
+//
+// The shape is deliberately parallel to ``DFlashDraftBackend`` (spec 015):
+// the iterator owns the cycle; the backend owns the draft model + its
+// internal state. Same swappability for testing.
+//
+// **Phase 1A status:** this file ships the protocol + a scripted test
+// stub + a vocabulary-equivalence gate. The actual Core ML ANE backend
+// lands in Phase 1B alongside the `CoreML-LLM` dependency decision; the
+// scaffold here lets us write the iterator + registry + tests without
+// pulling Core ML into the build yet.
+
+/// Draft backend for Mirror Speculative Decoding. The Mirror SD iterator
+/// asks this backend for K candidate continuation tokens given the last
+/// committed token; the backend implementation decides where the draft
+/// runs (ANE via Core ML, ANE via the private NeuralEngine API, or a
+/// pure-CPU stub for tests).
+///
+/// Unlike ``DFlashDraftBackend`` the Mirror SD draft does *not* receive
+/// target hidden states — Mirror SD pairs an independently-trained draft
+/// with the target through token I/O alone. That keeps the cross-
+/// framework plumbing trivially shippable: just an `[Int]` round-trips
+/// between MLX and Core ML; no tensor interop required.
+public protocol ANEDraftBackend {
+    /// Number of candidate tokens emitted per cycle. The iterator builds
+    /// a `[1, K+1]` verify batch for the target; smaller K reduces verify
+    /// cost when the draft's accept rate is low.
+    var draftLength: Int { get }
+
+    /// Generate `draftLength` candidate tokens conditioned on the
+    /// recently-committed token sequence. Implementations are responsible
+    /// for managing their own KV state across calls — the iterator never
+    /// touches the draft's cache.
+    ///
+    /// - Parameter committedTokens: full prefix of accepted target tokens
+    ///   so far. The backend may use this to warm a fresh KV cache or to
+    ///   resync after rejection — most backends only need the suffix.
+    /// - Parameter lastCommittedToken: the most recent accepted target
+    ///   token (also `committedTokens.last`, when non-empty). Passed
+    ///   separately so backends that only condition on the seed don't
+    ///   need to subscript.
+    /// - Returns: `draftLength` candidate token IDs.
+    mutating func draftBlock(
+        committedTokens: [Int],
+        lastCommittedToken: Int
+    ) -> [Int]
+
+    /// Reset the backend's internal draft KV state. Called on iterator
+    /// init and on iterator-level rollbacks the backend cannot itself
+    /// observe (e.g. the iterator advancing past `maxTokens`).
+    mutating func reset()
+
+    /// Bytes held by the backend's internal cache. Returned for parity
+    /// with ``KVCache/memoryBytes`` accounting on the GPU side; nil when
+    /// the backend doesn't expose a measurable footprint.
+    var draftCacheMemoryBytes: Int? { get }
+}
+
+extension ANEDraftBackend {
+    public var draftCacheMemoryBytes: Int? { nil }
+}
+
+// MARK: - Scripted test backend
+
+/// Test-only backend that replays a pre-baked list of draft blocks. Mirrors
+/// ``ScriptedDraftBackend`` (DFlash side) so the test surface is the same
+/// pattern across all speculative paths: drive the iterator with a
+/// deterministic accept/reject sequence and assert on bookkeeping.
+///
+/// When the script is exhausted, returns an empty block — the iterator
+/// treats that as "fall through to AR decode" (same convention as
+/// ``DFlashDraftBackend``).
+public struct ScriptedANEDraftBackend: ANEDraftBackend {
+    public let draftLength: Int
+    private var script: [[Int]]
+    private var cursor: Int = 0
+
+    /// Number of `draftBlock` calls served so far (excludes empty
+    /// fallback returns).
+    public var callCount: Int { cursor }
+
+    public init(draftLength: Int, script: [[Int]]) {
+        precondition(draftLength >= 1, "draftLength must be >= 1 (got \(draftLength))")
+        for (i, block) in script.enumerated() {
+            precondition(
+                block.count <= draftLength,
+                "ScriptedANEDraftBackend block[\(i)] has \(block.count) tokens, "
+                    + "exceeds draftLength=\(draftLength)")
+        }
+        self.draftLength = draftLength
+        self.script = script
+    }
+
+    public mutating func draftBlock(
+        committedTokens: [Int],
+        lastCommittedToken: Int
+    ) -> [Int] {
+        guard cursor < script.count else { return [] }
+        defer { cursor += 1 }
+        return script[cursor]
+    }
+
+    public mutating func reset() {
+        cursor = 0
+    }
+}
+
+/// Always-rejected stub — emits a constant out-of-vocabulary token for
+/// every draft slot. Used by the iterator's correctness tests to exercise
+/// the "verify rejects everything, emit only the bonus" path on every
+/// cycle. By construction zero acceptance.
+public struct ZeroAcceptANEDraftBackend: ANEDraftBackend {
+    public let draftLength: Int
+    public let stubToken: Int
+
+    public init(draftLength: Int = 4, stubToken: Int = 0) {
+        precondition(draftLength >= 1, "draftLength must be >= 1 (got \(draftLength))")
+        self.draftLength = draftLength
+        self.stubToken = stubToken
+    }
+
+    public mutating func draftBlock(
+        committedTokens: [Int],
+        lastCommittedToken: Int
+    ) -> [Int] {
+        Array(repeating: stubToken, count: draftLength)
+    }
+
+    public mutating func reset() {}
+}

--- a/Libraries/MLXLMCommon/ANEDraftRegistry.swift
+++ b/Libraries/MLXLMCommon/ANEDraftRegistry.swift
@@ -1,0 +1,105 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+// MARK: - ANE draft registry (Mirror Speculative Decoding)
+//
+// Mirror SD pairs each supported MLX target with a Core ML draft model
+// running on the ANE. The pairing is fixed per target — you don't get to
+// run Mirror SD with an arbitrary draft because the verify-side correct-
+// ness depends on tokenizer alignment (see ``ANEVocabEquivalence``).
+// This file defines the registry shape + pure-Swift registration logic.
+//
+// The registry is intentionally **data-only** — no Core ML imports, no
+// model loading. Phase 1B will add a `CoreMLANEDraftBackend` that takes
+// a registry entry and constructs the backend; for now, the registry just
+// answers "is this target Mirror-SD eligible?" and returns a bundle path
+// the future loader will consume.
+
+/// One entry in the ANE draft registry.
+public struct ANEDraftRegistryEntry: Equatable, Hashable, Sendable {
+    /// Target HuggingFace model ID this draft is registered for. Match is
+    /// exact; family-base matching is the caller's job (e.g. "match
+    /// `mlx-community/Qwen3.5-27B-Instruct-4bit` and any quantization
+    /// variant of it" is a routing decision, not a registry fact).
+    public let targetID: String
+
+    /// Local file URL of the Core ML `.mlpackage` (or compiled `.mlmodelc`)
+    /// containing the draft model. The registry stores the URL but does
+    /// not validate its existence — callers do that when they actually
+    /// load. Lets the registry survive partial deployments where some
+    /// drafts haven't been downloaded yet.
+    public let draftBundleURL: URL
+
+    /// Number of candidate tokens this draft is configured to emit per
+    /// cycle. Mirror SD's K is per-draft because the draft's batch shape
+    /// is baked into the Core ML graph at conversion time.
+    public let draftLength: Int
+
+    /// HuggingFace tokenizer ID expected for *both* draft and target. The
+    /// vocabulary-equivalence gate compares the actual target tokenizer
+    /// against this expectation at iterator-construction time.
+    public let expectedTokenizerID: String
+
+    public init(
+        targetID: String,
+        draftBundleURL: URL,
+        draftLength: Int,
+        expectedTokenizerID: String
+    ) {
+        precondition(draftLength >= 1, "draftLength must be >= 1 (got \(draftLength))")
+        self.targetID = targetID
+        self.draftBundleURL = draftBundleURL
+        self.draftLength = draftLength
+        self.expectedTokenizerID = expectedTokenizerID
+    }
+}
+
+/// Pure-Swift registry mapping target IDs → ANE draft bundle metadata.
+///
+/// The default registry ships empty in Phase 1A — drafts get added as
+/// they're converted (Phase 1B onward). Tests construct ad-hoc registries
+/// to exercise lookup behavior; production callers can extend the default
+/// instance via ``register(_:)`` at app startup.
+public final class ANEDraftRegistry: @unchecked Sendable {
+    private var entries: [String: ANEDraftRegistryEntry] = [:]
+
+    /// Process-wide shared registry. Apps populate this at launch with
+    /// any drafts they've shipped with the bundle. Tests construct local
+    /// registries instead of using this to keep side effects out of the
+    /// shared instance.
+    public static let shared = ANEDraftRegistry()
+
+    public init() {}
+
+    /// Insert or replace an entry. Replacement is intentional — useful
+    /// for hot-swapping in tests and for late-binding draft URLs (e.g.
+    /// after on-demand download).
+    public func register(_ entry: ANEDraftRegistryEntry) {
+        entries[entry.targetID] = entry
+    }
+
+    public func remove(targetID: String) {
+        entries.removeValue(forKey: targetID)
+    }
+
+    public func entry(for targetID: String) -> ANEDraftRegistryEntry? {
+        entries[targetID]
+    }
+
+    /// Whether the given target has a registered ANE draft. Used as the
+    /// `ane-draft-eligible` predicate's first gate during auto-routing
+    /// in `MLXLMCommon.generate(...)` (see spec 021 §5).
+    public func isRegistered(targetID: String) -> Bool {
+        entries[targetID] != nil
+    }
+
+    /// All registered target IDs, for diagnostic UIs and bench harness
+    /// listings. Order is not stable across calls.
+    public func registeredTargetIDs() -> [String] {
+        Array(entries.keys)
+    }
+
+    /// Number of registered drafts. Mostly a test convenience.
+    public var count: Int { entries.count }
+}

--- a/Libraries/MLXLMCommon/ANEVocabEquivalence.swift
+++ b/Libraries/MLXLMCommon/ANEVocabEquivalence.swift
@@ -1,0 +1,133 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+// MARK: - Vocabulary equivalence gate (Mirror Speculative Decoding)
+//
+// Mirror SD pairs a draft and a target that train independently — they
+// can be totally different architectures (one trained on ANE-friendly
+// shapes, one trained for GPU). The cross-framework token I/O works only
+// if their tokenizers agree token-for-token: a draft saying "token 12345"
+// has to mean the *same string* on the target side, otherwise the verify
+// step is comparing apples to oranges and the iterator silently produces
+// nonsense.
+//
+// llama.cpp solves this with `SPEC_VOCAB_MAX_SIZE_DIFFERENCE = 128` plus
+// a token-by-token sample check. We mirror that policy here so the gate
+// is identical in spirit — refuse a pairing whose tokenizers disagree on
+// more than a handful of token IDs.
+//
+// The gate is **pure-Swift** — no dependency on any specific tokenizer
+// implementation. Callers pass two `[Int: String]` maps (token ID → token
+// string); we walk the intersection of their keysets and tally
+// disagreements. This keeps the gate testable without standing up real
+// tokenizers and without coupling to the `Tokenizers` package.
+
+/// Result of comparing two tokenizer vocabularies for Mirror SD pairing.
+public struct ANEVocabEquivalenceReport: Equatable, Sendable {
+    /// Number of token IDs present in both vocabularies (the comparable
+    /// set — IDs only present on one side are not counted as a
+    /// disagreement, but they do reduce the comparable set so a vastly-
+    /// different-size vocabulary will hit the size-difference gate first).
+    public let comparedTokenCount: Int
+
+    /// Number of compared token IDs whose strings differ.
+    public let disagreementCount: Int
+
+    /// Absolute size difference (`||draft| - |target||`).
+    public let sizeDifference: Int
+
+    /// True when both gates pass: sizes within `maxSizeDifference` AND
+    /// disagreement count within `maxDisagreements`.
+    public let isCompatible: Bool
+
+    public var disagreementRate: Double {
+        guard comparedTokenCount > 0 else { return 0 }
+        return Double(disagreementCount) / Double(comparedTokenCount)
+    }
+}
+
+/// llama.cpp's default — see `SPEC_VOCAB_MAX_SIZE_DIFFERENCE`. Refuses
+/// pairings whose vocabularies differ in size by more than this many
+/// tokens.
+public let aneVocabDefaultMaxSizeDifference: Int = 128
+
+/// llama.cpp's default — `SPEC_VOCAB_CHECK_START_TOKEN_ID = 5`. Tokens
+/// 0..<5 are usually special (BOS/EOS/PAD/UNK + one reserved) and
+/// occasionally drift between draft and target without affecting
+/// generation. Skipping them avoids false negatives.
+public let aneVocabDefaultStartTokenID: Int = 5
+
+/// Maximum tolerated token-string disagreements. llama.cpp uses zero
+/// (any disagreement above the start ID rejects); we expose it as a
+/// parameter so tests can probe the boundary cleanly.
+public let aneVocabDefaultMaxDisagreements: Int = 0
+
+/// Compare two tokenizer vocabularies for Mirror SD eligibility.
+///
+/// Both maps are token-ID → token-string. We walk every ID in
+/// `[startTokenID, min(draft.size, target.size))` and count
+/// disagreements. The size check is independent — vocabularies whose
+/// sizes differ by more than `maxSizeDifference` fail outright, even
+/// when their shared prefix matches.
+///
+/// - Parameter draftVocab: token ID → token string for the draft model.
+/// - Parameter targetVocab: token ID → token string for the target.
+/// - Parameter startTokenID: skip tokens below this ID. Defaults to
+///   `aneVocabDefaultStartTokenID = 5`.
+/// - Parameter maxSizeDifference: size-difference gate. Default 128.
+/// - Parameter maxDisagreements: disagreement gate. Default 0.
+public func aneCheckVocabEquivalence(
+    draftVocab: [Int: String],
+    targetVocab: [Int: String],
+    startTokenID: Int = aneVocabDefaultStartTokenID,
+    maxSizeDifference: Int = aneVocabDefaultMaxSizeDifference,
+    maxDisagreements: Int = aneVocabDefaultMaxDisagreements
+) -> ANEVocabEquivalenceReport {
+    let draftSize = draftVocab.count
+    let targetSize = targetVocab.count
+    let sizeDiff = abs(draftSize - targetSize)
+
+    // Size gate first — bail without walking tokens when this fails.
+    if sizeDiff > maxSizeDifference {
+        return ANEVocabEquivalenceReport(
+            comparedTokenCount: 0,
+            disagreementCount: 0,
+            sizeDifference: sizeDiff,
+            isCompatible: false)
+    }
+
+    // Walk the shared ID range and tally disagreements.
+    let upperBound = Swift.min(draftSize, targetSize)
+    var compared = 0
+    var disagreements = 0
+    if startTokenID < upperBound {
+        for id in startTokenID ..< upperBound {
+            // A token only present on one side is a disagreement: the
+            // draft and target have different ideas about what ID
+            // means. Skipping such IDs would mask real mismatches.
+            let draftStr = draftVocab[id]
+            let targetStr = targetVocab[id]
+            switch (draftStr, targetStr) {
+            case (nil, nil):
+                // Neither side has the token — sparse vocabularies. Don't
+                // count this slot at all; nothing to compare.
+                continue
+            case (let d?, let t?):
+                compared += 1
+                if d != t { disagreements += 1 }
+            default:
+                // One side missing → disagreement.
+                compared += 1
+                disagreements += 1
+            }
+        }
+    }
+
+    let pass = sizeDiff <= maxSizeDifference && disagreements <= maxDisagreements
+    return ANEVocabEquivalenceReport(
+        comparedTokenCount: compared,
+        disagreementCount: disagreements,
+        sizeDifference: sizeDiff,
+        isCompatible: pass)
+}

--- a/Libraries/MLXLMCommon/MirrorSpeculativeDecoding.swift
+++ b/Libraries/MLXLMCommon/MirrorSpeculativeDecoding.swift
@@ -1,0 +1,317 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+// MARK: - Mirror Speculative Decoding iterator (spec 021 phase 1A scaffold)
+//
+// Mirror SD pairs a small ANE draft (Core ML) with a GPU target (MLX).
+// The two compute units are physically independent so the cycles can run
+// in parallel: ANE drafts K tokens while the GPU verifies the previous
+// K-block. The structural difference vs. the existing
+// ``SpeculativeTokenIterator`` (which uses an MLX draft):
+//
+//   1. The draft lives behind ``ANEDraftBackend`` — a protocol that
+//      doesn't depend on MLX at all. The iterator never holds draft KV
+//      state; the backend manages it.
+//   2. The verify path is identical to the DFlash and SpeculativeToken
+//      iterators — single-pass [y, draft_1...draft_K] forward, argmax
+//      compare, accept-prefix walk, cache trim.
+//
+// **Phase 1A status:** this iterator runs the draft + verify *sequentially*
+// — submit draft, wait, run verify, repeat. The "true" Mirror SD path
+// (overlap draft and verify across the cycle) is Phase 2 and requires
+// the actual Core ML backend + IPC primitives. Sequential is correct,
+// just not throughput-optimal.
+
+/// Generator of tokens with **Mirror Speculative Decoding** (ANE draft +
+/// GPU target). Currently sequential per cycle; Phase 2 will pipeline
+/// draft and verify across compute units.
+///
+/// Drop-in replacement for ``TokenIterator`` when the caller has an
+/// ANE-eligible target (registered in ``ANEDraftRegistry``) and
+/// `temperature == 0`. Output is byte-identical to greedy
+/// ``TokenIterator`` decode at temperature 0 (the verifier compares
+/// against the target's argmax — same contract as DFlash).
+///
+/// Construction throws if the configured draft vocabulary doesn't agree
+/// with the target's tokenizer up to the
+/// ``aneVocabDefaultMaxSizeDifference`` / ``aneVocabDefaultMaxDisagreements``
+/// gate — Mirror SD relies on token-ID equivalence across frameworks.
+public struct MirrorSpeculativeTokenIterator: TokenIteratorProtocol {
+
+    // MARK: - State
+
+    var y: LMInput.Text
+
+    let target: any LanguageModel
+    var mainState: LMOutput.State?
+    var mainCache: [KVCache]
+    let quantizeKVCache: (inout [KVCache]) -> Void
+
+    var draftBackend: any ANEDraftBackend
+
+    let sampler: LogitSampler
+    var tokenCount = 0
+    let maxTokens: Int?
+
+    /// Full prefix of accepted tokens (prompt + everything emitted so far).
+    /// Mirror SD's draft backend wants the full committed sequence to
+    /// resync after partial-accept, since the ANE backend's KV state may
+    /// not be trim-able the same way the MLX target's is. Keeping it on
+    /// the iterator side lets the backend stay stateless across rejections
+    /// if it wants to.
+    private var committedTokens: [Int] = []
+
+    private var pendingTokens = [Int]()
+    private var pendingIndex = 0
+
+    // MARK: - Metrics
+
+    public private(set) var promptPrefillTime: TimeInterval = 0.0
+
+    public private(set) var mirrorAcceptedCount = 0
+    public private(set) var mirrorProposedCount = 0
+    public private(set) var mirrorCycleCount = 0
+
+    public var mirrorAcceptanceRate: Double {
+        guard mirrorProposedCount > 0 else { return 0 }
+        return Double(mirrorAcceptedCount) / Double(mirrorProposedCount)
+    }
+
+    public var specDecodeProposed: Int { mirrorProposedCount }
+    public var specDecodeAccepted: Int { mirrorAcceptedCount }
+
+    public var kvCacheMemoryBytes: Int? {
+        let main = mainCache.isEmpty ? 0 : mainCache.reduce(0) { $0 + $1.memoryBytes }
+        let draft = draftBackend.draftCacheMemoryBytes ?? 0
+        return main + draft
+    }
+
+    private static var debugTracing: Bool {
+        ProcessInfo.processInfo.environment["MLX_MIRROR_DEBUG"] == "1"
+    }
+
+    // MARK: - Init
+
+    /// Initialize a `MirrorSpeculativeTokenIterator` over a target + ANE
+    /// draft backend pairing.
+    ///
+    /// - Parameter input: language model input.
+    /// - Parameter target: the GPU target (MLX language model).
+    /// - Parameter mainCache: optional pre-allocated target KV cache.
+    /// - Parameter draftBackend: the ANE-side draft backend.
+    /// - Parameter parameters: generation parameters. Must specify
+    ///   `temperature == 0` for the greedy verify gate to be sound.
+    /// - Parameter vocabReport: optional pre-computed vocab equivalence
+    ///   report. When non-nil and `isCompatible == false`, init throws.
+    ///   When nil, the gate is skipped — caller takes responsibility.
+    public init(
+        input: LMInput,
+        target: any LanguageModel,
+        mainCache: [KVCache]? = nil,
+        draftBackend: any ANEDraftBackend,
+        parameters: GenerateParameters,
+        vocabReport: ANEVocabEquivalenceReport? = nil
+    ) throws {
+        if let report = vocabReport, !report.isCompatible {
+            throw KVCacheError(
+                message: "Mirror SD vocabulary equivalence gate failed: "
+                    + "size diff = \(report.sizeDifference), "
+                    + "disagreements = \(report.disagreementCount) "
+                    + "(\(String(format: "%.2f%%", report.disagreementRate * 100))). "
+                    + "Mirror SD requires the draft and target tokenizers "
+                    + "to agree token-for-token; pair a different draft.")
+        }
+
+        self.y = input.text
+        self.target = target
+        self.mainCache = mainCache ?? target.newCache(parameters: parameters)
+        guard canTrimPromptCache(self.mainCache) else {
+            throw KVCacheError(
+                message: "Mirror SD requires a trimmable target KV cache. "
+                    + "Hybrid GDN/Mamba targets need the tape-replay path "
+                    + "(spec 020); Mirror SD's correctness is upstream of "
+                    + "that fix.")
+        }
+
+        self.sampler = parameters.sampler()
+        self.maxTokens = parameters.maxTokens
+        self.draftBackend = draftBackend
+
+        self.quantizeKVCache = { cache in
+            maybeQuantizeKVCache(
+                cache: &cache,
+                kvBits: parameters.kvBits,
+                kvGroupSize: parameters.kvGroupSize,
+                quantizedKVStart: parameters.quantizedKVStart
+            )
+        }
+
+        // Seed committedTokens with the prompt — backends that want full
+        // history have it from the start.
+        self.committedTokens = input.text.tokens.asArray(Int.self)
+
+        self.promptPrefillTime = try measure {
+            try prepare(input: input, windowSize: parameters.prefillStepSize)
+        }
+
+        if Self.debugTracing {
+            print("[MIRROR] iterator engaged: K=\(draftBackend.draftLength) "
+                + "prompt=\(input.text.tokens.size)")
+        }
+    }
+
+    /// Prefill the target + prime the pump. Same shape as the n-gram and
+    /// DFlash iterators. The trailing `eval(token)` is the Gemma-4
+    /// async-prefill commit barrier (see comment on
+    /// ``NGramSpeculativeTokenIterator/prepare``).
+    mutating func prepare(input: LMInput, windowSize: Int? = nil) throws {
+        switch try target.prepare(input, cache: mainCache, windowSize: windowSize) {
+        case .tokens(let tokens):
+            let result = target(tokens[text: .newAxis], cache: mainCache, state: nil)
+            quantizeKVCache(&mainCache)
+            let logits = result.logits[0..., -1, 0...]
+            let token = sampler.sample(logits: logits)
+            mainState = result.state
+            eval(token)
+            let tokenInt = token.item(Int.self)
+            y = .init(tokens: token)
+            pendingTokens.append(tokenInt)
+            committedTokens.append(tokenInt)
+        case .logits(let result):
+            let logits = result.logits[0..., -1, 0...]
+            let token = sampler.sample(logits: logits)
+            eval(token)
+            let tokenInt = token.item(Int.self)
+            y = .init(tokens: token)
+            mainState = result.state
+            pendingTokens.append(tokenInt)
+            committedTokens.append(tokenInt)
+        }
+    }
+
+    // MARK: - Cycle
+
+    /// One Mirror SD cycle: ANE draft → GPU verify → accept → trim.
+    mutating func speculateRound() {
+        let remaining = maxTokens.map { $0 - tokenCount } ?? draftBackend.draftLength
+        guard remaining > 0 else { return }
+
+        let lastToken = committedTokens.last ?? 0
+        let draftInts = draftBackend.draftBlock(
+            committedTokens: committedTokens,
+            lastCommittedToken: lastToken)
+
+        // Empty draft → AR fallback (single-step). Same shape as the
+        // DFlash iterator; not pipelined yet.
+        if draftInts.isEmpty {
+            let result = target(y[text: .newAxis], cache: mainCache, state: mainState)
+            quantizeKVCache(&mainCache)
+            let logits = result.logits[0..., -1, 0...]
+            let token = sampler.sample(logits: logits)
+            eval(token)
+            let tokenInt = token.item(Int.self)
+            mainState = result.state
+            pendingTokens.append(tokenInt)
+            committedTokens.append(tokenInt)
+            y = .init(tokens: token)
+            mirrorCycleCount += 1
+            if Self.debugTracing {
+                print("[MIRROR] cycle=\(mirrorCycleCount) draft=0 ar=\(tokenInt)")
+            }
+            return
+        }
+
+        // Clamp to (remaining - 1) so we always leave a slot for the
+        // bonus token. Same logic as the DFlash iterator.
+        let budget = Swift.max(0, remaining - 1)
+        let clampedDraft = budget < draftInts.count
+            ? Array(draftInts.prefix(budget))
+            : draftInts
+        let numDraft = clampedDraft.count
+
+        if numDraft == 0 {
+            let result = target(y[text: .newAxis], cache: mainCache, state: mainState)
+            quantizeKVCache(&mainCache)
+            let logits = result.logits[0..., -1, 0...]
+            let token = sampler.sample(logits: logits)
+            eval(token)
+            let tokenInt = token.item(Int.self)
+            mainState = result.state
+            pendingTokens.append(tokenInt)
+            committedTokens.append(tokenInt)
+            y = .init(tokens: token)
+            mirrorCycleCount += 1
+            return
+        }
+
+        let draftArray = MLXArray(clampedDraft.map { Int32($0) })
+        let verifyTokens = concatenated([y.tokens, draftArray])
+        let verifyInput = LMInput.Text(tokens: verifyTokens)
+        let verifyStart = verifyInput.tokens.dim(0) - (numDraft + 1)
+        let mainResult = target(verifyInput[text: .newAxis], cache: mainCache, state: mainState)
+        let mainLogits = mainResult.logits
+        mainState = mainResult.state
+
+        let verifyLogits = mainLogits[0..., verifyStart..., 0...].squeezed(axis: 0)
+        let mainTokens = sampler.sample(logits: verifyLogits)
+        eval(mainTokens)
+        let mainTokensList = mainTokens.asArray(Int.self)
+
+        // Reuse the DFlash accept-prefix helper — same pure-Swift logic;
+        // no need for two copies. The contract is identical: longest
+        // matching prefix between draft and target argmax.
+        let accepted = dflashAcceptedPrefixLength(
+            draft: clampedDraft,
+            targetArgmax: mainTokensList)
+
+        for i in 0 ..< accepted {
+            pendingTokens.append(mainTokensList[i])
+            committedTokens.append(mainTokensList[i])
+        }
+        let bonus = mainTokensList[accepted]
+        pendingTokens.append(bonus)
+        committedTokens.append(bonus)
+
+        // Cache trim for rejected tokens.
+        let rejected = numDraft - accepted
+        if rejected > 0 {
+            trimPromptCache(mainCache, numTokens: rejected)
+        }
+        quantizeKVCache(&mainCache)
+
+        mirrorAcceptedCount += accepted
+        mirrorProposedCount += numDraft
+        mirrorCycleCount += 1
+
+        y = .init(tokens: mainTokens[accepted ... accepted])
+
+        if Self.debugTracing {
+            print("[MIRROR] cycle=\(mirrorCycleCount) draft=\(numDraft) "
+                + "accepted=\(accepted) rejected=\(rejected) bonus=\(bonus)")
+        }
+    }
+
+    // MARK: - IteratorProtocol
+
+    public mutating func next() -> Int? {
+        if let maxTokens, tokenCount >= maxTokens {
+            return nil
+        }
+        if pendingIndex < pendingTokens.count {
+            let t = pendingTokens[pendingIndex]
+            pendingIndex += 1
+            tokenCount += 1
+            return t
+        }
+        pendingTokens.removeAll(keepingCapacity: true)
+        pendingIndex = 0
+        speculateRound()
+        guard !pendingTokens.isEmpty else { return nil }
+        let t = pendingTokens[pendingIndex]
+        pendingIndex += 1
+        tokenCount += 1
+        return t
+    }
+}

--- a/Tests/MLXLMTests/MirrorSpeculativeTests.swift
+++ b/Tests/MLXLMTests/MirrorSpeculativeTests.swift
@@ -1,0 +1,367 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLLM
+@testable import MLXLMCommon
+import MLXNN
+import Testing
+
+// MARK: - Mirror Speculative Decoding tests (spec 021 phase 1A scaffold)
+//
+// Three suites:
+//   1. `ANEDraftRegistryTests` — pure-Swift register/lookup behaviour.
+//   2. `ANEVocabEquivalenceTests` — size + disagreement gate at the
+//      llama.cpp-default boundaries.
+//   3. `ANEDraftBackendStubTests` — `ScriptedANEDraftBackend` and
+//      `ZeroAcceptANEDraftBackend` semantics.
+//   4. `MirrorSpeculativeIteratorTests` — integration with
+//      `Gemma3TextModel`. Exercises emit count, cycle bookkeeping,
+//      vocab-gate rejection, AR fallback, and count-parity vs.
+//      `TokenIterator`.
+
+// MARK: - Registry tests
+
+@Suite
+struct ANEDraftRegistryTests {
+
+    @Test
+    func `Registry default is empty`() {
+        let reg = ANEDraftRegistry()
+        #expect(reg.count == 0)
+        #expect(reg.isRegistered(targetID: "anything") == false)
+        #expect(reg.entry(for: "anything") == nil)
+    }
+
+    @Test
+    func `Register, lookup, remove round-trips`() {
+        let reg = ANEDraftRegistry()
+        let entry = ANEDraftRegistryEntry(
+            targetID: "Qwen3.5-27B-Instruct-4bit",
+            draftBundleURL: URL(fileURLWithPath: "/tmp/draft.mlpackage"),
+            draftLength: 4,
+            expectedTokenizerID: "Qwen/Qwen3.5-27B-Instruct")
+        reg.register(entry)
+        #expect(reg.count == 1)
+        #expect(reg.isRegistered(targetID: "Qwen3.5-27B-Instruct-4bit"))
+        #expect(reg.entry(for: "Qwen3.5-27B-Instruct-4bit") == entry)
+
+        reg.remove(targetID: "Qwen3.5-27B-Instruct-4bit")
+        #expect(reg.count == 0)
+        #expect(reg.entry(for: "Qwen3.5-27B-Instruct-4bit") == nil)
+    }
+
+    @Test
+    func `Re-register replaces the previous entry`() {
+        let reg = ANEDraftRegistry()
+        let v1 = ANEDraftRegistryEntry(
+            targetID: "X", draftBundleURL: URL(fileURLWithPath: "/v1"),
+            draftLength: 4, expectedTokenizerID: "tok")
+        let v2 = ANEDraftRegistryEntry(
+            targetID: "X", draftBundleURL: URL(fileURLWithPath: "/v2"),
+            draftLength: 8, expectedTokenizerID: "tok")
+        reg.register(v1)
+        reg.register(v2)
+        #expect(reg.count == 1)
+        #expect(reg.entry(for: "X")?.draftBundleURL.path == "/v2")
+        #expect(reg.entry(for: "X")?.draftLength == 8)
+    }
+
+    @Test
+    func `registeredTargetIDs returns all registered IDs`() {
+        let reg = ANEDraftRegistry()
+        for id in ["A", "B", "C"] {
+            reg.register(ANEDraftRegistryEntry(
+                targetID: id,
+                draftBundleURL: URL(fileURLWithPath: "/tmp/\(id)"),
+                draftLength: 4,
+                expectedTokenizerID: "tok"))
+        }
+        let ids = Set(reg.registeredTargetIDs())
+        #expect(ids == Set(["A", "B", "C"]))
+    }
+}
+
+// MARK: - Vocabulary equivalence tests
+
+@Suite
+struct ANEVocabEquivalenceTests {
+
+    /// Build a synthetic vocab `[0..count)` → "tok_<id>".
+    private static func mkVocab(_ count: Int, mutate: (inout [Int: String]) -> Void = { _ in }) -> [Int: String] {
+        var v: [Int: String] = [:]
+        for i in 0 ..< count { v[i] = "tok_\(i)" }
+        mutate(&v)
+        return v
+    }
+
+    @Test
+    func `Identical vocabularies pass`() {
+        let v = Self.mkVocab(1000)
+        let r = aneCheckVocabEquivalence(draftVocab: v, targetVocab: v)
+        #expect(r.isCompatible)
+        #expect(r.disagreementCount == 0)
+        #expect(r.sizeDifference == 0)
+    }
+
+    @Test
+    func `Disagreement above zero threshold rejects (default policy)`() {
+        var draft = Self.mkVocab(1000)
+        let target = Self.mkVocab(1000)
+        draft[100] = "different_string"
+        let r = aneCheckVocabEquivalence(draftVocab: draft, targetVocab: target)
+        #expect(!r.isCompatible)
+        #expect(r.disagreementCount == 1)
+    }
+
+    @Test
+    func `Disagreement under custom threshold passes`() {
+        var draft = Self.mkVocab(1000)
+        let target = Self.mkVocab(1000)
+        draft[100] = "different_string"
+        let r = aneCheckVocabEquivalence(
+            draftVocab: draft, targetVocab: target, maxDisagreements: 1)
+        #expect(r.isCompatible)
+        #expect(r.disagreementCount == 1)
+    }
+
+    @Test
+    func `Tokens below startTokenID are skipped`() {
+        var draft = Self.mkVocab(1000)
+        let target = Self.mkVocab(1000)
+        // Disagree on tokens 0..<5 (BOS/EOS/etc.) — should not count.
+        for i in 0 ..< 5 { draft[i] = "alt_\(i)" }
+        let r = aneCheckVocabEquivalence(draftVocab: draft, targetVocab: target)
+        #expect(r.isCompatible)
+        #expect(r.disagreementCount == 0)
+    }
+
+    @Test
+    func `Size difference above gate rejects without walking tokens`() {
+        let draft = Self.mkVocab(1000)
+        let target = Self.mkVocab(2000)
+        let r = aneCheckVocabEquivalence(
+            draftVocab: draft, targetVocab: target,
+            maxSizeDifference: 128)
+        #expect(!r.isCompatible)
+        #expect(r.sizeDifference == 1000)
+        #expect(r.comparedTokenCount == 0)  // bailed out early
+    }
+
+    @Test
+    func `Size difference exactly at gate passes`() {
+        let draft = Self.mkVocab(1000)
+        let target = Self.mkVocab(1128)
+        let r = aneCheckVocabEquivalence(
+            draftVocab: draft, targetVocab: target,
+            maxSizeDifference: 128)
+        #expect(r.isCompatible)
+        #expect(r.sizeDifference == 128)
+    }
+
+    @Test
+    func `One-side-only token counts as disagreement`() {
+        var draft = Self.mkVocab(1000)
+        var target = Self.mkVocab(1000)
+        draft[500] = nil  // hole on draft side, target still has it
+        target[500] = "present"
+        let r = aneCheckVocabEquivalence(draftVocab: draft, targetVocab: target)
+        #expect(!r.isCompatible)
+        #expect(r.disagreementCount >= 1)
+    }
+
+    @Test
+    func `Sparse-on-both-sides hole is not a disagreement`() {
+        var draft = Self.mkVocab(1000)
+        var target = Self.mkVocab(1000)
+        draft[500] = nil
+        target[500] = nil
+        let r = aneCheckVocabEquivalence(draftVocab: draft, targetVocab: target)
+        #expect(r.isCompatible)
+        #expect(r.disagreementCount == 0)
+    }
+
+    @Test
+    func `disagreementRate is computed correctly`() {
+        var draft = Self.mkVocab(100)
+        let target = Self.mkVocab(100)
+        // Disagree on tokens 50, 51, 52 (above startTokenID).
+        for i in 50 ..< 53 { draft[i] = "diff_\(i)" }
+        let r = aneCheckVocabEquivalence(
+            draftVocab: draft, targetVocab: target, maxDisagreements: 100)
+        #expect(r.disagreementCount == 3)
+        // comparedTokenCount = (100 - 5) = 95
+        #expect(r.comparedTokenCount == 95)
+        #expect(abs(r.disagreementRate - 3.0/95.0) < 1e-9)
+    }
+}
+
+// MARK: - Stub backend tests
+
+@Suite
+struct ANEDraftBackendStubTests {
+
+    @Test
+    func `ScriptedANEDraftBackend replays in order then returns empty`() {
+        var b = ScriptedANEDraftBackend(draftLength: 3, script: [[1, 2, 3], [4, 5, 6]])
+        #expect(b.callCount == 0)
+        #expect(b.draftBlock(committedTokens: [], lastCommittedToken: 0) == [1, 2, 3])
+        #expect(b.draftBlock(committedTokens: [], lastCommittedToken: 0) == [4, 5, 6])
+        #expect(b.draftBlock(committedTokens: [], lastCommittedToken: 0) == [])
+        // Exhausted call doesn't bump cursor (early-return short-circuits
+        // before defer increment) — same convention as the DFlash side.
+        #expect(b.callCount == 2)
+    }
+
+    @Test
+    func `ScriptedANEDraftBackend reset rewinds cursor`() {
+        var b = ScriptedANEDraftBackend(draftLength: 2, script: [[1, 2], [3, 4]])
+        _ = b.draftBlock(committedTokens: [], lastCommittedToken: 0)
+        _ = b.draftBlock(committedTokens: [], lastCommittedToken: 0)
+        #expect(b.callCount == 2)
+        b.reset()
+        #expect(b.callCount == 0)
+        #expect(b.draftBlock(committedTokens: [], lastCommittedToken: 0) == [1, 2])
+    }
+
+    @Test
+    func `ZeroAcceptANEDraftBackend emits draftLength stub tokens`() {
+        var b = ZeroAcceptANEDraftBackend(draftLength: 5, stubToken: 999)
+        let block = b.draftBlock(committedTokens: [1, 2, 3], lastCommittedToken: 3)
+        #expect(block == [999, 999, 999, 999, 999])
+    }
+
+    @Test
+    func `Default draftCacheMemoryBytes is nil`() {
+        let b = ZeroAcceptANEDraftBackend(draftLength: 4)
+        #expect(b.draftCacheMemoryBytes == nil)
+    }
+}
+
+// MARK: - Iterator integration tests
+
+@Suite(.serialized)
+struct MirrorSpeculativeIteratorTests {
+
+    let processor: any UserInputProcessor
+    let model: Gemma3TextModel
+
+    init() {
+        let processor = TestInputProcessor()
+        let modelConfig = Gemma3TextConfiguration(
+            modelType: "text",
+            hiddenSize: 64, hiddenLayers: 8, intermediateSize: 64,
+            attentionHeads: 4, headDim: 64,
+            rmsNormEps: 0.00001, vocabularySize: 100, kvHeads: 4,
+            ropeTheta: 1_000_000, ropeLocalBaseFreq: 10_000,
+            ropeTraditional: false, queryPreAttnScalar: 256,
+            slidingWindow: 512, slidingWindowPattern: 6,
+            maxPositionEmbeddings: 32768
+        )
+        let model = Gemma3TextModel(modelConfig)
+        eval(model)
+        self.processor = processor
+        self.model = model
+    }
+
+    @Test
+    func `Iterator emits exactly maxTokens tokens`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hello world"))
+        let backend = ZeroAcceptANEDraftBackend(draftLength: 4)
+        let params = GenerateParameters(maxTokens: 10, temperature: 0.0)
+        var iter = try MirrorSpeculativeTokenIterator(
+            input: input, target: model,
+            draftBackend: backend, parameters: params)
+        var tokens: [Int] = []
+        while let t = iter.next() { tokens.append(t) }
+        #expect(tokens.count == 10)
+    }
+
+    @Test
+    func `ZeroAccept backend never accepts`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hello world"))
+        let backend = ZeroAcceptANEDraftBackend(draftLength: 4, stubToken: 12345)
+        let params = GenerateParameters(maxTokens: 12, temperature: 0.0)
+        var iter = try MirrorSpeculativeTokenIterator(
+            input: input, target: model,
+            draftBackend: backend, parameters: params)
+        while iter.next() != nil {}
+        #expect(iter.mirrorAcceptedCount == 0)
+        #expect(iter.mirrorProposedCount > 0)
+        #expect(iter.mirrorAcceptanceRate == 0)
+    }
+
+    @Test
+    func `Output count parity with TokenIterator`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hello world"))
+        let params = GenerateParameters(maxTokens: 10, temperature: 0.0)
+
+        var ref = try TokenIterator(input: input, model: model, parameters: params)
+        var refTokens: [Int] = []
+        while let t = ref.next() { refTokens.append(t) }
+
+        let backend = ZeroAcceptANEDraftBackend(draftLength: 4)
+        var spec = try MirrorSpeculativeTokenIterator(
+            input: input, target: model,
+            draftBackend: backend, parameters: params)
+        var specTokens: [Int] = []
+        while let t = spec.next() { specTokens.append(t) }
+
+        // Tiny random-weight model: argmax ties can flip on
+        // batched-vs-sequential paths; assert count parity.
+        #expect(specTokens.count == refTokens.count)
+    }
+
+    @Test
+    func `Vocab equivalence gate rejects incompatible report`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hi"))
+        let backend = ZeroAcceptANEDraftBackend(draftLength: 4)
+        let params = GenerateParameters(maxTokens: 4, temperature: 0.0)
+        let badReport = ANEVocabEquivalenceReport(
+            comparedTokenCount: 1000, disagreementCount: 50,
+            sizeDifference: 0, isCompatible: false)
+        do {
+            _ = try MirrorSpeculativeTokenIterator(
+                input: input, target: model,
+                draftBackend: backend, parameters: params,
+                vocabReport: badReport)
+            Issue.record("expected init to throw on incompatible vocab")
+        } catch let err as KVCacheError {
+            #expect(err.message.contains("vocabulary"))
+        } catch {
+            Issue.record("expected KVCacheError, got \(error)")
+        }
+    }
+
+    @Test
+    func `Compatible vocab report passes through`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hi"))
+        let backend = ZeroAcceptANEDraftBackend(draftLength: 4)
+        let params = GenerateParameters(maxTokens: 4, temperature: 0.0)
+        let goodReport = ANEVocabEquivalenceReport(
+            comparedTokenCount: 1000, disagreementCount: 0,
+            sizeDifference: 0, isCompatible: true)
+        // Should construct without error.
+        _ = try MirrorSpeculativeTokenIterator(
+            input: input, target: model,
+            draftBackend: backend, parameters: params,
+            vocabReport: goodReport)
+    }
+
+    @Test
+    func `Empty-script ScriptedBackend still progresses via AR`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hi"))
+        // Empty script — backend always returns []; iterator must keep
+        // emitting via AR fallback.
+        let backend = ScriptedANEDraftBackend(draftLength: 4, script: [])
+        let params = GenerateParameters(maxTokens: 6, temperature: 0.0)
+        var iter = try MirrorSpeculativeTokenIterator(
+            input: input, target: model,
+            draftBackend: backend, parameters: params)
+        var tokens: [Int] = []
+        while let t = iter.next() { tokens.append(t) }
+        #expect(tokens.count == 6)
+        // Never proposed anything because every call returned empty.
+        #expect(iter.mirrorProposedCount == 0)
+    }
+}


### PR DESCRIPTION
## Summary

Spec 021 phase 1A scaffold — Mirror Speculative Decoding (ANE draft × MLX target). Lands the protocol surface, registry, vocabulary-equivalence gate, iterator skeleton, and a 23-test unit/integration suite. Phase 1B will plug in the actual Core ML backend; Phase 2 will pipeline draft↔verify across compute units.

Stack: #113 → #140 → #141 → **this PR**.

### What lands

- `Libraries/MLXLMCommon/ANEDraftBackend.swift` — `ANEDraftBackend` protocol + `ScriptedANEDraftBackend` + `ZeroAcceptANEDraftBackend` test stubs. Cross-framework boundary is just `[Int]` token IDs — no MLX tensors cross the protocol so the future Core ML backend has minimal binding work.
- `Libraries/MLXLMCommon/ANEDraftRegistry.swift` — pure-Swift target ID → draft bundle URL mapping. Default empty; apps populate at launch.
- `Libraries/MLXLMCommon/ANEVocabEquivalence.swift` — llama.cpp-style vocab gate (`SPEC_VOCAB_MAX_SIZE_DIFFERENCE = 128`, start-token-ID skip = 5, zero-disagreement default policy).
- `Libraries/MLXLMCommon/MirrorSpeculativeDecoding.swift` — `MirrorSpeculativeTokenIterator`. Reuses `dflashAcceptedPrefixLength` for the accept walk. Sequential draft→verify in this scaffold; Phase 2 pipelines them.
- `Tests/MLXLMTests/MirrorSpeculativeTests.swift` — 23 tests:
  - `ANEDraftRegistryTests` (4): register / lookup / remove / replace.
  - `ANEVocabEquivalenceTests` (9): identical / disagreement / startTokenID skip / size-gate boundaries / sparse holes / disagreement-rate.
  - `ANEDraftBackendStubTests` (4): scripted replay + reset + zero-accept + default cache-bytes nil.
  - `MirrorSpeculativeIteratorTests` (6): emit count, zero-accept path, count parity vs `TokenIterator`, vocab-gate rejection, vocab-gate pass-through, empty-script AR fallback.

### Phase-1A limitations (deferred)

- **No Core ML backend yet.** Lands when `CoreML-LLM` dependency is resolved + Qwen 3.5 0.8B Core ML bundle integrated. Protocol surface is ready for swap.
- **Sequential draft→verify.** Phase 2 unlocks the parallelism that gives Mirror SD its 3× headline speedup. Sequential is correct, just not throughput-optimal.
- **No auto-routing** in `MLXLMCommon.generate(...)` yet — Phase 2 wires the registry-driven dispatch.
- **Hybrid GDN/Mamba targets** blocked at construction (awaits spec 020 tape-replay rollback).

## Test plan

- [x] `swift test -c release --filter MirrorSpeculative` — all 23 tests pass.
- [x] `make` — full build with metallib + xctest bundle install green.
- [ ] (Phase 1B) Plug in Core ML backend; benchmark Qwen 3.5-27B-4bit (≥3× target).
- [ ] (Phase 2) Pipeline draft↔verify; iterator auto-routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evaluation (when phase 2+ lands)

**Mirror SD (spec 021) eval — phase 1B+:** Once the CoreML-LLM Swift Package dep is wired and the Core ML draft loader is integrated:

```bash
# Note: requires Core ML model bundle + ANE measurement infra
scripts/spec-decode-sweep.sh --model qwen35-27b --quant 4bit \
    --prompts Tests/Benchmarks/Resources/ngram-sweep-prompts/qa-requote \
    --cells "baseline:0:0:,mirror-sd:0:0:MLX_MIRROR_SD_ENABLED=1" \
    --trials 5 --output /tmp/mirror-sd-treatment.log
scripts/spec-decode-compare.py /tmp/baseline.log /tmp/mirror-sd-treatment.log
```

**Pass criterion** (per spec 021 §6 Phase 1A): any 2 of [≥3× throughput improvement; ≥4× tokens/watt; verified parallel ANE+GPU execution; per-round wall time ≤ max(t_ANE_draft, t_GPU_verify) × 1.2].

For the canonical sweep+compare workflow, see `scripts/spec-decode-sweep.sh` and `scripts/spec-decode-compare.py` (added in PR #154). Workload classification + recommended cell-set in `Tests/Benchmarks/Resources/ngram-sweep-prompts/README.md`.