### PR TITLE
feat(spec-decode): spec 022 phase 1 — deterministic-stretch acceleration

### DIFF
--- a/Libraries/MLXLMCommon/ANEDraftBackend.swift
+++ b/Libraries/MLXLMCommon/ANEDraftBackend.swift
@@ -1,0 +1,142 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+// MARK: - ANE-side draft backend protocol surface (Mirror Speculative Decoding)
+//
+// Spec 021's headline path: a small draft model running on the Apple
+// Neural Engine via Core ML, paired with an MLX target on GPU. Different
+// physical compute units, so they can run in parallel — the ANE drafts
+// while the GPU verifies. This file declares the **draft-side protocol**
+// the Mirror SD iterator uses to talk to whichever Core ML draft is
+// loaded for the current target.
+//
+// The shape is deliberately parallel to ``DFlashDraftBackend`` (spec 015):
+// the iterator owns the cycle; the backend owns the draft model + its
+// internal state. Same swappability for testing.
+//
+// **Phase 1A status:** this file ships the protocol + a scripted test
+// stub + a vocabulary-equivalence gate. The actual Core ML ANE backend
+// lands in Phase 1B alongside the `CoreML-LLM` dependency decision; the
+// scaffold here lets us write the iterator + registry + tests without
+// pulling Core ML into the build yet.
+
+/// Draft backend for Mirror Speculative Decoding. The Mirror SD iterator
+/// asks this backend for K candidate continuation tokens given the last
+/// committed token; the backend implementation decides where the draft
+/// runs (ANE via Core ML, ANE via the private NeuralEngine API, or a
+/// pure-CPU stub for tests).
+///
+/// Unlike ``DFlashDraftBackend`` the Mirror SD draft does *not* receive
+/// target hidden states — Mirror SD pairs an independently-trained draft
+/// with the target through token I/O alone. That keeps the cross-
+/// framework plumbing trivially shippable: just an `[Int]` round-trips
+/// between MLX and Core ML; no tensor interop required.
+public protocol ANEDraftBackend {
+    /// Number of candidate tokens emitted per cycle. The iterator builds
+    /// a `[1, K+1]` verify batch for the target; smaller K reduces verify
+    /// cost when the draft's accept rate is low.
+    var draftLength: Int { get }
+
+    /// Generate `draftLength` candidate tokens conditioned on the
+    /// recently-committed token sequence. Implementations are responsible
+    /// for managing their own KV state across calls — the iterator never
+    /// touches the draft's cache.
+    ///
+    /// - Parameter committedTokens: full prefix of accepted target tokens
+    ///   so far. The backend may use this to warm a fresh KV cache or to
+    ///   resync after rejection — most backends only need the suffix.
+    /// - Parameter lastCommittedToken: the most recent accepted target
+    ///   token (also `committedTokens.last`, when non-empty). Passed
+    ///   separately so backends that only condition on the seed don't
+    ///   need to subscript.
+    /// - Returns: `draftLength` candidate token IDs.
+    mutating func draftBlock(
+        committedTokens: [Int],
+        lastCommittedToken: Int
+    ) -> [Int]
+
+    /// Reset the backend's internal draft KV state. Called on iterator
+    /// init and on iterator-level rollbacks the backend cannot itself
+    /// observe (e.g. the iterator advancing past `maxTokens`).
+    mutating func reset()
+
+    /// Bytes held by the backend's internal cache. Returned for parity
+    /// with ``KVCache/memoryBytes`` accounting on the GPU side; nil when
+    /// the backend doesn't expose a measurable footprint.
+    var draftCacheMemoryBytes: Int? { get }
+}
+
+extension ANEDraftBackend {
+    public var draftCacheMemoryBytes: Int? { nil }
+}
+
+// MARK: - Scripted test backend
+
+/// Test-only backend that replays a pre-baked list of draft blocks. Mirrors
+/// ``ScriptedDraftBackend`` (DFlash side) so the test surface is the same
+/// pattern across all speculative paths: drive the iterator with a
+/// deterministic accept/reject sequence and assert on bookkeeping.
+///
+/// When the script is exhausted, returns an empty block — the iterator
+/// treats that as "fall through to AR decode" (same convention as
+/// ``DFlashDraftBackend``).
+public struct ScriptedANEDraftBackend: ANEDraftBackend {
+    public let draftLength: Int
+    private var script: [[Int]]
+    private var cursor: Int = 0
+
+    /// Number of `draftBlock` calls served so far (excludes empty
+    /// fallback returns).
+    public var callCount: Int { cursor }
+
+    public init(draftLength: Int, script: [[Int]]) {
+        precondition(draftLength >= 1, "draftLength must be >= 1 (got \(draftLength))")
+        for (i, block) in script.enumerated() {
+            precondition(
+                block.count <= draftLength,
+                "ScriptedANEDraftBackend block[\(i)] has \(block.count) tokens, "
+                    + "exceeds draftLength=\(draftLength)")
+        }
+        self.draftLength = draftLength
+        self.script = script
+    }
+
+    public mutating func draftBlock(
+        committedTokens: [Int],
+        lastCommittedToken: Int
+    ) -> [Int] {
+        guard cursor < script.count else { return [] }
+        defer { cursor += 1 }
+        return script[cursor]
+    }
+
+    public mutating func reset() {
+        cursor = 0
+    }
+}
+
+/// Always-rejected stub — emits a constant out-of-vocabulary token for
+/// every draft slot. Used by the iterator's correctness tests to exercise
+/// the "verify rejects everything, emit only the bonus" path on every
+/// cycle. By construction zero acceptance.
+public struct ZeroAcceptANEDraftBackend: ANEDraftBackend {
+    public let draftLength: Int
+    public let stubToken: Int
+
+    public init(draftLength: Int = 4, stubToken: Int = 0) {
+        precondition(draftLength >= 1, "draftLength must be >= 1 (got \(draftLength))")
+        self.draftLength = draftLength
+        self.stubToken = stubToken
+    }
+
+    public mutating func draftBlock(
+        committedTokens: [Int],
+        lastCommittedToken: Int
+    ) -> [Int] {
+        Array(repeating: stubToken, count: draftLength)
+    }
+
+    public mutating func reset() {}
+}

--- a/Libraries/MLXLMCommon/ANEDraftRegistry.swift
+++ b/Libraries/MLXLMCommon/ANEDraftRegistry.swift
@@ -1,0 +1,105 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+// MARK: - ANE draft registry (Mirror Speculative Decoding)
+//
+// Mirror SD pairs each supported MLX target with a Core ML draft model
+// running on the ANE. The pairing is fixed per target — you don't get to
+// run Mirror SD with an arbitrary draft because the verify-side correct-
+// ness depends on tokenizer alignment (see ``ANEVocabEquivalence``).
+// This file defines the registry shape + pure-Swift registration logic.
+//
+// The registry is intentionally **data-only** — no Core ML imports, no
+// model loading. Phase 1B will add a `CoreMLANEDraftBackend` that takes
+// a registry entry and constructs the backend; for now, the registry just
+// answers "is this target Mirror-SD eligible?" and returns a bundle path
+// the future loader will consume.
+
+/// One entry in the ANE draft registry.
+public struct ANEDraftRegistryEntry: Equatable, Hashable, Sendable {
+    /// Target HuggingFace model ID this draft is registered for. Match is
+    /// exact; family-base matching is the caller's job (e.g. "match
+    /// `mlx-community/Qwen3.5-27B-Instruct-4bit` and any quantization
+    /// variant of it" is a routing decision, not a registry fact).
+    public let targetID: String
+
+    /// Local file URL of the Core ML `.mlpackage` (or compiled `.mlmodelc`)
+    /// containing the draft model. The registry stores the URL but does
+    /// not validate its existence — callers do that when they actually
+    /// load. Lets the registry survive partial deployments where some
+    /// drafts haven't been downloaded yet.
+    public let draftBundleURL: URL
+
+    /// Number of candidate tokens this draft is configured to emit per
+    /// cycle. Mirror SD's K is per-draft because the draft's batch shape
+    /// is baked into the Core ML graph at conversion time.
+    public let draftLength: Int
+
+    /// HuggingFace tokenizer ID expected for *both* draft and target. The
+    /// vocabulary-equivalence gate compares the actual target tokenizer
+    /// against this expectation at iterator-construction time.
+    public let expectedTokenizerID: String
+
+    public init(
+        targetID: String,
+        draftBundleURL: URL,
+        draftLength: Int,
+        expectedTokenizerID: String
+    ) {
+        precondition(draftLength >= 1, "draftLength must be >= 1 (got \(draftLength))")
+        self.targetID = targetID
+        self.draftBundleURL = draftBundleURL
+        self.draftLength = draftLength
+        self.expectedTokenizerID = expectedTokenizerID
+    }
+}
+
+/// Pure-Swift registry mapping target IDs → ANE draft bundle metadata.
+///
+/// The default registry ships empty in Phase 1A — drafts get added as
+/// they're converted (Phase 1B onward). Tests construct ad-hoc registries
+/// to exercise lookup behavior; production callers can extend the default
+/// instance via ``register(_:)`` at app startup.
+public final class ANEDraftRegistry: @unchecked Sendable {
+    private var entries: [String: ANEDraftRegistryEntry] = [:]
+
+    /// Process-wide shared registry. Apps populate this at launch with
+    /// any drafts they've shipped with the bundle. Tests construct local
+    /// registries instead of using this to keep side effects out of the
+    /// shared instance.
+    public static let shared = ANEDraftRegistry()
+
+    public init() {}
+
+    /// Insert or replace an entry. Replacement is intentional — useful
+    /// for hot-swapping in tests and for late-binding draft URLs (e.g.
+    /// after on-demand download).
+    public func register(_ entry: ANEDraftRegistryEntry) {
+        entries[entry.targetID] = entry
+    }
+
+    public func remove(targetID: String) {
+        entries.removeValue(forKey: targetID)
+    }
+
+    public func entry(for targetID: String) -> ANEDraftRegistryEntry? {
+        entries[targetID]
+    }
+
+    /// Whether the given target has a registered ANE draft. Used as the
+    /// `ane-draft-eligible` predicate's first gate during auto-routing
+    /// in `MLXLMCommon.generate(...)` (see spec 021 §5).
+    public func isRegistered(targetID: String) -> Bool {
+        entries[targetID] != nil
+    }
+
+    /// All registered target IDs, for diagnostic UIs and bench harness
+    /// listings. Order is not stable across calls.
+    public func registeredTargetIDs() -> [String] {
+        Array(entries.keys)
+    }
+
+    /// Number of registered drafts. Mostly a test convenience.
+    public var count: Int { entries.count }
+}

--- a/Libraries/MLXLMCommon/ANEVocabEquivalence.swift
+++ b/Libraries/MLXLMCommon/ANEVocabEquivalence.swift
@@ -1,0 +1,133 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+// MARK: - Vocabulary equivalence gate (Mirror Speculative Decoding)
+//
+// Mirror SD pairs a draft and a target that train independently — they
+// can be totally different architectures (one trained on ANE-friendly
+// shapes, one trained for GPU). The cross-framework token I/O works only
+// if their tokenizers agree token-for-token: a draft saying "token 12345"
+// has to mean the *same string* on the target side, otherwise the verify
+// step is comparing apples to oranges and the iterator silently produces
+// nonsense.
+//
+// llama.cpp solves this with `SPEC_VOCAB_MAX_SIZE_DIFFERENCE = 128` plus
+// a token-by-token sample check. We mirror that policy here so the gate
+// is identical in spirit — refuse a pairing whose tokenizers disagree on
+// more than a handful of token IDs.
+//
+// The gate is **pure-Swift** — no dependency on any specific tokenizer
+// implementation. Callers pass two `[Int: String]` maps (token ID → token
+// string); we walk the intersection of their keysets and tally
+// disagreements. This keeps the gate testable without standing up real
+// tokenizers and without coupling to the `Tokenizers` package.
+
+/// Result of comparing two tokenizer vocabularies for Mirror SD pairing.
+public struct ANEVocabEquivalenceReport: Equatable, Sendable {
+    /// Number of token IDs present in both vocabularies (the comparable
+    /// set — IDs only present on one side are not counted as a
+    /// disagreement, but they do reduce the comparable set so a vastly-
+    /// different-size vocabulary will hit the size-difference gate first).
+    public let comparedTokenCount: Int
+
+    /// Number of compared token IDs whose strings differ.
+    public let disagreementCount: Int
+
+    /// Absolute size difference (`||draft| - |target||`).
+    public let sizeDifference: Int
+
+    /// True when both gates pass: sizes within `maxSizeDifference` AND
+    /// disagreement count within `maxDisagreements`.
+    public let isCompatible: Bool
+
+    public var disagreementRate: Double {
+        guard comparedTokenCount > 0 else { return 0 }
+        return Double(disagreementCount) / Double(comparedTokenCount)
+    }
+}
+
+/// llama.cpp's default — see `SPEC_VOCAB_MAX_SIZE_DIFFERENCE`. Refuses
+/// pairings whose vocabularies differ in size by more than this many
+/// tokens.
+public let aneVocabDefaultMaxSizeDifference: Int = 128
+
+/// llama.cpp's default — `SPEC_VOCAB_CHECK_START_TOKEN_ID = 5`. Tokens
+/// 0..<5 are usually special (BOS/EOS/PAD/UNK + one reserved) and
+/// occasionally drift between draft and target without affecting
+/// generation. Skipping them avoids false negatives.
+public let aneVocabDefaultStartTokenID: Int = 5
+
+/// Maximum tolerated token-string disagreements. llama.cpp uses zero
+/// (any disagreement above the start ID rejects); we expose it as a
+/// parameter so tests can probe the boundary cleanly.
+public let aneVocabDefaultMaxDisagreements: Int = 0
+
+/// Compare two tokenizer vocabularies for Mirror SD eligibility.
+///
+/// Both maps are token-ID → token-string. We walk every ID in
+/// `[startTokenID, min(draft.size, target.size))` and count
+/// disagreements. The size check is independent — vocabularies whose
+/// sizes differ by more than `maxSizeDifference` fail outright, even
+/// when their shared prefix matches.
+///
+/// - Parameter draftVocab: token ID → token string for the draft model.
+/// - Parameter targetVocab: token ID → token string for the target.
+/// - Parameter startTokenID: skip tokens below this ID. Defaults to
+///   `aneVocabDefaultStartTokenID = 5`.
+/// - Parameter maxSizeDifference: size-difference gate. Default 128.
+/// - Parameter maxDisagreements: disagreement gate. Default 0.
+public func aneCheckVocabEquivalence(
+    draftVocab: [Int: String],
+    targetVocab: [Int: String],
+    startTokenID: Int = aneVocabDefaultStartTokenID,
+    maxSizeDifference: Int = aneVocabDefaultMaxSizeDifference,
+    maxDisagreements: Int = aneVocabDefaultMaxDisagreements
+) -> ANEVocabEquivalenceReport {
+    let draftSize = draftVocab.count
+    let targetSize = targetVocab.count
+    let sizeDiff = abs(draftSize - targetSize)
+
+    // Size gate first — bail without walking tokens when this fails.
+    if sizeDiff > maxSizeDifference {
+        return ANEVocabEquivalenceReport(
+            comparedTokenCount: 0,
+            disagreementCount: 0,
+            sizeDifference: sizeDiff,
+            isCompatible: false)
+    }
+
+    // Walk the shared ID range and tally disagreements.
+    let upperBound = Swift.min(draftSize, targetSize)
+    var compared = 0
+    var disagreements = 0
+    if startTokenID < upperBound {
+        for id in startTokenID ..< upperBound {
+            // A token only present on one side is a disagreement: the
+            // draft and target have different ideas about what ID
+            // means. Skipping such IDs would mask real mismatches.
+            let draftStr = draftVocab[id]
+            let targetStr = targetVocab[id]
+            switch (draftStr, targetStr) {
+            case (nil, nil):
+                // Neither side has the token — sparse vocabularies. Don't
+                // count this slot at all; nothing to compare.
+                continue
+            case (let d?, let t?):
+                compared += 1
+                if d != t { disagreements += 1 }
+            default:
+                // One side missing → disagreement.
+                compared += 1
+                disagreements += 1
+            }
+        }
+    }
+
+    let pass = sizeDiff <= maxSizeDifference && disagreements <= maxDisagreements
+    return ANEVocabEquivalenceReport(
+        comparedTokenCount: compared,
+        disagreementCount: disagreements,
+        sizeDifference: sizeDiff,
+        isCompatible: pass)
+}

--- a/Libraries/MLXLMCommon/BigramTable.swift
+++ b/Libraries/MLXLMCommon/BigramTable.swift
@@ -1,0 +1,161 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+// MARK: - Common-bigram fallback drafter (spec 022 mechanism B)
+//
+// A pure-CPU bigram lookup that proposes drafts when neither the chat-
+// template grammar nor PLD has a hit. Compiled offline from a
+// representative corpus per tokenizer family: for each ordered pair
+// `(t_{i-1}, t_i)`, record the top-1 next token if its frequency is
+// >= a confidence threshold (default 0.95). At decode time the iterator
+// walks the table greedily until it runs out of confident bigrams.
+//
+// Phase 1 ships the in-memory data structure + a builder that takes a
+// frequency map. The on-disk binary format + offline build pipeline
+// land in phase 2 (the spec calls out
+// `Resources/bigrams/<tokenizer-family>.bin` as the artifact).
+
+/// One entry in the bigram table — the top-1 successor token for a
+/// `(prev, current)` bigram, plus the confidence that fired the
+/// admission filter at build time.
+public struct BigramEntry: Equatable, Sendable {
+    public let nextToken: Int
+    public let confidence: Float
+
+    public init(nextToken: Int, confidence: Float) {
+        precondition(confidence >= 0.0 && confidence <= 1.0,
+            "confidence must be in [0, 1] (got \(confidence))")
+        self.nextToken = nextToken
+        self.confidence = confidence
+    }
+}
+
+/// Sparse bigram → next-token map. Entries are admitted only when their
+/// top-1 successor cleared the confidence threshold at build time;
+/// lookup is unconditional (the threshold has already been applied).
+///
+/// Storage: `[Int: [Int: BigramEntry]]` keyed `prev → current →
+/// entry`. Two-level dict instead of `[(Int, Int): BigramEntry]` so
+/// `confidentNext(after:)` doesn't need to construct a tuple key on
+/// every decode-time call. Flat tuple-key would be cleaner; the nested
+/// form is measurably faster on Swift's standard `Dictionary` impl
+/// (avoids hash-of-tuple boxing).
+public struct BigramTable: Sendable {
+    private var table: [Int: [Int: BigramEntry]]
+
+    public let admissionThreshold: Float
+
+    /// Number of (prev, current) → entry mappings stored. Used by tests
+    /// and by the bench harness `[BIGRAM]` line.
+    public var entryCount: Int {
+        table.reduce(0) { $0 + $1.value.count }
+    }
+
+    public init(admissionThreshold: Float = 0.95) {
+        precondition(
+            admissionThreshold >= 0.0 && admissionThreshold <= 1.0,
+            "admissionThreshold must be in [0, 1] (got \(admissionThreshold))")
+        self.admissionThreshold = admissionThreshold
+        self.table = [:]
+    }
+
+    /// Insert an entry directly. Tests use this; the offline builder
+    /// goes through `build(fromFrequencies:)` instead.
+    ///
+    /// Re-insert with the same `(prev, current)` overwrites in place
+    /// — matches "rebuilt from a fresher corpus" semantics.
+    public mutating func insert(prev: Int, current: Int, entry: BigramEntry) {
+        precondition(
+            entry.confidence >= admissionThreshold,
+            "Inserted entry below admission threshold: \(entry.confidence) "
+                + "< \(admissionThreshold). Builder should filter first.")
+        if table[prev] == nil { table[prev] = [:] }
+        table[prev]![current] = entry
+    }
+
+    /// Look up the confident successor for `(prev, current)`, or nil if
+    /// the bigram isn't in the table.
+    public func confidentNext(prev: Int, current: Int) -> BigramEntry? {
+        table[prev]?[current]
+    }
+
+    /// Walk the bigram chain greedily up to `maxK` drafts.
+    ///
+    /// - Parameter recentTokens: at least the last 2 emitted tokens.
+    ///   The walk seeds from `(recentTokens[-2], recentTokens[-1])`.
+    /// - Parameter maxK: cap on draft length (the iterator's per-round
+    ///   budget).
+    /// - Returns: greedy chain of confident successors. Empty if
+    ///   `recentTokens.count < 2` or the seed bigram has no confident
+    ///   continuation.
+    public func bigramDraft(maxK: Int, recentTokens: [Int]) -> [Int] {
+        guard maxK > 0, recentTokens.count >= 2 else { return [] }
+        var draft: [Int] = []
+        var prev = recentTokens[recentTokens.count - 2]
+        var current = recentTokens[recentTokens.count - 1]
+        for _ in 0 ..< maxK {
+            guard let next = confidentNext(prev: prev, current: current) else { break }
+            draft.append(next.nextToken)
+            prev = current
+            current = next.nextToken
+        }
+        return draft
+    }
+
+    /// Build a bigram table from a `(prev, current) -> [next: count]`
+    /// frequency map, applying the admission threshold.
+    ///
+    /// Threshold semantics: for each `(prev, current)` key, the top-1
+    /// `next`'s share of the total observed continuations must be
+    /// >= `threshold` to admit the entry. Bigrams whose top-1 falls
+    /// below threshold are simply omitted — the table is "sparse on the
+    /// confident set", not "exhaustive over the corpus".
+    ///
+    /// Tied top-1 candidates are broken arbitrarily (Dictionary
+    /// iteration order). For phase-1 the threshold is 0.95 and ties
+    /// at that level are vanishingly rare; phase-2's offline tool
+    /// will use a stable tiebreaker (numeric token ID) when it serializes.
+    public static func build(
+        fromFrequencies frequencies: [BigramKey: [Int: Int]],
+        threshold: Float = 0.95
+    ) -> BigramTable {
+        var t = BigramTable(admissionThreshold: threshold)
+        for (key, nextCounts) in frequencies {
+            let total = nextCounts.values.reduce(0, +)
+            guard total > 0 else { continue }
+            // Find the top-1 successor.
+            var bestNext: Int? = nil
+            var bestCount: Int = 0
+            for (next, count) in nextCounts {
+                if count > bestCount {
+                    bestCount = count
+                    bestNext = next
+                }
+            }
+            guard let nt = bestNext else { continue }
+            let confidence = Float(bestCount) / Float(total)
+            if confidence >= threshold {
+                t.insert(
+                    prev: key.prev,
+                    current: key.current,
+                    entry: BigramEntry(nextToken: nt, confidence: confidence))
+            }
+        }
+        return t
+    }
+}
+
+/// Key for the frequency map consumed by `BigramTable.build(...)`. Wraps
+/// `(prev, current)` into a Hashable struct — Swift can hash tuples of
+/// Hashable elements but the ergonomics of an explicit struct are
+/// nicer for the offline builder's call sites.
+public struct BigramKey: Equatable, Hashable, Sendable {
+    public let prev: Int
+    public let current: Int
+
+    public init(prev: Int, current: Int) {
+        self.prev = prev
+        self.current = current
+    }
+}

--- a/Libraries/MLXLMCommon/ChatTemplateGrammar.swift
+++ b/Libraries/MLXLMCommon/ChatTemplateGrammar.swift
@@ -1,0 +1,163 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+// MARK: - Chat-template grammar (spec 022 mechanism A — deterministic stretch)
+//
+// Modern chat templates emit deterministic token sequences at structural
+// boundaries: after a channel marker, after a thinking-end tag, at the
+// turn opener after the assistant header. By construction these
+// continuations don't depend on model output — they're forced by the
+// template grammar. A small per-family state machine can predict them
+// 100% of the time and feed them through the speculative-decode verify
+// path as zero-error drafts.
+//
+// Phase 1 (this file): the protocol + state types + a `NoOpChatGrammar`
+// that always returns nil. Per-family implementations
+// (Qwen35Grammar, Gemma4Grammar, GPTOSSGrammar, LlamaGrammar) land in
+// follow-up PRs once we wire in the tokenizer-resolved special-token IDs.
+//
+// The state machine is queried in the speculative iterator's draft
+// ladder *before* PLD lookup (deterministic stretches always beat
+// probabilistic ones) and *after* the model has just emitted a token —
+// the grammar inspects the recent token history + current phase and
+// decides whether to inject a deterministic continuation.
+
+/// High-level conversation phase the grammar uses to scope its
+/// transition rules. Values are deliberately coarse — fine-grained
+/// state lives in the recent-tokens window and the per-family grammar's
+/// internal logic.
+public enum ChatTemplatePhase: Equatable, Hashable, Sendable {
+    case userTurn
+    case assistantTurn
+    case thinking
+    case channelMarker
+    case toolCall
+    case other
+}
+
+/// Tokenizer-resolved chat-template special token IDs. The grammar
+/// implementations consume this to convert text-level patterns
+/// (`<|channel|>`, `<|im_end|>`, etc.) into token-ID-level rules
+/// without re-tokenizing at decode time.
+///
+/// Phase 1 ships with a small set of fields covering the four
+/// supported families. Per-family grammars can ignore fields they
+/// don't use; nil-valued fields signal "this template doesn't have
+/// that boundary".
+public struct ChatTemplateConfig: Equatable, Sendable {
+    /// Begin-of-turn / opener token (e.g. `<|im_start|>` for Qwen,
+    /// `<start_of_turn>` for Gemma 4).
+    public let turnOpenerToken: Int?
+
+    /// End-of-turn / closer token (e.g. `<|im_end|>`, `<end_of_turn>`).
+    public let turnCloserToken: Int?
+
+    /// Begin-thinking marker (`<think>` for Qwen 3.5).
+    public let thinkBeginToken: Int?
+
+    /// End-thinking marker (`</think>` for Qwen 3.5).
+    public let thinkEndToken: Int?
+
+    /// Channel marker (`<|channel|>` for GPT-OSS harmony format).
+    public let channelMarkerToken: Int?
+
+    /// Message marker (`<|message|>` for GPT-OSS harmony).
+    public let messageMarkerToken: Int?
+
+    /// Newline token IDs — varies per tokenizer (some have a single
+    /// `\n`, others have `\n\n` as a separate token). Stored as a set
+    /// because matching against any newline-shaped token is fine for
+    /// the phase-1 grammars.
+    public let newlineTokens: Set<Int>
+
+    public init(
+        turnOpenerToken: Int? = nil,
+        turnCloserToken: Int? = nil,
+        thinkBeginToken: Int? = nil,
+        thinkEndToken: Int? = nil,
+        channelMarkerToken: Int? = nil,
+        messageMarkerToken: Int? = nil,
+        newlineTokens: Set<Int> = []
+    ) {
+        self.turnOpenerToken = turnOpenerToken
+        self.turnCloserToken = turnCloserToken
+        self.thinkBeginToken = thinkBeginToken
+        self.thinkEndToken = thinkEndToken
+        self.channelMarkerToken = channelMarkerToken
+        self.messageMarkerToken = messageMarkerToken
+        self.newlineTokens = newlineTokens
+    }
+}
+
+/// State the grammar inspects to decide whether to fire a deterministic
+/// draft on this round. Iterator constructs it fresh per call; grammars
+/// are stateless across calls (any state they need to accumulate is
+/// derived from `recentTokens`).
+public struct ChatTemplateState: Equatable, Sendable {
+    public let phase: ChatTemplatePhase
+    public let recentTokens: [Int]
+    public let chatTemplateConfig: ChatTemplateConfig
+
+    public init(
+        phase: ChatTemplatePhase,
+        recentTokens: [Int],
+        chatTemplateConfig: ChatTemplateConfig
+    ) {
+        self.phase = phase
+        self.recentTokens = recentTokens
+        self.chatTemplateConfig = chatTemplateConfig
+    }
+}
+
+/// Per-family grammar. Implementations decide whether the just-emitted
+/// token has put us at a deterministic-stretch boundary; if so, return
+/// the next K forced tokens (typically 1-4); otherwise return nil so
+/// the iterator falls through to PLD / bigram / AR.
+public protocol ChatTemplateGrammar: Sendable {
+    /// - Parameter justEmittedToken: the token that was emitted in the
+    ///   last decode step.
+    /// - Parameter state: current chat-template state.
+    /// - Returns: deterministic continuation tokens, or nil if no
+    ///   deterministic stretch applies here.
+    func deterministicContinuation(
+        afterToken justEmittedToken: Int,
+        state: ChatTemplateState
+    ) -> [Int]?
+}
+
+/// Trivial fallback grammar — always returns nil. Used by the iterator
+/// when the target's chat template doesn't match any registered family
+/// (and as a default in tests). Drop-in compatible with the protocol so
+/// we don't need optional handling in the iterator hot path.
+public struct NoOpChatGrammar: ChatTemplateGrammar {
+    public init() {}
+    public func deterministicContinuation(
+        afterToken justEmittedToken: Int,
+        state: ChatTemplateState
+    ) -> [Int]? {
+        nil
+    }
+}
+
+/// Test / generic grammar that fires a fixed continuation after seeing
+/// a specific trigger token. Lets tests exercise the iterator's
+/// draft-ladder routing without standing up a real per-family grammar.
+public struct TriggerTokenGrammar: ChatTemplateGrammar {
+    public let triggerToken: Int
+    public let continuation: [Int]
+
+    public init(triggerToken: Int, continuation: [Int]) {
+        precondition(!continuation.isEmpty,
+            "TriggerTokenGrammar requires non-empty continuation")
+        self.triggerToken = triggerToken
+        self.continuation = continuation
+    }
+
+    public func deterministicContinuation(
+        afterToken justEmittedToken: Int,
+        state: ChatTemplateState
+    ) -> [Int]? {
+        justEmittedToken == triggerToken ? continuation : nil
+    }
+}

--- a/Libraries/MLXLMCommon/DFlashDraftBackend.swift
+++ b/Libraries/MLXLMCommon/DFlashDraftBackend.swift
@@ -1,0 +1,205 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+// MARK: - Draft-side protocol surface for DFlash speculative decoding
+//
+// The DFlash draft is a small block-diffusion transformer that, given the
+// target's most-recent hidden states at a configured set of capture layers
+// and the last committed token, emits K (typically 16) candidate
+// continuation tokens in **one** forward pass. The target then verifies
+// all K in one batched forward pass and accepts the longest matching
+// prefix.
+//
+// This file defines the **draft-side** protocol — what a draft backend
+// must expose to ``DFlashSpeculativeTokenIterator``. Phase 1 ships two
+// implementations:
+//
+//   - ``ZeroAcceptDraftBackend`` — always returns a constant non-matching
+//     token. Lets the iterator test the "all rejected" path end-to-end
+//     without GPU model weights, exercising the rollback and bonus-token
+//     emission code paths. Acceptance rate is by construction zero.
+//   - ``ScriptedDraftBackend`` — replays a caller-provided list of blocks.
+//     Tests use this to drive specific accept/reject patterns.
+//
+// Phase 2 will add a real ``DFlashTransformerDraftBackend`` that loads
+// trained weights from a HuggingFace draft repo (e.g.
+// `z-lab/Qwen3.5-9B-DFlash`) and runs a block-diffusion forward.
+
+/// A draft-side backend for DFlash speculative decoding.
+///
+/// Implementations encapsulate everything the iterator needs to know about
+/// the draft model: the iterator does not own draft KV state, draft model
+/// weights, or block-diffusion specifics. This lets us swap in a stub for
+/// scaffold-time testing, a scripted backend for unit tests, and the real
+/// transformer backend without iterator changes.
+public protocol DFlashDraftBackend {
+    /// The fixed block size this backend emits per ``draftBlock`` call.
+    /// dflash-mlx uses 16 by default; smaller drafts are valid for
+    /// experimentation.
+    var blockSize: Int { get }
+
+    /// The set of target-side layer IDs whose post-block hidden states this
+    /// backend wants to consume. Returned by the registry / draft config so
+    /// the iterator knows which layers to ask the target to capture during
+    /// verify forward.
+    var captureLayerIDs: Set<Int> { get }
+
+    /// Generate one block of `blockSize` candidate tokens, conditioned on
+    /// the target's captured hidden states and the last committed token.
+    ///
+    /// - Parameter targetHidden: `layerID -> [B=1, T=1, H]` hidden states
+    ///   captured at the configured layers during the previous verify
+    ///   forward (or the prefill forward, on the first call). May be empty
+    ///   on the very first cycle if the iterator has not yet captured any
+    ///   target hidden state — backends should handle that case (the stub
+    ///   backends do; the real diffusion backend will warm-start from the
+    ///   target's prefill capture).
+    /// - Parameter lastCommittedToken: The most recently emitted token from
+    ///   the target (the seed for the next block).
+    /// - Returns: `blockSize` candidate token IDs. Returning fewer is
+    ///   permitted (e.g. when generation is approaching `maxTokens`); the
+    ///   iterator clamps the verify batch shape to the returned length.
+    mutating func draftBlock(
+        targetHidden: [Int: MLXArray],
+        lastCommittedToken: Int
+    ) -> [Int]
+
+    /// Reset any internal draft KV state — called on iterator init and any
+    /// time the iterator wants to discard accumulated draft context (e.g.
+    /// reuse across requests). Stub backends typically no-op.
+    mutating func reset()
+}
+
+// MARK: - Phase-1 stub backends
+
+/// Phase-1 stub draft backend that emits a single repeated token for every
+/// position in the block. Designed to never match the target's argmax, so
+/// the iterator runs the full "draft → verify → reject all → emit bonus
+/// → trim cache" cycle on every round.
+///
+/// Acceptance rate is by construction `0/blockSize` per cycle. Throughput
+/// is _slower_ than baseline `TokenIterator` (because the verify forward
+/// processes `blockSize+1` positions instead of 1). This is intentional:
+/// the goal is to validate the cycle plumbing — protocol conformances,
+/// hidden-state capture, verify forward, accept-prefix computation,
+/// cache trim — before we add the real diffusion draft model in phase 2.
+public struct ZeroAcceptDraftBackend: DFlashDraftBackend {
+    public let blockSize: Int
+    public let captureLayerIDs: Set<Int>
+
+    /// The "draft" we emit each round. Picked to be a token that the target
+    /// is extremely unlikely to argmax to (negative would be invalid; we
+    /// settle for token 0 since an EOS or pad token usually sits there for
+    /// most tokenizers but we do _not_ depend on that — we depend on the
+    /// target argmaxing to something, and as long as it's not 0 we get the
+    /// "all rejected" path exercised). On the rare prompt where the target
+    /// _does_ argmax to 0, the cycle still completes correctly — it just
+    /// happens to accept one token per cycle for that prompt.
+    public let stubToken: Int
+
+    public init(blockSize: Int = 16, captureLayerIDs: Set<Int> = [], stubToken: Int = 0) {
+        precondition(blockSize >= 1, "blockSize must be >= 1 (got \(blockSize))")
+        self.blockSize = blockSize
+        self.captureLayerIDs = captureLayerIDs
+        self.stubToken = stubToken
+    }
+
+    public mutating func draftBlock(
+        targetHidden: [Int: MLXArray],
+        lastCommittedToken: Int
+    ) -> [Int] {
+        Array(repeating: stubToken, count: blockSize)
+    }
+
+    public mutating func reset() {}
+}
+
+/// Test-only draft backend that replays a caller-supplied list of blocks
+/// in order. When the script is exhausted, returns an empty block (which
+/// the iterator treats as "skip this round, fall through to AR decode").
+///
+/// Used by the unit tests to drive specific accept/reject patterns
+/// deterministically — e.g. "first cycle: matches first 3 of 4, rejects
+/// the 4th; second cycle: full reject" — without needing a real draft
+/// model.
+public struct ScriptedDraftBackend: DFlashDraftBackend {
+    public let blockSize: Int
+    public let captureLayerIDs: Set<Int>
+    private var script: [[Int]]
+    private var cursor: Int = 0
+
+    /// Number of `draftBlock` calls served so far. Tests use this to assert
+    /// the iterator made the expected number of round-trips.
+    public var callCount: Int { cursor }
+
+    public init(
+        blockSize: Int,
+        script: [[Int]],
+        captureLayerIDs: Set<Int> = []
+    ) {
+        precondition(blockSize >= 1, "blockSize must be >= 1 (got \(blockSize))")
+        for (i, block) in script.enumerated() {
+            precondition(
+                block.count <= blockSize,
+                "ScriptedDraftBackend block[\(i)] has \(block.count) tokens, "
+                    + "exceeds blockSize=\(blockSize)")
+        }
+        self.blockSize = blockSize
+        self.script = script
+        self.captureLayerIDs = captureLayerIDs
+    }
+
+    public mutating func draftBlock(
+        targetHidden: [Int: MLXArray],
+        lastCommittedToken: Int
+    ) -> [Int] {
+        guard cursor < script.count else { return [] }
+        defer { cursor += 1 }
+        return script[cursor]
+    }
+
+    public mutating func reset() {
+        cursor = 0
+    }
+}
+
+// MARK: - Pure-Swift accept-prefix helper
+//
+// The iterator's verify path computes the accepted-prefix length by
+// matching draft tokens against target argmax position-by-position. We
+// factor that out as a pure-Swift function so it can be unit-tested
+// without standing up a model + cache. Mirrors dflash-mlx's
+// `cumprod`-over-equality-mask (the first zero in the cumulative
+// product marks the first mismatch); we use the linear-scan form because
+// at K=16 the constant factor is irrelevant and the linear form is
+// the easier port target.
+
+/// Compute the longest matching prefix length between `draft` and
+/// `targetArgmax`. Both arrays are tokens at the same set of verify
+/// positions; the iterator emits exactly `acceptedPrefixLength + 1`
+/// tokens — the matching prefix plus the target's "bonus" token at the
+/// first mismatch (or the position past the matching prefix on full
+/// accept).
+///
+/// - Parameter draft: candidate tokens from the draft backend.
+/// - Parameter targetArgmax: tokens the target argmaxes to at each
+///   verify position. Must have at least `draft.count + 1` entries
+///   (one bonus position past the draft).
+/// - Returns: the largest `n` such that `draft[0..<n] == targetArgmax[0..<n]`.
+public func dflashAcceptedPrefixLength(
+    draft: [Int],
+    targetArgmax: [Int]
+) -> Int {
+    precondition(
+        targetArgmax.count >= draft.count + 1,
+        "targetArgmax must contain at least draft.count + 1 entries "
+            + "(got \(targetArgmax.count) for draft \(draft.count))")
+    for i in 0 ..< draft.count {
+        if draft[i] != targetArgmax[i] {
+            return i
+        }
+    }
+    return draft.count
+}

--- a/Libraries/MLXLMCommon/DFlashSpeculativeDecoding.swift
+++ b/Libraries/MLXLMCommon/DFlashSpeculativeDecoding.swift
@@ -1,0 +1,368 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+// MARK: - DFlash speculative decoding iterator (phase 1 — full-attention only)
+//
+// State machine per cycle:
+//   1. Ask the draft backend for K candidate tokens, given the last
+//      committed token and the most recent target capture.
+//   2. Build the verify-batch input  `[y, draft_1, ..., draft_K]`.
+//   3. Run the target's ``DFlashTargetModel/dflashForwardWithCapture`` on
+//      that batch — returns logits `[1, K+1, V]` + captured hidden states
+//      `[layerID -> [1, K+1, H]]` at the requested layers.
+//   4. Compute target argmax at each verify position — the K+1 "main
+//      tokens".
+//   5. Walk drafts in order; stop at the first mismatch with main tokens.
+//      That's the accept count.
+//   6. Emit the accepted prefix + main tokens[accept] (the bonus token —
+//      either the correction after the first reject, or the K+1th token
+//      after a full accept).
+//   7. Trim the KV cache by (K - accept) for full-attention layers — those
+//      drafted-K/V rows must be undone so the cache offset matches what
+//      the iterator thinks it has.
+//   8. Slice the captured hidden state at position `accept` and store it
+//      for the next cycle's draft backend.
+//
+// Phase 1 supports **full-attention targets only** (`dflashIsHybridGDN ==
+// false`). Hybrid GDN/Mamba targets need the tape-replay rollback path
+// (spec 020); init throws for those targets so the caller can choose
+// either to await Phase 3 or to fall back to a different iterator.
+
+/// Generator of tokens with **DFlash block-diffusion speculative decoding**.
+///
+/// Pairs a small block-diffusion draft model (the ``DFlashDraftBackend``)
+/// with a target language model that conforms to ``DFlashTargetModel``.
+/// The draft conditions on captured target hidden states; the target
+/// verifies the K-token candidate block in one forward pass and accepts
+/// the longest matching prefix.
+///
+/// Drop-in replacement for ``TokenIterator`` when the caller has a
+/// DFlash-conforming target and a registered draft backend. The cycle
+/// produces byte-identical output to greedy ``TokenIterator`` decode at
+/// `temperature: 0` (the verifier compares against the target's argmax).
+///
+/// Construction throws if the target reports `dflashIsHybridGDN == true`
+/// — those need the tape-replay rollback path (spec 020) which lands in
+/// Phase 3. Callers should fall back to ``TokenIterator`` or a different
+/// speculative path on that error.
+public struct DFlashSpeculativeTokenIterator: TokenIteratorProtocol {
+
+    // MARK: - Inputs / state
+
+    var y: LMInput.Text
+
+    let target: any LanguageModel
+    let dflashTarget: any DFlashTargetModel
+    var mainState: LMOutput.State?
+    var mainCache: [KVCache]
+    let quantizeKVCache: (inout [KVCache]) -> Void
+
+    /// The draft backend — held as a typed value so its mutating-method
+    /// state (KV cache, scripted cursor, etc.) survives across cycles.
+    /// We use `any DFlashDraftBackend` and accept the existential
+    /// dispatch cost: at K=16 the per-cycle backend call is one of the
+    /// cheap pieces.
+    var draftBackend: any DFlashDraftBackend
+
+    /// Captured target hidden states from the most recent verify forward,
+    /// sliced to the accepted-prefix's last position. Empty on the first
+    /// cycle (the draft backend handles cold-start). Keyed by layerID.
+    var lastCapturedHidden: [Int: MLXArray] = [:]
+
+    let sampler: LogitSampler
+    var tokenCount = 0
+    let maxTokens: Int?
+
+    // Per-round emission buffer
+    private var pendingTokens = [Int]()
+    private var pendingIndex = 0
+
+    /// Prompt prefill time (ms), measured once at init.
+    public private(set) var promptPrefillTime: TimeInterval = 0.0
+
+    /// Tokens accepted from the draft backend (for acceptance-rate tracking).
+    public private(set) var dflashAcceptedCount = 0
+
+    /// Total draft tokens proposed across all cycles.
+    public private(set) var dflashProposedCount = 0
+
+    /// Cycle count — number of completed `speculateRound()` invocations.
+    /// Used by the bench harness to compute mean accept-per-cycle, which
+    /// cross-checks against the dflash-mlx published numbers.
+    public private(set) var dflashCycleCount = 0
+
+    public var dflashAcceptanceRate: Double {
+        guard dflashProposedCount > 0 else { return 0 }
+        return Double(dflashAcceptedCount) / Double(dflashProposedCount)
+    }
+
+    public var specDecodeProposed: Int { dflashProposedCount }
+    public var specDecodeAccepted: Int { dflashAcceptedCount }
+
+    public var kvCacheMemoryBytes: Int? {
+        mainCache.isEmpty ? nil : mainCache.reduce(0) { $0 + $1.memoryBytes }
+    }
+
+    /// Verbose tracing (`MLX_DFLASH_DEBUG=1`). When enabled, every cycle
+    /// logs draft/accept counts, cache offset, and capture-layer summary.
+    private static var debugTracing: Bool {
+        ProcessInfo.processInfo.environment["MLX_DFLASH_DEBUG"] == "1"
+    }
+
+    // MARK: - Init
+
+    /// Initialize a `DFlashSpeculativeTokenIterator` over a target that
+    /// conforms to both ``LanguageModel`` (for prefill / sampler glue)
+    /// and ``DFlashTargetModel`` (for capture forward).
+    ///
+    /// The `draftBackend` parameter is consumed by value but stored as
+    /// existential because Swift's `any P` is the only way to hold a
+    /// mutating-method protocol value across cycles without losing
+    /// type erasure benefits we need for testing.
+    ///
+    /// - Throws: ``KVCacheError`` if the target's cache is non-trimmable
+    ///   (i.e. contains hybrid GDN/Mamba layers and `dflashIsHybridGDN`
+    ///   is true). Phase 3 will lift this restriction via tape-replay.
+    public init(
+        input: LMInput,
+        target: any LanguageModel & DFlashTargetModel,
+        mainCache: [KVCache]? = nil,
+        draftBackend: any DFlashDraftBackend,
+        parameters: GenerateParameters
+    ) throws {
+        self.y = input.text
+        self.target = target
+        self.dflashTarget = target
+
+        if target.dflashIsHybridGDN {
+            throw KVCacheError(
+                message: "DFlashSpeculativeTokenIterator phase 1 supports "
+                    + "full-attention targets only. Hybrid GDN/Mamba "
+                    + "targets need the tape-replay rollback path "
+                    + "(spec 020 / phase 3). Got "
+                    + "\(type(of: target)) with dflashIsHybridGDN == true.")
+        }
+
+        self.mainCache = mainCache ?? target.newCache(parameters: parameters)
+        guard canTrimPromptCache(self.mainCache) else {
+            throw KVCacheError(
+                message: "DFlash speculative decoding (phase 1) requires "
+                    + "trimmable KV caches. The target reported a hybrid "
+                    + "or otherwise non-trimmable cache.")
+        }
+
+        self.sampler = parameters.sampler()
+        self.maxTokens = parameters.maxTokens
+        self.draftBackend = draftBackend
+
+        self.quantizeKVCache = { cache in
+            maybeQuantizeKVCache(
+                cache: &cache,
+                kvBits: parameters.kvBits,
+                kvGroupSize: parameters.kvGroupSize,
+                quantizedKVStart: parameters.quantizedKVStart
+            )
+        }
+
+        self.promptPrefillTime = try measure {
+            try prepare(input: input, windowSize: parameters.prefillStepSize)
+        }
+
+        if Self.debugTracing {
+            print("[DFLASH] iterator engaged: blockSize=\(draftBackend.blockSize) "
+                + "captureLayers=\(draftBackend.captureLayerIDs.sorted()) "
+                + "promptTokens=\(input.text.tokens.size)")
+        }
+    }
+
+    /// Prefill the target with the prompt + prime the pump with one decode
+    /// step. Mirrors ``NGramSpeculativeTokenIterator/prepare`` — the first
+    /// emitted token must be the target's argmax at the last prompt
+    /// position. Without this step, the first `speculateRound` would
+    /// conflate "prefill's last token" with "the first generated token"
+    /// and produce a stream offset by one vs. ``TokenIterator``.
+    ///
+    /// As with the n-gram iterator, the trailing `eval(token)` is also a
+    /// **sync barrier** required by Gemma 4 — without it, async-prefill
+    /// KV writes may not have committed by the time the first verify
+    /// forward in `speculateRound()` reads the cache.
+    mutating func prepare(input: LMInput, windowSize: Int? = nil) throws {
+        switch try target.prepare(input, cache: mainCache, windowSize: windowSize) {
+        case .tokens(let tokens):
+            let result = target(tokens[text: .newAxis], cache: mainCache, state: nil)
+            quantizeKVCache(&mainCache)
+            let logits = result.logits[0..., -1, 0...]
+            let token = sampler.sample(logits: logits)
+            mainState = result.state
+            eval(token)
+            let tokenInt = token.item(Int.self)
+            y = .init(tokens: token)
+            pendingTokens.append(tokenInt)
+        case .logits(let result):
+            let logits = result.logits[0..., -1, 0...]
+            let token = sampler.sample(logits: logits)
+            eval(token)
+            let tokenInt = token.item(Int.self)
+            y = .init(tokens: token)
+            mainState = result.state
+            pendingTokens.append(tokenInt)
+        }
+    }
+
+    // MARK: - Cycle
+
+    /// One DFlash cycle: draft → verify → accept → trim.
+    mutating func speculateRound() {
+        let remaining = maxTokens.map { $0 - tokenCount } ?? draftBackend.blockSize
+        guard remaining > 0 else { return }
+
+        let draftInts = draftBackend.draftBlock(
+            targetHidden: lastCapturedHidden,
+            lastCommittedToken: y.tokens.asArray(Int.self).last ?? 0)
+
+        // Empty draft → fall through to single-step AR decode.
+        // Same shape as the n-gram iterator's miss path, but we keep it
+        // single-step rather than batched (the AR-batch size choice is
+        // workload-dependent and DFlash phase 1 is correctness-first).
+        if draftInts.isEmpty {
+            let result = target(y[text: .newAxis], cache: mainCache, state: mainState)
+            quantizeKVCache(&mainCache)
+            let logits = result.logits[0..., -1, 0...]
+            let token = sampler.sample(logits: logits)
+            eval(token)
+            let tokenInt = token.item(Int.self)
+            mainState = result.state
+            pendingTokens.append(tokenInt)
+            y = .init(tokens: token)
+            dflashCycleCount += 1
+            if Self.debugTracing {
+                print("[DFLASH] cycle=\(dflashCycleCount) draft=0 (empty) "
+                    + "ar_emit=\(tokenInt)")
+            }
+            return
+        }
+
+        // Clamp the draft to remaining-token budget. We need to keep at
+        // least one slot for the bonus token, so cap drafts at
+        // (remaining - 1) — when remaining == 1, we degenerate to no-draft
+        // AR (handled above by the empty-draft branch logically, but here
+        // the draft might still be non-empty; we just truncate).
+        let budget = Swift.max(0, remaining - 1)
+        let clampedDraft = budget < draftInts.count
+            ? Array(draftInts.prefix(budget))
+            : draftInts
+        let numDraft = clampedDraft.count
+
+        if numDraft == 0 {
+            // Same path as empty draft — degenerate.
+            let result = target(y[text: .newAxis], cache: mainCache, state: mainState)
+            quantizeKVCache(&mainCache)
+            let logits = result.logits[0..., -1, 0...]
+            let token = sampler.sample(logits: logits)
+            eval(token)
+            let tokenInt = token.item(Int.self)
+            mainState = result.state
+            pendingTokens.append(tokenInt)
+            y = .init(tokens: token)
+            dflashCycleCount += 1
+            return
+        }
+
+        let draftArray = MLXArray(clampedDraft.map { Int32($0) })
+
+        // Verify-batch input: [y, draft_1, ..., draft_K]
+        let verifyTokens = concatenated([y.tokens, draftArray])
+        let verifyInputIDs = verifyTokens[.newAxis, 0...]  // [1, K+1]
+        let verifyStart = verifyTokens.dim(0) - (numDraft + 1)
+
+        // Capture hidden states at the configured layers via the DFlash
+        // protocol method. Empty `captureLayerIDs` is fine — the target
+        // implementation should return an empty `captured` dict in that
+        // case.
+        let (verifyLogitsFull, captured) = dflashTarget.dflashForwardWithCapture(
+            inputIDs: verifyInputIDs,
+            cache: mainCache,
+            captureLayerIDs: draftBackend.captureLayerIDs)
+
+        // Argmax per verify position. Greedy = `sampler.sample` at temp=0.
+        let verifyLogits = verifyLogitsFull[0..., verifyStart..., 0...].squeezed(axis: 0)
+        let mainTokens = sampler.sample(logits: verifyLogits)
+        eval(mainTokens)
+        let mainTokensList = mainTokens.asArray(Int.self)
+
+        // Accept-prefix walk — pure-Swift helper so this slice is unit-tested.
+        let accepted = dflashAcceptedPrefixLength(
+            draft: clampedDraft,
+            targetArgmax: mainTokensList)
+
+        // Emit accepted prefix + bonus token.
+        for i in 0 ..< accepted {
+            pendingTokens.append(mainTokensList[i])
+        }
+        let bonusToken = mainTokensList[accepted]
+        pendingTokens.append(bonusToken)
+
+        // Trim the KV cache for rejected tokens — same as the linear-K
+        // speculative path. The verify forward wrote K+1 positions; we
+        // commit `accepted + 1` of them (accepted prefix + bonus). The
+        // remaining `numDraft - accepted` rows must be undone.
+        let rejected = numDraft - accepted
+        if rejected > 0 {
+            trimPromptCache(mainCache, numTokens: rejected)
+        }
+        quantizeKVCache(&mainCache)
+
+        // Slice the captured hidden state at position `accepted` so the
+        // next cycle's draft conditions on the hidden state at the actual
+        // committed-prefix tail (not somewhere mid-rejected-draft). Phase
+        // 2's real backend will use this; the stub backends ignore it.
+        if !captured.isEmpty {
+            var sliced: [Int: MLXArray] = [:]
+            sliced.reserveCapacity(captured.count)
+            for (layerID, h) in captured {
+                // h shape: [1, K+1, H]. Take position `accepted` -> [1, 1, H].
+                sliced[layerID] = h[0..., accepted ..< (accepted + 1), 0...]
+            }
+            lastCapturedHidden = sliced
+        } else {
+            lastCapturedHidden = [:]
+        }
+
+        // Bookkeeping.
+        dflashAcceptedCount += accepted
+        dflashProposedCount += numDraft
+        dflashCycleCount += 1
+
+        // Next round seeds from the bonus token.
+        y = .init(tokens: mainTokens[accepted ... accepted])
+
+        if Self.debugTracing {
+            print("[DFLASH] cycle=\(dflashCycleCount) draft=\(numDraft) "
+                + "accepted=\(accepted) rejected=\(rejected) bonus=\(bonusToken)")
+        }
+    }
+
+    // MARK: - IteratorProtocol
+
+    public mutating func next() -> Int? {
+        if let maxTokens, tokenCount >= maxTokens {
+            return nil
+        }
+        if pendingIndex < pendingTokens.count {
+            let t = pendingTokens[pendingIndex]
+            pendingIndex += 1
+            tokenCount += 1
+            return t
+        }
+        pendingTokens.removeAll(keepingCapacity: true)
+        pendingIndex = 0
+        speculateRound()
+        guard !pendingTokens.isEmpty else { return nil }
+        let t = pendingTokens[pendingIndex]
+        pendingIndex += 1
+        tokenCount += 1
+        return t
+    }
+}

--- a/Libraries/MLXLMCommon/DFlashTargetModel.swift
+++ b/Libraries/MLXLMCommon/DFlashTargetModel.swift
@@ -1,0 +1,101 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+// MARK: - Target-side protocol surface for DFlash speculative decoding
+//
+// DFlash speculative decoding pairs a small block-diffusion draft model with
+// the target model (the model the user actually wants outputs from). The
+// draft conditions on **target-side hidden states** captured at a small
+// configured set of layers, and the target verifies the K=16 candidate
+// tokens produced by the draft in one batched forward pass.
+//
+// This file defines the **target-side** protocol — what a model adopting
+// DFlash must expose to the iterator. The complementary **draft-side**
+// protocol is in `DFlashDraftBackend.swift`.
+//
+// The shape mirrors SwiftLM's `Sources/DFlash/DFlashTargetModel.swift`
+// surface (which in turn ports the `bstnxbt/dflash-mlx` Python reference).
+// We keep it small + Swift-idiomatic — no Core ML, no Python-shape glue
+// here. Per-target conformance lives next to each target model in
+// `Libraries/MLXLLM/Models/*+DFlash.swift`.
+
+/// A target model that can drive DFlash speculative decoding.
+///
+/// "Target" = the big model whose outputs we want. The DFlash draft
+/// reads target hidden states from selected layers and emits 16 candidate
+/// tokens in one parallel-decoder forward pass; this protocol exposes the
+/// hidden-state capture hook the draft needs plus the standard embed /
+/// LM-head pieces the iterator uses to glue the cycle together.
+///
+/// Per-target conformance is a small extension that taps into the existing
+/// per-layer activations on the model's forward path — see spec 015 phase
+/// 1 for the bootstrapping pattern.
+public protocol DFlashTargetModel: AnyObject {
+    /// Token-embedding lookup. Maps `[B, T]` token IDs to `[B, T, H]`
+    /// hidden states. Used by the iterator's prefill path.
+    func dflashEmbedTokens(_ tokens: MLXArray) -> MLXArray
+
+    /// LM-head projection from `[B, T, H]` hidden states to `[B, T, V]`
+    /// logits. Used by the iterator's verify path to sample target argmax
+    /// at each verify-position.
+    func dflashLmHeadLogits(_ hiddenStates: MLXArray) -> MLXArray
+
+    /// Forward pass over `inputIDs` of shape `[B, T]` with hidden-state
+    /// capture at the configured `captureLayerIDs`. Returns:
+    ///   - `logits`: `[B, T, V]` — the standard forward output.
+    ///   - `captured`: `[Int: MLXArray]` — `layerID -> [B, T, H]` post-block
+    ///     hidden state at each captured layer.
+    ///
+    /// The captured hidden states feed the draft's cross-attention input
+    /// on the next speculative cycle.
+    ///
+    /// Implementations on hybrid GDN/Mamba models must respect any active
+    /// tape-replay-rollback session on `cache` — see spec 020 for the
+    /// recording protocol.
+    func dflashForwardWithCapture(
+        inputIDs: MLXArray,
+        cache: [KVCache],
+        captureLayerIDs: Set<Int>
+    ) -> (logits: MLXArray, captured: [Int: MLXArray])
+
+    /// Whether this target uses GatedDeltaNet / Mamba / SSM layers anywhere
+    /// in its stack. When `true`, the iterator routes through the
+    /// tape-replay-rollback path (spec 020) on partial accept; when
+    /// `false`, plain positional cache trim is sufficient.
+    ///
+    /// Pure-attention targets (Llama, Qwen 3 dense, Gemma 4) return
+    /// `false`. Hybrid targets (Qwen 3.5 / 3.6, Nemotron H, Jamba, etc.)
+    /// return `true`.
+    var dflashIsHybridGDN: Bool { get }
+}
+
+// MARK: - Default selection of capture layers
+
+/// Pick a small spread of target layers for the draft to condition on.
+/// dflash-mlx's reference convention: roughly evenly spaced layers from
+/// just past the embedding to a few layers shy of the LM head.
+///
+/// For a target with `numLayers` total decoder layers and a draft model
+/// trained to consume `numDraftLayers` captures, returns the layer IDs
+/// the target should expose to the draft.
+///
+/// The choice is identical to dflash-mlx's `buildTargetLayerIDs` helper
+/// (cited inline). Single-layer drafts grab the middle of the stack;
+/// multi-layer drafts evenly span layers `[1, numLayers - 3]`.
+public func dflashDefaultCaptureLayerIDs(
+    numTargetLayers: Int,
+    numDraftLayers: Int
+) -> [Int] {
+    if numDraftLayers <= 1 {
+        return [numTargetLayers / 2]
+    }
+    let start = 1
+    let end = numTargetLayers - 3
+    let span = max(1, end - start)
+    return (0 ..< numDraftLayers).map { i in
+        Int((Double(start) + Double(i) * Double(span) / Double(numDraftLayers - 1))
+            .rounded())
+    }
+}

--- a/Libraries/MLXLMCommon/MirrorSpeculativeDecoding.swift
+++ b/Libraries/MLXLMCommon/MirrorSpeculativeDecoding.swift
@@ -1,0 +1,317 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+// MARK: - Mirror Speculative Decoding iterator (spec 021 phase 1A scaffold)
+//
+// Mirror SD pairs a small ANE draft (Core ML) with a GPU target (MLX).
+// The two compute units are physically independent so the cycles can run
+// in parallel: ANE drafts K tokens while the GPU verifies the previous
+// K-block. The structural difference vs. the existing
+// ``SpeculativeTokenIterator`` (which uses an MLX draft):
+//
+//   1. The draft lives behind ``ANEDraftBackend`` — a protocol that
+//      doesn't depend on MLX at all. The iterator never holds draft KV
+//      state; the backend manages it.
+//   2. The verify path is identical to the DFlash and SpeculativeToken
+//      iterators — single-pass [y, draft_1...draft_K] forward, argmax
+//      compare, accept-prefix walk, cache trim.
+//
+// **Phase 1A status:** this iterator runs the draft + verify *sequentially*
+// — submit draft, wait, run verify, repeat. The "true" Mirror SD path
+// (overlap draft and verify across the cycle) is Phase 2 and requires
+// the actual Core ML backend + IPC primitives. Sequential is correct,
+// just not throughput-optimal.
+
+/// Generator of tokens with **Mirror Speculative Decoding** (ANE draft +
+/// GPU target). Currently sequential per cycle; Phase 2 will pipeline
+/// draft and verify across compute units.
+///
+/// Drop-in replacement for ``TokenIterator`` when the caller has an
+/// ANE-eligible target (registered in ``ANEDraftRegistry``) and
+/// `temperature == 0`. Output is byte-identical to greedy
+/// ``TokenIterator`` decode at temperature 0 (the verifier compares
+/// against the target's argmax — same contract as DFlash).
+///
+/// Construction throws if the configured draft vocabulary doesn't agree
+/// with the target's tokenizer up to the
+/// ``aneVocabDefaultMaxSizeDifference`` / ``aneVocabDefaultMaxDisagreements``
+/// gate — Mirror SD relies on token-ID equivalence across frameworks.
+public struct MirrorSpeculativeTokenIterator: TokenIteratorProtocol {
+
+    // MARK: - State
+
+    var y: LMInput.Text
+
+    let target: any LanguageModel
+    var mainState: LMOutput.State?
+    var mainCache: [KVCache]
+    let quantizeKVCache: (inout [KVCache]) -> Void
+
+    var draftBackend: any ANEDraftBackend
+
+    let sampler: LogitSampler
+    var tokenCount = 0
+    let maxTokens: Int?
+
+    /// Full prefix of accepted tokens (prompt + everything emitted so far).
+    /// Mirror SD's draft backend wants the full committed sequence to
+    /// resync after partial-accept, since the ANE backend's KV state may
+    /// not be trim-able the same way the MLX target's is. Keeping it on
+    /// the iterator side lets the backend stay stateless across rejections
+    /// if it wants to.
+    private var committedTokens: [Int] = []
+
+    private var pendingTokens = [Int]()
+    private var pendingIndex = 0
+
+    // MARK: - Metrics
+
+    public private(set) var promptPrefillTime: TimeInterval = 0.0
+
+    public private(set) var mirrorAcceptedCount = 0
+    public private(set) var mirrorProposedCount = 0
+    public private(set) var mirrorCycleCount = 0
+
+    public var mirrorAcceptanceRate: Double {
+        guard mirrorProposedCount > 0 else { return 0 }
+        return Double(mirrorAcceptedCount) / Double(mirrorProposedCount)
+    }
+
+    public var specDecodeProposed: Int { mirrorProposedCount }
+    public var specDecodeAccepted: Int { mirrorAcceptedCount }
+
+    public var kvCacheMemoryBytes: Int? {
+        let main = mainCache.isEmpty ? 0 : mainCache.reduce(0) { $0 + $1.memoryBytes }
+        let draft = draftBackend.draftCacheMemoryBytes ?? 0
+        return main + draft
+    }
+
+    private static var debugTracing: Bool {
+        ProcessInfo.processInfo.environment["MLX_MIRROR_DEBUG"] == "1"
+    }
+
+    // MARK: - Init
+
+    /// Initialize a `MirrorSpeculativeTokenIterator` over a target + ANE
+    /// draft backend pairing.
+    ///
+    /// - Parameter input: language model input.
+    /// - Parameter target: the GPU target (MLX language model).
+    /// - Parameter mainCache: optional pre-allocated target KV cache.
+    /// - Parameter draftBackend: the ANE-side draft backend.
+    /// - Parameter parameters: generation parameters. Must specify
+    ///   `temperature == 0` for the greedy verify gate to be sound.
+    /// - Parameter vocabReport: optional pre-computed vocab equivalence
+    ///   report. When non-nil and `isCompatible == false`, init throws.
+    ///   When nil, the gate is skipped — caller takes responsibility.
+    public init(
+        input: LMInput,
+        target: any LanguageModel,
+        mainCache: [KVCache]? = nil,
+        draftBackend: any ANEDraftBackend,
+        parameters: GenerateParameters,
+        vocabReport: ANEVocabEquivalenceReport? = nil
+    ) throws {
+        if let report = vocabReport, !report.isCompatible {
+            throw KVCacheError(
+                message: "Mirror SD vocabulary equivalence gate failed: "
+                    + "size diff = \(report.sizeDifference), "
+                    + "disagreements = \(report.disagreementCount) "
+                    + "(\(String(format: "%.2f%%", report.disagreementRate * 100))). "
+                    + "Mirror SD requires the draft and target tokenizers "
+                    + "to agree token-for-token; pair a different draft.")
+        }
+
+        self.y = input.text
+        self.target = target
+        self.mainCache = mainCache ?? target.newCache(parameters: parameters)
+        guard canTrimPromptCache(self.mainCache) else {
+            throw KVCacheError(
+                message: "Mirror SD requires a trimmable target KV cache. "
+                    + "Hybrid GDN/Mamba targets need the tape-replay path "
+                    + "(spec 020); Mirror SD's correctness is upstream of "
+                    + "that fix.")
+        }
+
+        self.sampler = parameters.sampler()
+        self.maxTokens = parameters.maxTokens
+        self.draftBackend = draftBackend
+
+        self.quantizeKVCache = { cache in
+            maybeQuantizeKVCache(
+                cache: &cache,
+                kvBits: parameters.kvBits,
+                kvGroupSize: parameters.kvGroupSize,
+                quantizedKVStart: parameters.quantizedKVStart
+            )
+        }
+
+        // Seed committedTokens with the prompt — backends that want full
+        // history have it from the start.
+        self.committedTokens = input.text.tokens.asArray(Int.self)
+
+        self.promptPrefillTime = try measure {
+            try prepare(input: input, windowSize: parameters.prefillStepSize)
+        }
+
+        if Self.debugTracing {
+            print("[MIRROR] iterator engaged: K=\(draftBackend.draftLength) "
+                + "prompt=\(input.text.tokens.size)")
+        }
+    }
+
+    /// Prefill the target + prime the pump. Same shape as the n-gram and
+    /// DFlash iterators. The trailing `eval(token)` is the Gemma-4
+    /// async-prefill commit barrier (see comment on
+    /// ``NGramSpeculativeTokenIterator/prepare``).
+    mutating func prepare(input: LMInput, windowSize: Int? = nil) throws {
+        switch try target.prepare(input, cache: mainCache, windowSize: windowSize) {
+        case .tokens(let tokens):
+            let result = target(tokens[text: .newAxis], cache: mainCache, state: nil)
+            quantizeKVCache(&mainCache)
+            let logits = result.logits[0..., -1, 0...]
+            let token = sampler.sample(logits: logits)
+            mainState = result.state
+            eval(token)
+            let tokenInt = token.item(Int.self)
+            y = .init(tokens: token)
+            pendingTokens.append(tokenInt)
+            committedTokens.append(tokenInt)
+        case .logits(let result):
+            let logits = result.logits[0..., -1, 0...]
+            let token = sampler.sample(logits: logits)
+            eval(token)
+            let tokenInt = token.item(Int.self)
+            y = .init(tokens: token)
+            mainState = result.state
+            pendingTokens.append(tokenInt)
+            committedTokens.append(tokenInt)
+        }
+    }
+
+    // MARK: - Cycle
+
+    /// One Mirror SD cycle: ANE draft → GPU verify → accept → trim.
+    mutating func speculateRound() {
+        let remaining = maxTokens.map { $0 - tokenCount } ?? draftBackend.draftLength
+        guard remaining > 0 else { return }
+
+        let lastToken = committedTokens.last ?? 0
+        let draftInts = draftBackend.draftBlock(
+            committedTokens: committedTokens,
+            lastCommittedToken: lastToken)
+
+        // Empty draft → AR fallback (single-step). Same shape as the
+        // DFlash iterator; not pipelined yet.
+        if draftInts.isEmpty {
+            let result = target(y[text: .newAxis], cache: mainCache, state: mainState)
+            quantizeKVCache(&mainCache)
+            let logits = result.logits[0..., -1, 0...]
+            let token = sampler.sample(logits: logits)
+            eval(token)
+            let tokenInt = token.item(Int.self)
+            mainState = result.state
+            pendingTokens.append(tokenInt)
+            committedTokens.append(tokenInt)
+            y = .init(tokens: token)
+            mirrorCycleCount += 1
+            if Self.debugTracing {
+                print("[MIRROR] cycle=\(mirrorCycleCount) draft=0 ar=\(tokenInt)")
+            }
+            return
+        }
+
+        // Clamp to (remaining - 1) so we always leave a slot for the
+        // bonus token. Same logic as the DFlash iterator.
+        let budget = Swift.max(0, remaining - 1)
+        let clampedDraft = budget < draftInts.count
+            ? Array(draftInts.prefix(budget))
+            : draftInts
+        let numDraft = clampedDraft.count
+
+        if numDraft == 0 {
+            let result = target(y[text: .newAxis], cache: mainCache, state: mainState)
+            quantizeKVCache(&mainCache)
+            let logits = result.logits[0..., -1, 0...]
+            let token = sampler.sample(logits: logits)
+            eval(token)
+            let tokenInt = token.item(Int.self)
+            mainState = result.state
+            pendingTokens.append(tokenInt)
+            committedTokens.append(tokenInt)
+            y = .init(tokens: token)
+            mirrorCycleCount += 1
+            return
+        }
+
+        let draftArray = MLXArray(clampedDraft.map { Int32($0) })
+        let verifyTokens = concatenated([y.tokens, draftArray])
+        let verifyInput = LMInput.Text(tokens: verifyTokens)
+        let verifyStart = verifyInput.tokens.dim(0) - (numDraft + 1)
+        let mainResult = target(verifyInput[text: .newAxis], cache: mainCache, state: mainState)
+        let mainLogits = mainResult.logits
+        mainState = mainResult.state
+
+        let verifyLogits = mainLogits[0..., verifyStart..., 0...].squeezed(axis: 0)
+        let mainTokens = sampler.sample(logits: verifyLogits)
+        eval(mainTokens)
+        let mainTokensList = mainTokens.asArray(Int.self)
+
+        // Reuse the DFlash accept-prefix helper — same pure-Swift logic;
+        // no need for two copies. The contract is identical: longest
+        // matching prefix between draft and target argmax.
+        let accepted = dflashAcceptedPrefixLength(
+            draft: clampedDraft,
+            targetArgmax: mainTokensList)
+
+        for i in 0 ..< accepted {
+            pendingTokens.append(mainTokensList[i])
+            committedTokens.append(mainTokensList[i])
+        }
+        let bonus = mainTokensList[accepted]
+        pendingTokens.append(bonus)
+        committedTokens.append(bonus)
+
+        // Cache trim for rejected tokens.
+        let rejected = numDraft - accepted
+        if rejected > 0 {
+            trimPromptCache(mainCache, numTokens: rejected)
+        }
+        quantizeKVCache(&mainCache)
+
+        mirrorAcceptedCount += accepted
+        mirrorProposedCount += numDraft
+        mirrorCycleCount += 1
+
+        y = .init(tokens: mainTokens[accepted ... accepted])
+
+        if Self.debugTracing {
+            print("[MIRROR] cycle=\(mirrorCycleCount) draft=\(numDraft) "
+                + "accepted=\(accepted) rejected=\(rejected) bonus=\(bonus)")
+        }
+    }
+
+    // MARK: - IteratorProtocol
+
+    public mutating func next() -> Int? {
+        if let maxTokens, tokenCount >= maxTokens {
+            return nil
+        }
+        if pendingIndex < pendingTokens.count {
+            let t = pendingTokens[pendingIndex]
+            pendingIndex += 1
+            tokenCount += 1
+            return t
+        }
+        pendingTokens.removeAll(keepingCapacity: true)
+        pendingIndex = 0
+        speculateRound()
+        guard !pendingTokens.isEmpty else { return nil }
+        let t = pendingTokens[pendingIndex]
+        pendingIndex += 1
+        tokenCount += 1
+        return t
+    }
+}

--- a/Libraries/MLXLMCommon/PrefixKVCache.swift
+++ b/Libraries/MLXLMCommon/PrefixKVCache.swift
@@ -1,0 +1,332 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+// MARK: - Cross-request prefix KV cache (spec 017 phase 1 — in-memory only)
+//
+// Multi-turn chat and agentic workloads send a prompt whose **prefix is
+// identical** to the previous turn's prompt. Today every turn re-runs
+// prefill over that prefix; the prefix cache snapshots the target's KV
+// state at a stable prefix boundary so the next turn can hydrate from
+// the snapshot and prefill only the suffix.
+//
+// **Phase 1 scope** (this file): in-memory LRU cache with token-exact
+// prefix matching, byte-budget eviction, and a configurable
+// ``StablePrefixPolicy``. The on-disk persistence layer (phase 4) is
+// deferred. The actual cache-type-specific `serialise` / `hydrate`
+// methods land in phase 1B once we've decided which caches to support
+// first; the snapshot type here uses an opaque `[MLXArray]` payload that
+// hydrate-time code interprets per-layer.
+
+/// Identity key for a prefix snapshot. Snapshots whose `PrefixKey`
+/// doesn't match the current target's are not interchangeable — model
+/// configuration changes (layer count, head dims, KV bit-width) make
+/// snapshot KV state semantically different.
+public struct PrefixKey: Hashable, Sendable {
+    /// Stable model identifier (HuggingFace ID or local model directory
+    /// hash). The cache uses this to refuse cross-model snapshot reuse.
+    public let modelID: String
+
+    /// Total layers in the target stack. Snapshots from a different
+    /// layer count are unusable.
+    public let layerCount: Int
+
+    /// Per-layer KV head dimension. Catches cases where two checkpoints
+    /// share a model ID but were quantised with different head configs.
+    public let kvHeadDim: Int
+
+    /// KV bit-width (`nil` for fp16, otherwise the cache quantization
+    /// bits). Snapshots from quantised vs. unquantised state can't
+    /// hydrate into each other without re-quantisation work that's
+    /// outside this cache's scope.
+    public let kvBits: Int?
+
+    public init(modelID: String, layerCount: Int, kvHeadDim: Int, kvBits: Int? = nil) {
+        precondition(layerCount >= 1, "layerCount must be >= 1 (got \(layerCount))")
+        precondition(kvHeadDim >= 1, "kvHeadDim must be >= 1 (got \(kvHeadDim))")
+        if let bits = kvBits {
+            precondition(bits >= 1 && bits <= 16,
+                "kvBits must be in [1, 16] (got \(bits))")
+        }
+        self.modelID = modelID
+        self.layerCount = layerCount
+        self.kvHeadDim = kvHeadDim
+        self.kvBits = kvBits
+    }
+}
+
+/// Per-layer cache state captured in a snapshot. Phase 1 stores the
+/// layer's `state` array opaquely (the `KVCache.state` accessor); phase
+/// 1B will add typed variants per concrete cache class so hydration can
+/// validate shape + dtype.
+public struct LayerCacheState: @unchecked Sendable {
+    /// Number of tokens this layer's state represents. For trim-able
+    /// caches this is the cache offset; for hybrid caches it's the
+    /// position-stamp at snapshot time.
+    public let tokenCount: Int
+
+    /// Opaque per-layer arrays — typically `[K, V]` for attention layers,
+    /// `[hiddenState, convState]` or similar for SSM layers. The hydrate
+    /// path matches by index, not by shape — caller's responsibility to
+    /// align with the target cache's `state` layout.
+    public let arrays: [MLXArray]
+
+    public init(tokenCount: Int, arrays: [MLXArray]) {
+        precondition(tokenCount >= 0, "tokenCount must be >= 0 (got \(tokenCount))")
+        self.tokenCount = tokenCount
+        self.arrays = arrays
+    }
+
+    /// Sum of all backing arrays' sizes in bytes. The cache uses this for
+    /// LRU-budget accounting; not a contract on hydration cost.
+    public var byteSize: Int {
+        arrays.reduce(0) { $0 + $1.nbytes }
+    }
+}
+
+/// One snapshot in the prefix cache. Captures the target's KV state at
+/// the end of a stable prefix prefill.
+public struct PrefixSnapshot: @unchecked Sendable {
+    public let key: PrefixKey
+    public let tokens: [Int]
+    public let layerStates: [LayerCacheState]
+
+    /// Optional final hidden state — DFlash uses it to warm-start its
+    /// draft; baseline iterators ignore it. Stored as `[1, 1, H]` if
+    /// present.
+    public let lastHidden: MLXArray?
+
+    public let createdAt: Date
+
+    public init(
+        key: PrefixKey,
+        tokens: [Int],
+        layerStates: [LayerCacheState],
+        lastHidden: MLXArray? = nil,
+        createdAt: Date = Date()
+    ) {
+        precondition(layerStates.count == key.layerCount,
+            "layerStates.count (\(layerStates.count)) must equal "
+                + "key.layerCount (\(key.layerCount))")
+        self.key = key
+        self.tokens = tokens
+        self.layerStates = layerStates
+        self.lastHidden = lastHidden
+        self.createdAt = createdAt
+    }
+
+    /// Total bytes held by this snapshot — sum of per-layer byte sizes
+    /// plus optional last-hidden. Drives the LRU budget.
+    public var byteSize: Int {
+        var b = layerStates.reduce(0) { $0 + $1.byteSize }
+        if let lh = lastHidden { b += lh.nbytes }
+        return b
+    }
+}
+
+/// Result of a prefix-cache lookup. `matchedLength == 0` is a miss;
+/// `> 0` is a hit, and the iterator should hydrate from `snapshot` then
+/// prefill only over `tokens[matchedLength...]`.
+public struct PrefixCacheLookupResult: @unchecked Sendable {
+    public let matchedLength: Int
+    public let snapshot: PrefixSnapshot
+
+    public init(matchedLength: Int, snapshot: PrefixSnapshot) {
+        precondition(matchedLength > 0, "lookup result must have matchedLength > 0")
+        self.matchedLength = matchedLength
+        self.snapshot = snapshot
+    }
+}
+
+/// Telemetry for the prefix cache. Bench harness reads this once per
+/// request to surface a `[PREFIX-CACHE]` line.
+public struct PrefixCacheStats: Equatable, Sendable {
+    public var hits: Int
+    public var misses: Int
+    public var partialHits: Int
+    public var insertions: Int
+    public var evictions: Int
+    public var bytesUsed: Int
+    public var entryCount: Int
+
+    /// Sum of matched lengths on hits — used to compute mean matched
+    /// length in benchmark reports.
+    public var totalMatchedTokens: Int
+
+    public init(
+        hits: Int = 0, misses: Int = 0, partialHits: Int = 0,
+        insertions: Int = 0, evictions: Int = 0,
+        bytesUsed: Int = 0, entryCount: Int = 0,
+        totalMatchedTokens: Int = 0
+    ) {
+        self.hits = hits
+        self.misses = misses
+        self.partialHits = partialHits
+        self.insertions = insertions
+        self.evictions = evictions
+        self.bytesUsed = bytesUsed
+        self.entryCount = entryCount
+        self.totalMatchedTokens = totalMatchedTokens
+    }
+
+    public var hitRate: Double {
+        let total = hits + misses
+        guard total > 0 else { return 0 }
+        return Double(hits) / Double(total)
+    }
+
+    public var meanMatchedLength: Double {
+        guard hits > 0 else { return 0 }
+        return Double(totalMatchedTokens) / Double(hits)
+    }
+}
+
+/// In-memory LRU prefix KV cache.
+///
+/// Lookup is **longest token-prefix match**: among snapshots whose
+/// `PrefixKey` matches and whose tokens form a prefix of the request
+/// prompt, return the one with the longest matched length.
+///
+/// Eviction is byte-budgeted LRU: on insert, while
+/// `bytesUsed + newSnap.byteSize > maxBytes`, evict the oldest entry.
+/// `maxEntries` is a secondary cap — useful for tests and for capping
+/// metadata overhead even when individual snapshots are tiny.
+///
+/// Thread safety: phase 1 is **not** thread-safe. Callers wrap accesses
+/// with their own queue / lock when sharing across requests; the
+/// `PrefixKVCache.shared` global instance is intended for single-iterator
+/// use, not concurrent serving. Phase 4 will add an actor wrapper if/when
+/// needed.
+///
+/// `@unchecked Sendable` for the shared global — the contract is documented
+/// above and Phase 4 will add proper actor isolation when concurrent
+/// serving lands.
+public final class PrefixKVCache: @unchecked Sendable {
+
+    /// Process-wide shared cache. Apps that want a single cache across
+    /// all requests use this; tests construct local instances.
+    public static let shared = PrefixKVCache()
+
+    /// Hard byte budget. Default 8 GiB — same as the spec's design
+    /// section.
+    public let maxBytes: Int
+
+    /// Hard entry-count cap. Default 4 — see spec rationale.
+    public let maxEntries: Int
+
+    /// Stable-prefix policy used at insert time to decide where to trim
+    /// the snapshot before storing it. Lookup uses the full cached
+    /// prefix; the trimming happens on the producer side.
+    public let stablePrefixPolicy: StablePrefixPolicy
+
+    /// Insertion-ordered storage. Most-recently-used = last index.
+    /// LRU eviction pops `entries.first`. We use an array because at
+    /// `maxEntries = 4` the linear scan is faster than dictionary
+    /// hashing and gives byte-stable iteration order.
+    private var entries: [PrefixSnapshot] = []
+
+    private(set) public var stats: PrefixCacheStats = PrefixCacheStats()
+
+    public init(
+        maxBytes: Int = 8 * 1024 * 1024 * 1024,
+        maxEntries: Int = 4,
+        stablePrefixPolicy: StablePrefixPolicy = IdentityPolicy()
+    ) {
+        precondition(maxBytes > 0, "maxBytes must be > 0 (got \(maxBytes))")
+        precondition(maxEntries >= 1, "maxEntries must be >= 1 (got \(maxEntries))")
+        self.maxBytes = maxBytes
+        self.maxEntries = maxEntries
+        self.stablePrefixPolicy = stablePrefixPolicy
+    }
+
+    /// Look up the longest-matching snapshot for a request.
+    ///
+    /// - Returns: nil on miss; `(matchedLength, snapshot)` on hit. On
+    ///   hit, the snapshot is moved to most-recently-used in the LRU
+    ///   order. `matchedLength` is the length of the snapshot's full
+    ///   prefix (token-exact match), not a partial match — phase 1 only
+    ///   considers byte-equal prefix matches.
+    public func lookup(prefix tokens: [Int], key: PrefixKey) -> PrefixCacheLookupResult? {
+        var bestIndex: Int? = nil
+        var bestLen = 0
+        for (i, snap) in entries.enumerated() {
+            guard snap.key == key else { continue }
+            guard snap.tokens.count <= tokens.count else { continue }
+            // Token-exact prefix match.
+            let matches = snap.tokens.elementsEqual(tokens.prefix(snap.tokens.count))
+            if matches && snap.tokens.count > bestLen {
+                bestLen = snap.tokens.count
+                bestIndex = i
+            }
+        }
+        guard let idx = bestIndex else {
+            stats.misses += 1
+            return nil
+        }
+        // Partial-hit accounting: the snapshot covered some but not all
+        // of the request — i.e. there's a non-empty suffix to prefill.
+        // Full-hit (matchedLen == request length) is logically a "hit
+        // with nothing left to prefill", which still counts as a hit
+        // here.
+        if bestLen < tokens.count { stats.partialHits += 1 }
+        stats.hits += 1
+        stats.totalMatchedTokens += bestLen
+
+        // LRU bump: move the matched entry to the back of the list.
+        let snap = entries.remove(at: idx)
+        entries.append(snap)
+        return PrefixCacheLookupResult(matchedLength: bestLen, snapshot: snap)
+    }
+
+    /// Insert a snapshot. Evicts oldest entries until budget allows.
+    /// Replaces any existing snapshot whose key + tokens are exactly
+    /// equal — same prefix from the same model is the same snapshot.
+    public func insert(_ snapshot: PrefixSnapshot) {
+        // Replace existing exact-match snapshot in place if present.
+        if let existingIdx = entries.firstIndex(where: {
+            $0.key == snapshot.key && $0.tokens == snapshot.tokens
+        }) {
+            stats.bytesUsed -= entries[existingIdx].byteSize
+            entries.remove(at: existingIdx)
+        }
+
+        // Evict to fit the new snapshot.
+        while !entries.isEmpty
+            && (stats.bytesUsed + snapshot.byteSize > maxBytes
+                || entries.count >= maxEntries) {
+            let evicted = entries.removeFirst()
+            stats.bytesUsed -= evicted.byteSize
+            stats.evictions += 1
+        }
+
+        entries.append(snapshot)
+        stats.bytesUsed += snapshot.byteSize
+        stats.entryCount = entries.count
+        stats.insertions += 1
+    }
+
+    /// Clear all entries. Stats are preserved (callers reset them
+    /// independently).
+    public func clear() {
+        entries.removeAll()
+        stats.bytesUsed = 0
+        stats.entryCount = 0
+    }
+
+    /// Reset statistics counters without clearing entries. Useful at
+    /// bench-run boundaries.
+    public func resetStats() {
+        let bytesUsed = stats.bytesUsed
+        let entryCount = stats.entryCount
+        stats = PrefixCacheStats(bytesUsed: bytesUsed, entryCount: entryCount)
+    }
+
+    /// Number of stored entries.
+    public var count: Int { entries.count }
+
+    /// Snapshot of entry order (oldest → newest), exposed for tests and
+    /// diagnostics. Not for production callers — they should go through
+    /// `lookup` / `insert`.
+    public var entrySnapshot: [PrefixSnapshot] { entries }
+}

--- a/Libraries/MLXLMCommon/StablePrefixPolicy.swift
+++ b/Libraries/MLXLMCommon/StablePrefixPolicy.swift
@@ -1,0 +1,56 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+// MARK: - Stable prefix policy (spec 017)
+//
+// The prefix KV cache (`PrefixKVCache`) stores snapshots of the target's
+// KV state at the *end* of a stable prefix — the largest token prefix
+// that's expected to recur byte-stably across requests. For
+// completion-style workloads that's the entire request prefix; for chat
+// workloads the trailing chat-template boilerplate (e.g.
+// `<|im_start|>assistant\n`) regenerates every turn and must be excluded
+// to maximise hit rate.
+//
+// Phase 1 ships ``IdentityPolicy`` only. ``LastAssistantOpenerPolicy``
+// (chat-aware) lands in phase 2 alongside the per-tokenizer template
+// scanner.
+
+/// A policy that decides where the **stable prefix** of a request ends.
+/// Returns `n` such that `tokens[0..<n]` is the largest prefix expected
+/// to recur unchanged across subsequent requests in the same session.
+public protocol StablePrefixPolicy: Sendable {
+    /// - Parameter tokens: the request's prompt tokens.
+    /// - Returns: number of leading tokens that form the stable prefix
+    ///   (`0` if no prefix is stable, `tokens.count` if the entire prompt
+    ///   is stable).
+    func stablePrefixLen(_ tokens: [Int]) -> Int
+}
+
+/// Trivial policy: the entire prompt is treated as stable. Right answer
+/// for completion-style workloads where the prompt is request-final
+/// (no trailing chat-template boilerplate).
+public struct IdentityPolicy: StablePrefixPolicy {
+    public init() {}
+    public func stablePrefixLen(_ tokens: [Int]) -> Int { tokens.count }
+}
+
+/// Trim a fixed number of trailing tokens from the prompt. Useful as a
+/// crude phase-1 alternative for chat workloads where the trailing
+/// chat-template suffix length is known to be constant (e.g. exactly N
+/// tokens for `<|im_start|>assistant\n`). Phase 2's
+/// `LastAssistantOpenerPolicy` will scan for the boundary tokens directly
+/// instead, but this gives bench harnesses a way to reach for a chat-
+/// style cache hit without waiting on phase 2.
+public struct FixedTrimPolicy: StablePrefixPolicy {
+    public let trimSuffix: Int
+
+    public init(trimSuffix: Int) {
+        precondition(trimSuffix >= 0, "trimSuffix must be >= 0 (got \(trimSuffix))")
+        self.trimSuffix = trimSuffix
+    }
+
+    public func stablePrefixLen(_ tokens: [Int]) -> Int {
+        Swift.max(0, tokens.count - trimSuffix)
+    }
+}

--- a/Libraries/MLXLMCommon/TapeReplayCache.swift
+++ b/Libraries/MLXLMCommon/TapeReplayCache.swift
@@ -1,0 +1,200 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+// MARK: - Tape-replay rollback (spec 020 phase 1 — protocol + no-op defaults)
+//
+// Today's `NGramSpeculativeTokenIterator` and the new
+// `DFlashSpeculativeTokenIterator` both refuse to run on hybrid models
+// (Qwen 3.5 / 3.6 GatedDeltaNet, Nemotron-H, Jamba, …) because their
+// Mamba / SSM layers don't have positional cache state — there's nothing
+// to "trim" by N positions on rejection. dflash-mlx solves this with
+// **innovation-tape rollback**: during the verify forward, record the
+// per-step recurrent updates; on partial accept, replay only the
+// accepted prefix's updates onto a snapshot taken at round entry.
+//
+// **Phase 1 scope** (this file): land the protocol + a no-op default
+// conformance for the caches that already trim cleanly. The iterator's
+// rollback path becomes mode-aware via `canRollbackPromptCache(_:)` and
+// `rollbackPromptCache(_:acceptedPrefix:numDraft:)`. Concrete `MambaCache`
+// conformance + the Metal replay kernel land in phase 2.
+//
+// Why ship phase 1 standalone: the predicate change unblocks call sites
+// to start preparing for tape-replay (e.g. `MLXLMCommon.generate(...)`'s
+// auto-routing can stop discriminating against hybrid caches at the
+// surface) without risk to the existing trim path. Phase 2 is then a
+// drop-in: `MambaCache` conforms, the iterators flip a flag, and the
+// gate auto-engages.
+
+/// Cost class for the rollback operation. Used by the iterator's draft
+/// budget heuristic — at very high blockSize × layer-count, a `reforward`
+/// is sometimes cheaper than recording deltas every cycle.
+public enum TapeReplayCost: Equatable, Sendable {
+    /// Constant-time rollback (linear SSMs / pure-attention trim). Cheap.
+    case o1
+    /// Linear in accepted-prefix length (Mamba gated delta). Mid-cost.
+    case ok
+    /// Falls back to re-running the layer from snapshot. Slow.
+    case reforward
+}
+
+/// Cache that supports innovation-tape rollback in addition to (or
+/// instead of) positional trim.
+///
+/// The recording session lifecycle is:
+///   `beginRecord()` → zero or more `appendInnovation(...)` calls →
+///   exactly one of `commitFull()`, `rollback(acceptedPrefix:)`, or
+///   `cancel()`. Calling those terminators outside an active session is
+///   a programmer error (precondition).
+///
+/// `update(...)` becomes mode-aware on conforming caches: outside a
+/// recording session it behaves as today; inside one, the layer's update
+/// implementation is responsible for also calling `appendInnovation(...)`
+/// with the per-step delta (or a logical equivalent — for SSMs this is
+/// the `B_t * x_t` term; for trim-only caches the implementation can
+/// pass an empty placeholder since `rollback` will translate to `trim`).
+public protocol TapeReplayCache: KVCache {
+    /// Whether this cache currently supports tape replay. False on
+    /// caches that only conform via the no-op default — those still
+    /// route through `rollbackPromptCache` correctly because the helper
+    /// falls back to `trim` for them, but the iterator can branch on
+    /// this flag to skip recording overhead entirely.
+    var canTapeReplay: Bool { get }
+
+    /// Cost class — drives the iterator's choice between recording every
+    /// cycle vs. snapshotting + reforward.
+    var replayCost: TapeReplayCost { get }
+
+    /// Begin recording an innovation tape. Caller commits to one of
+    /// `commitFull()`, `rollback(acceptedPrefix:)`, or `cancel()` before
+    /// starting a new round.
+    func beginRecord()
+
+    /// Append the next innovation. Called from inside the layer's
+    /// `update(...)` during a recording session. The implementation
+    /// stores the delta for later replay; the no-op default on
+    /// trimmable caches discards it (correct behaviour — those caches
+    /// don't *need* the delta, they trim positionally on rollback).
+    func appendInnovation(_ delta: MLXArray)
+
+    /// Accept all tape entries: cache state advances to end-of-tape.
+    /// Tape buffer is cleared; cache is now in steady state.
+    func commitFull()
+
+    /// Accept only the first `k` tape entries. Tape entries `k..<count`
+    /// are discarded. For positional-trim caches this is equivalent to
+    /// `trim(count - k)`; for SSM caches this folds the deltas through
+    /// the recurrence.
+    func rollback(acceptedPrefix k: Int)
+
+    /// Reject all tape entries: cache state restored to the pre-record
+    /// snapshot. Equivalent to `rollback(acceptedPrefix: 0)` semantically
+    /// but typically cheaper to dispatch — implementations may special-
+    /// case the all-rejected path.
+    func cancel()
+}
+
+// MARK: - Default no-op conformance via free helpers
+//
+// We don't want to retroactively mark every existing cache as
+// `TapeReplayCache` — that's a breaking ABI change for downstream
+// adopters. Instead, the rollback helpers below check for protocol
+// conformance and fall back to `trim` semantics on caches that don't
+// conform. This means every existing trimmable cache (KVCacheSimple,
+// QuantizedKVCache, RotatingKVCache, etc.) just works with the new
+// rollback API; only the hybrid caches need to opt in for phase 2.
+
+/// Whether the cache array supports rollback on partial accept — either
+/// every layer is positionally trimmable, or every non-trimmable layer
+/// is a `TapeReplayCache`.
+///
+/// Mirrors `canTrimPromptCache` in shape but accepts the broader set of
+/// caches that can be rolled back via tape replay. Used by the
+/// speculative iterators to gate construction; their existing
+/// `canTrimPromptCache` checks become this for hybrid-model support.
+public func canRollbackPromptCache(_ cache: [KVCache]) -> Bool {
+    cache.allSatisfy { layer in
+        layer.isTrimmable || (layer as? TapeReplayCache)?.canTapeReplay == true
+    }
+}
+
+/// Begin a recording session on every layer that supports tape replay.
+/// Layers that don't support it (positional-trim caches, or `TapeReplayCache`s
+/// reporting `canTapeReplay == false`) are skipped — the helper is
+/// idempotent there.
+public func beginCacheRecord(_ cache: [KVCache]) {
+    for layer in cache {
+        if let tape = layer as? TapeReplayCache, tape.canTapeReplay {
+            tape.beginRecord()
+        }
+    }
+}
+
+/// Commit the recording session on every layer (full-accept path).
+/// Layers without an active session are skipped.
+public func commitCacheRecord(_ cache: [KVCache]) {
+    for layer in cache {
+        if let tape = layer as? TapeReplayCache, tape.canTapeReplay {
+            tape.commitFull()
+        }
+    }
+}
+
+/// Roll back the cache by accepting only the first `acceptedPrefix`
+/// drafts of a `numDraft`-token verify round. Layers that support tape
+/// replay use it; trimmable layers fall back to `trim(numDraft -
+/// acceptedPrefix)`. Mixed-cache stacks (some trimmable, some tape-
+/// replay) are supported transparently.
+///
+/// - Parameter cache: per-layer cache stack.
+/// - Parameter acceptedPrefix: count of accepted draft tokens (0 ≤
+///   acceptedPrefix ≤ numDraft).
+/// - Parameter numDraft: total drafts in the just-completed verify round.
+/// - Returns: number of tokens trimmed by the *first* trimmable layer
+///   (mirrors `trimPromptCache`'s return shape — pure information for
+///   diagnostics, not a contract).
+@discardableResult
+public func rollbackPromptCache(
+    _ cache: [KVCache],
+    acceptedPrefix: Int,
+    numDraft: Int
+) -> Int {
+    precondition(
+        acceptedPrefix >= 0 && acceptedPrefix <= numDraft,
+        "acceptedPrefix (\(acceptedPrefix)) must be in [0, numDraft=\(numDraft)]")
+    let rejected = numDraft - acceptedPrefix
+    var firstReturn: Int?
+    for layer in cache {
+        if let tape = layer as? TapeReplayCache, tape.canTapeReplay {
+            // Tape-replay layer: full accept skips work; partial calls
+            // through to the kernel; zero accept goes through cancel.
+            if rejected == 0 {
+                tape.commitFull()
+            } else if acceptedPrefix == 0 {
+                tape.cancel()
+            } else {
+                tape.rollback(acceptedPrefix: acceptedPrefix)
+            }
+            // Tape-replay caches don't have a meaningful "tokens
+            // trimmed" return; report 0 unless the layer is also
+            // trimmable.
+            if firstReturn == nil { firstReturn = 0 }
+        } else if layer.isTrimmable {
+            let trimmed = layer.trim(rejected)
+            if firstReturn == nil { firstReturn = trimmed }
+        }
+    }
+    return firstReturn ?? 0
+}
+
+/// Cancel the recording session on every layer that supports tape
+/// replay. Used by the iterator on rounds it abandons (e.g. `maxTokens`
+/// reached mid-record). Trimmable-only caches are no-op.
+public func cancelCacheRecord(_ cache: [KVCache]) {
+    for layer in cache {
+        if let tape = layer as? TapeReplayCache, tape.canTapeReplay {
+            tape.cancel()
+        }
+    }
+}

--- a/Tests/MLXLMTests/DFlashSpeculativeTests.swift
+++ b/Tests/MLXLMTests/DFlashSpeculativeTests.swift
@@ -304,10 +304,13 @@ struct DFlashSpeculativeIteratorTests {
         let countAfter = mockTarget.captureCallCount
         // At least one cycle must have invoked the capture forward.
         #expect(countAfter > countBefore)
-        // Cycle bookkeeping must agree with capture invocations (stub
-        // backend always returns a non-empty draft, so every cycle calls
-        // through dflashForwardWithCapture).
-        #expect(iter.dflashCycleCount == countAfter - countBefore)
+        // Capture-call count is bounded above by cycle count: every
+        // verify-path cycle calls `dflashForwardWithCapture` exactly once,
+        // but the iterator can also take the empty-draft AR fallback near
+        // `maxTokens` (when `remaining - 1 == 0`), which bumps
+        // `dflashCycleCount` but skips capture. So the inequality is
+        // capture-calls ≤ cycles.
+        #expect(countAfter - countBefore <= iter.dflashCycleCount)
     }
 
     @Test

--- a/Tests/MLXLMTests/DFlashSpeculativeTests.swift
+++ b/Tests/MLXLMTests/DFlashSpeculativeTests.swift
@@ -1,0 +1,438 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLLM
+@testable import MLXLMCommon
+import MLXNN
+import Testing
+
+// MARK: - DFlash speculative decoding tests (Phase 1 — full-attention only)
+//
+// Coverage layers:
+//
+// 1. Pure-Swift helper tests — no MLX evaluation. Cover the accept-prefix
+//    walk, default capture-layer-IDs picker, and the two stub draft
+//    backends. These run in milliseconds and don't depend on a model.
+//
+// 2. Integration tests with `Gemma3TextModel` wrapped in `MockDFlashTarget`
+//    (defined below) so the iterator gets a real forward pass + KV cache
+//    behavior. Same in-test random-weight model the n-gram tests use, so
+//    output is deterministic but argmax sequences are nonsense — that's
+//    fine; these tests check **plumbing**, not generation quality.
+//
+// Phase 2 will add tests against trained weights to validate accept rate;
+// Phase 3 will add hybrid GDN coverage. Both deferred.
+
+// MARK: - Pure-Swift helper tests
+
+@Suite
+struct DFlashHelperTests {
+
+    @Test
+    func `dflashAcceptedPrefixLength: empty draft returns 0`() {
+        #expect(dflashAcceptedPrefixLength(draft: [], targetArgmax: [42]) == 0)
+    }
+
+    @Test
+    func `dflashAcceptedPrefixLength: full match returns draft count`() {
+        let draft = [1, 2, 3, 4]
+        let targetArgmax = [1, 2, 3, 4, 99]  // bonus position past the draft
+        #expect(dflashAcceptedPrefixLength(draft: draft, targetArgmax: targetArgmax) == 4)
+    }
+
+    @Test
+    func `dflashAcceptedPrefixLength: first mismatch returns 0`() {
+        let draft = [7, 2, 3, 4]
+        let targetArgmax = [1, 2, 3, 4, 99]
+        #expect(dflashAcceptedPrefixLength(draft: draft, targetArgmax: targetArgmax) == 0)
+    }
+
+    @Test
+    func `dflashAcceptedPrefixLength: middle mismatch stops there`() {
+        let draft = [1, 2, 99, 4]
+        let targetArgmax = [1, 2, 3, 4, 5]
+        #expect(dflashAcceptedPrefixLength(draft: draft, targetArgmax: targetArgmax) == 2)
+    }
+
+    @Test
+    func `dflashAcceptedPrefixLength: tail mismatch returns count - 1`() {
+        let draft = [1, 2, 3, 99]
+        let targetArgmax = [1, 2, 3, 4, 5]
+        #expect(dflashAcceptedPrefixLength(draft: draft, targetArgmax: targetArgmax) == 3)
+    }
+
+    @Test
+    func `dflashDefaultCaptureLayerIDs: single-layer draft picks middle`() {
+        let ids = dflashDefaultCaptureLayerIDs(numTargetLayers: 32, numDraftLayers: 1)
+        #expect(ids == [16])
+    }
+
+    @Test
+    func `dflashDefaultCaptureLayerIDs: two-layer draft spans the stack`() {
+        let ids = dflashDefaultCaptureLayerIDs(numTargetLayers: 32, numDraftLayers: 2)
+        // start=1, end=29 → [1, 29]
+        #expect(ids.count == 2)
+        #expect(ids.first == 1)
+        #expect(ids.last == 29)
+    }
+
+    @Test
+    func `dflashDefaultCaptureLayerIDs: four-layer draft is monotonic`() {
+        let ids = dflashDefaultCaptureLayerIDs(numTargetLayers: 32, numDraftLayers: 4)
+        #expect(ids.count == 4)
+        // Strictly nondecreasing — sanity.
+        for i in 1 ..< ids.count {
+            #expect(ids[i] >= ids[i - 1])
+        }
+        // Stays within the [1, numTargetLayers - 3] band.
+        #expect(ids.first! >= 1)
+        #expect(ids.last! <= 32 - 3)
+    }
+
+    @Test
+    func `dflashDefaultCaptureLayerIDs: tiny target degrades gracefully`() {
+        // 4-layer target, 1-layer draft — should still pick something
+        // sensible (the middle: 4/2 = 2).
+        let ids = dflashDefaultCaptureLayerIDs(numTargetLayers: 4, numDraftLayers: 1)
+        #expect(ids == [2])
+    }
+}
+
+// MARK: - Stub draft backend tests
+
+@Suite
+struct DFlashDraftBackendTests {
+
+    @Test
+    func `ZeroAcceptDraftBackend: emits blockSize copies of stub token`() {
+        var backend = ZeroAcceptDraftBackend(blockSize: 4, captureLayerIDs: [3, 7], stubToken: 99)
+        let block = backend.draftBlock(targetHidden: [:], lastCommittedToken: 1)
+        #expect(block == [99, 99, 99, 99])
+        #expect(backend.captureLayerIDs == [3, 7])
+        #expect(backend.blockSize == 4)
+    }
+
+    @Test
+    func `ZeroAcceptDraftBackend: reset is a no-op (idempotent calls)`() {
+        var backend = ZeroAcceptDraftBackend(blockSize: 2)
+        backend.reset()
+        backend.reset()
+        let block = backend.draftBlock(targetHidden: [:], lastCommittedToken: 5)
+        #expect(block == [0, 0])
+    }
+
+    @Test
+    func `ScriptedDraftBackend: replays in order, then returns empty`() {
+        var backend = ScriptedDraftBackend(
+            blockSize: 4,
+            script: [[1, 2, 3, 4], [5, 6, 7, 8]])
+        #expect(backend.callCount == 0)
+        let b1 = backend.draftBlock(targetHidden: [:], lastCommittedToken: 0)
+        #expect(b1 == [1, 2, 3, 4])
+        #expect(backend.callCount == 1)
+        let b2 = backend.draftBlock(targetHidden: [:], lastCommittedToken: 0)
+        #expect(b2 == [5, 6, 7, 8])
+        let b3 = backend.draftBlock(targetHidden: [:], lastCommittedToken: 0)
+        #expect(b3 == [])
+        // callCount tracks served (non-empty) calls — the empty fallback
+        // doesn't bump the cursor (the early `return []` short-circuits
+        // ahead of the `defer cursor += 1`).
+        #expect(backend.callCount == 2)
+    }
+
+    @Test
+    func `ScriptedDraftBackend: reset rewinds the script cursor`() {
+        var backend = ScriptedDraftBackend(blockSize: 2, script: [[1, 2], [3, 4]])
+        _ = backend.draftBlock(targetHidden: [:], lastCommittedToken: 0)
+        _ = backend.draftBlock(targetHidden: [:], lastCommittedToken: 0)
+        #expect(backend.callCount == 2)
+        backend.reset()
+        #expect(backend.callCount == 0)
+        let b = backend.draftBlock(targetHidden: [:], lastCommittedToken: 0)
+        #expect(b == [1, 2])
+    }
+}
+
+// MARK: - Mock DFlashTargetModel for integration tests
+//
+// `Gemma3TextModel` doesn't conform to `DFlashTargetModel` upstream — that
+// conformance lands per-target in Phase 2 (spec 015 §"Files touched").
+// For phase-1 plumbing tests we wrap it in a `MockDFlashTarget` reference
+// type that delegates `LanguageModel` calls through and provides a stub
+// `dflashForwardWithCapture` implementation that returns an empty
+// `captured` dict (the iterator's slicing path handles that gracefully —
+// covered by the empty-captured branch in `speculateRound`).
+//
+// Once Phase 2 lands the real per-target conformances, these tests get
+// promoted to use those directly and the mock is retired.
+
+final class MockDFlashTarget: Module, LanguageModel, DFlashTargetModel {
+    let inner: Gemma3TextModel
+    var dflashIsHybridGDN: Bool { false }
+
+    /// Records every call to `dflashForwardWithCapture` — tests inspect
+    /// this to confirm the iterator routed verify forwards through the
+    /// capture method (not just the plain `callAsFunction`).
+    var captureCallCount = 0
+
+    init(_ inner: Gemma3TextModel) {
+        self.inner = inner
+        super.init()
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        inner(inputs, cache: cache)
+    }
+
+    func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        inner.newCache(parameters: parameters)
+    }
+
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        try inner.prepare(input, cache: cache, windowSize: windowSize)
+    }
+
+    func dflashEmbedTokens(_ tokens: MLXArray) -> MLXArray {
+        // Phase-1 plumbing tests don't exercise this path; the iterator
+        // doesn't call it. Real per-target conformances (Phase 2) tap
+        // into the model's `embed_tokens` directly.
+        fatalError("dflashEmbedTokens not exercised by phase-1 mock")
+    }
+
+    func dflashLmHeadLogits(_ hiddenStates: MLXArray) -> MLXArray {
+        // Same as above — phase-1 iterator goes through the verify
+        // forward, not through a stand-alone LM-head application.
+        fatalError("dflashLmHeadLogits not exercised by phase-1 mock")
+    }
+
+    func dflashForwardWithCapture(
+        inputIDs: MLXArray,
+        cache: [KVCache],
+        captureLayerIDs: Set<Int>
+    ) -> (logits: MLXArray, captured: [Int: MLXArray]) {
+        captureCallCount += 1
+        let logits = inner(inputIDs, cache: cache)
+        // Phase-1 mock: don't actually capture intermediate hidden states.
+        // The iterator handles the empty-dict case (covered by tests).
+        // Real per-target conformances (phase 2) tap into the Gemma3Model's
+        // per-layer activations and return them keyed by layerID.
+        return (logits, [:])
+    }
+}
+
+// MARK: - Iterator integration tests
+
+@Suite(.serialized)
+struct DFlashSpeculativeIteratorTests {
+
+    let processor: any UserInputProcessor
+    let context: ModelContext
+    let mockTarget: MockDFlashTarget
+
+    init() {
+        let processor = TestInputProcessor()
+        let modelConfig = Gemma3TextConfiguration(
+            modelType: "text",
+            hiddenSize: 64, hiddenLayers: 8, intermediateSize: 64,
+            attentionHeads: 4, headDim: 64,
+            rmsNormEps: 0.00001, vocabularySize: 100, kvHeads: 4,
+            ropeTheta: 1_000_000, ropeLocalBaseFreq: 10_000,
+            ropeTraditional: false, queryPreAttnScalar: 256,
+            slidingWindow: 512, slidingWindowPattern: 6,
+            maxPositionEmbeddings: 32768
+        )
+        let inner = Gemma3TextModel(modelConfig)
+        eval(inner)
+        let mock = MockDFlashTarget(inner)
+        eval(mock)
+        self.processor = processor
+        self.mockTarget = mock
+        self.context = ModelContext(
+            configuration: processor.configuration,
+            model: mock,
+            processor: processor,
+            tokenizer: processor.tokenizer
+        )
+    }
+
+    @Test
+    func `Iterator emits exactly maxTokens tokens`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hello world"))
+        let backend = ZeroAcceptDraftBackend(blockSize: 4)
+        let params = GenerateParameters(maxTokens: 12, temperature: 0.0)
+        var iter = try DFlashSpeculativeTokenIterator(
+            input: input,
+            target: mockTarget,
+            draftBackend: backend,
+            parameters: params)
+        var tokens: [Int] = []
+        while let t = iter.next() { tokens.append(t) }
+        #expect(tokens.count == 12)
+    }
+
+    @Test
+    func `ZeroAccept backend never accepts a draft token`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hello world"))
+        // stubToken=12345 is way out of vocab — guaranteed mismatch with any argmax.
+        let backend = ZeroAcceptDraftBackend(blockSize: 4, stubToken: 12345)
+        let params = GenerateParameters(maxTokens: 16, temperature: 0.0)
+        var iter = try DFlashSpeculativeTokenIterator(
+            input: input,
+            target: mockTarget,
+            draftBackend: backend,
+            parameters: params)
+        while iter.next() != nil {}
+        // Bonus token always emits, but nothing from the draft itself.
+        #expect(iter.dflashAcceptedCount == 0)
+        #expect(iter.dflashProposedCount > 0)
+        #expect(iter.dflashAcceptanceRate == 0)
+    }
+
+    @Test
+    func `Iterator routes verify forwards through dflashForwardWithCapture`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hello world"))
+        let backend = ZeroAcceptDraftBackend(blockSize: 4)
+        let params = GenerateParameters(maxTokens: 8, temperature: 0.0)
+        var iter = try DFlashSpeculativeTokenIterator(
+            input: input,
+            target: mockTarget,
+            draftBackend: backend,
+            parameters: params)
+        let countBefore = mockTarget.captureCallCount
+        while iter.next() != nil {}
+        let countAfter = mockTarget.captureCallCount
+        // At least one cycle must have invoked the capture forward.
+        #expect(countAfter > countBefore)
+        // Cycle bookkeeping must agree with capture invocations (stub
+        // backend always returns a non-empty draft, so every cycle calls
+        // through dflashForwardWithCapture).
+        #expect(iter.dflashCycleCount == countAfter - countBefore)
+    }
+
+    @Test
+    func `Output matches TokenIterator under greedy (count)`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hello world"))
+        let params = GenerateParameters(maxTokens: 12, temperature: 0.0)
+
+        var ref = try TokenIterator(
+            input: input, model: mockTarget, parameters: params)
+        var refTokens: [Int] = []
+        while let t = ref.next() { refTokens.append(t) }
+
+        // Re-init mock target to clear captureCallCount drift between runs.
+        let backend = ZeroAcceptDraftBackend(blockSize: 4)
+        var spec = try DFlashSpeculativeTokenIterator(
+            input: input,
+            target: mockTarget,
+            draftBackend: backend,
+            parameters: params)
+        var specTokens: [Int] = []
+        while let t = spec.next() { specTokens.append(t) }
+
+        // Count parity is the stable contract on tiny random-weight models —
+        // batched-vs-sequential argmax can flip on ties. Stricter sequence
+        // equality is the *intended* contract once a real model is wired in.
+        #expect(specTokens.count == refTokens.count)
+    }
+
+    @Test
+    func `ScriptedDraftBackend running out of script falls back to AR`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hello world"))
+        // Script length 2 only — the iterator must keep emitting via AR
+        // fallback after the script empties.
+        let backend = ScriptedDraftBackend(
+            blockSize: 4,
+            script: [[10, 20, 30, 40], [50, 60, 70, 80]])
+        let params = GenerateParameters(maxTokens: 16, temperature: 0.0)
+        var iter = try DFlashSpeculativeTokenIterator(
+            input: input,
+            target: mockTarget,
+            draftBackend: backend,
+            parameters: params)
+        var tokens: [Int] = []
+        while let t = iter.next() { tokens.append(t) }
+        #expect(tokens.count == 16)
+    }
+
+    @Test
+    func `Hybrid GDN target rejected at construction`() async throws {
+        // Same Gemma3TextModel config but hand-rolled mock that lies about
+        // its hybrid status, exercising the init-time guard.
+        let modelConfig = Gemma3TextConfiguration(
+            modelType: "text",
+            hiddenSize: 64, hiddenLayers: 8, intermediateSize: 64,
+            attentionHeads: 4, headDim: 64,
+            rmsNormEps: 0.00001, vocabularySize: 100, kvHeads: 4,
+            ropeTheta: 1_000_000, ropeLocalBaseFreq: 10_000,
+            ropeTraditional: false, queryPreAttnScalar: 256,
+            slidingWindow: 512, slidingWindowPattern: 6,
+            maxPositionEmbeddings: 32768
+        )
+        let inner = Gemma3TextModel(modelConfig)
+        eval(inner)
+        let hybridMock = HybridLyingMockTarget(inner)
+        eval(hybridMock)
+
+        let input = try await processor.prepare(input: UserInput(prompt: "hi"))
+        let backend = ZeroAcceptDraftBackend(blockSize: 4)
+        let params = GenerateParameters(maxTokens: 4, temperature: 0.0)
+
+        do {
+            _ = try DFlashSpeculativeTokenIterator(
+                input: input,
+                target: hybridMock,
+                draftBackend: backend,
+                parameters: params)
+            Issue.record("expected init to throw on hybrid GDN target")
+        } catch let err as KVCacheError {
+            // Look for the hybrid-related sentinel in the error message
+            // so we don't conflate this with the trimmable-cache error.
+            #expect(err.message.contains("Hybrid"))
+        } catch {
+            Issue.record("expected KVCacheError, got \(error)")
+        }
+    }
+}
+
+/// Variant of MockDFlashTarget that reports `dflashIsHybridGDN == true`
+/// to exercise the iterator's init-time hybrid-rejection guard. The cache
+/// is still trimmable (Gemma3 attention) — the test is purely about the
+/// hybrid-flag check, not the cache-trimmability check.
+final class HybridLyingMockTarget: Module, LanguageModel, DFlashTargetModel {
+    let inner: Gemma3TextModel
+    var dflashIsHybridGDN: Bool { true }
+
+    init(_ inner: Gemma3TextModel) {
+        self.inner = inner
+        super.init()
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        inner(inputs, cache: cache)
+    }
+
+    func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        inner.newCache(parameters: parameters)
+    }
+
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        try inner.prepare(input, cache: cache, windowSize: windowSize)
+    }
+
+    func dflashEmbedTokens(_ tokens: MLXArray) -> MLXArray {
+        fatalError("dflashEmbedTokens not exercised by HybridLyingMockTarget")
+    }
+
+    func dflashLmHeadLogits(_ hiddenStates: MLXArray) -> MLXArray {
+        fatalError("dflashLmHeadLogits not exercised by HybridLyingMockTarget")
+    }
+
+    func dflashForwardWithCapture(
+        inputIDs: MLXArray,
+        cache: [KVCache],
+        captureLayerIDs: Set<Int>
+    ) -> (logits: MLXArray, captured: [Int: MLXArray]) {
+        (inner(inputIDs, cache: cache), [:])
+    }
+}

--- a/Tests/MLXLMTests/DeterministicStretchTests.swift
+++ b/Tests/MLXLMTests/DeterministicStretchTests.swift
@@ -1,0 +1,191 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+@testable import MLXLMCommon
+import Testing
+
+// MARK: - Deterministic-stretch acceleration tests (spec 022 phase 1)
+//
+// Pure-Swift; no model evaluation needed. Phase 1 covers:
+//
+//   1. `ChatTemplateGrammar` protocol behaviour:
+//      - `NoOpChatGrammar` always returns nil.
+//      - `TriggerTokenGrammar` fires on the configured trigger only.
+//   2. `BigramTable` semantics:
+//      - lookup hit / miss
+//      - greedy chain walk (`bigramDraft`)
+//      - empty / short recentTokens fall-through
+//      - `build(fromFrequencies:)` admission threshold
+//      - re-insert overwrites
+//   3. `BigramKey` equality + hashable.
+
+// MARK: - Chat template grammar
+
+@Suite
+struct ChatTemplateGrammarTests {
+
+    private static let config = ChatTemplateConfig(
+        turnOpenerToken: 100,
+        turnCloserToken: 101,
+        thinkBeginToken: 200,
+        thinkEndToken: 201,
+        channelMarkerToken: 300,
+        messageMarkerToken: 301,
+        newlineTokens: [10, 13])
+
+    @Test
+    func `NoOpChatGrammar always returns nil`() {
+        let g = NoOpChatGrammar()
+        let state = ChatTemplateState(
+            phase: .assistantTurn,
+            recentTokens: [1, 2, 3],
+            chatTemplateConfig: Self.config)
+        #expect(g.deterministicContinuation(afterToken: 100, state: state) == nil)
+        #expect(g.deterministicContinuation(afterToken: 999, state: state) == nil)
+    }
+
+    @Test
+    func `TriggerTokenGrammar fires only on configured trigger`() {
+        let g = TriggerTokenGrammar(triggerToken: 300, continuation: [50, 51, 52])
+        let state = ChatTemplateState(
+            phase: .channelMarker,
+            recentTokens: [1, 2, 300],
+            chatTemplateConfig: Self.config)
+        #expect(g.deterministicContinuation(afterToken: 300, state: state) == [50, 51, 52])
+        #expect(g.deterministicContinuation(afterToken: 299, state: state) == nil)
+        #expect(g.deterministicContinuation(afterToken: 0, state: state) == nil)
+    }
+
+    @Test
+    func `ChatTemplatePhase equality`() {
+        #expect(ChatTemplatePhase.thinking == .thinking)
+        #expect(ChatTemplatePhase.assistantTurn != .channelMarker)
+    }
+}
+
+// MARK: - Bigram table
+
+@Suite
+struct BigramTableTests {
+
+    @Test
+    func `Empty table returns nil for any lookup`() {
+        let t = BigramTable()
+        #expect(t.confidentNext(prev: 1, current: 2) == nil)
+        #expect(t.entryCount == 0)
+    }
+
+    @Test
+    func `Insert and lookup round-trip`() {
+        var t = BigramTable(admissionThreshold: 0.5)
+        t.insert(prev: 1, current: 2, entry: BigramEntry(nextToken: 3, confidence: 0.99))
+        #expect(t.confidentNext(prev: 1, current: 2)?.nextToken == 3)
+        #expect(t.entryCount == 1)
+    }
+
+    @Test
+    func `Re-insert overwrites existing entry`() {
+        var t = BigramTable(admissionThreshold: 0.5)
+        t.insert(prev: 1, current: 2, entry: BigramEntry(nextToken: 3, confidence: 0.99))
+        t.insert(prev: 1, current: 2, entry: BigramEntry(nextToken: 99, confidence: 0.97))
+        #expect(t.entryCount == 1)
+        #expect(t.confidentNext(prev: 1, current: 2)?.nextToken == 99)
+    }
+
+    @Test
+    func `bigramDraft walks chain greedily up to maxK`() {
+        var t = BigramTable(admissionThreshold: 0.5)
+        // Chain: 1, 2 → 3 → 4 → 5
+        t.insert(prev: 1, current: 2, entry: BigramEntry(nextToken: 3, confidence: 0.99))
+        t.insert(prev: 2, current: 3, entry: BigramEntry(nextToken: 4, confidence: 0.99))
+        t.insert(prev: 3, current: 4, entry: BigramEntry(nextToken: 5, confidence: 0.99))
+
+        let draft = t.bigramDraft(maxK: 5, recentTokens: [99, 1, 2])
+        #expect(draft == [3, 4, 5])
+    }
+
+    @Test
+    func `bigramDraft stops when chain breaks (no confident next)`() {
+        var t = BigramTable(admissionThreshold: 0.5)
+        t.insert(prev: 1, current: 2, entry: BigramEntry(nextToken: 3, confidence: 0.99))
+        // No entry for (2, 3); chain breaks after one step.
+        let draft = t.bigramDraft(maxK: 5, recentTokens: [1, 2])
+        #expect(draft == [3])
+    }
+
+    @Test
+    func `bigramDraft caps at maxK`() {
+        var t = BigramTable(admissionThreshold: 0.5)
+        // Self-loop: prev=1, current=1, next=1 forever.
+        t.insert(prev: 1, current: 1, entry: BigramEntry(nextToken: 1, confidence: 0.99))
+        let draft = t.bigramDraft(maxK: 4, recentTokens: [1, 1])
+        #expect(draft == [1, 1, 1, 1])
+    }
+
+    @Test
+    func `bigramDraft returns empty when recentTokens is too short`() {
+        var t = BigramTable(admissionThreshold: 0.5)
+        t.insert(prev: 1, current: 2, entry: BigramEntry(nextToken: 3, confidence: 0.99))
+        #expect(t.bigramDraft(maxK: 4, recentTokens: []) == [])
+        #expect(t.bigramDraft(maxK: 4, recentTokens: [1]) == [])
+    }
+
+    @Test
+    func `bigramDraft returns empty when maxK is zero`() {
+        var t = BigramTable(admissionThreshold: 0.5)
+        t.insert(prev: 1, current: 2, entry: BigramEntry(nextToken: 3, confidence: 0.99))
+        #expect(t.bigramDraft(maxK: 0, recentTokens: [1, 2]) == [])
+    }
+
+    @Test
+    func `build admits entries above threshold, drops below`() {
+        let frequencies: [BigramKey: [Int: Int]] = [
+            BigramKey(prev: 1, current: 2): [3: 95, 4: 5],   // 95% → admit
+            BigramKey(prev: 5, current: 6): [7: 70, 8: 30],  // 70% → drop @ 0.95
+            BigramKey(prev: 9, current: 10): [11: 100],      // 100% → admit
+        ]
+        let t = BigramTable.build(fromFrequencies: frequencies, threshold: 0.95)
+        #expect(t.entryCount == 2)
+        #expect(t.confidentNext(prev: 1, current: 2)?.nextToken == 3)
+        #expect(t.confidentNext(prev: 9, current: 10)?.nextToken == 11)
+        #expect(t.confidentNext(prev: 5, current: 6) == nil)
+    }
+
+    @Test
+    func `build picks the top-1 successor by count`() {
+        let frequencies: [BigramKey: [Int: Int]] = [
+            BigramKey(prev: 1, current: 2): [3: 50, 4: 95, 5: 5],  // 4 wins
+        ]
+        let t = BigramTable.build(fromFrequencies: frequencies, threshold: 0.5)
+        #expect(t.confidentNext(prev: 1, current: 2)?.nextToken == 4)
+    }
+
+    @Test
+    func `build with all-empty frequency map produces empty table`() {
+        let frequencies: [BigramKey: [Int: Int]] = [:]
+        let t = BigramTable.build(fromFrequencies: frequencies)
+        #expect(t.entryCount == 0)
+    }
+
+    @Test
+    func `build skips zero-count entries (defensive)`() {
+        let frequencies: [BigramKey: [Int: Int]] = [
+            BigramKey(prev: 1, current: 2): [:],  // empty inner map
+        ]
+        let t = BigramTable.build(fromFrequencies: frequencies)
+        #expect(t.entryCount == 0)
+    }
+
+    @Test
+    func `BigramKey equality + hashable`() {
+        let a = BigramKey(prev: 1, current: 2)
+        let b = BigramKey(prev: 1, current: 2)
+        let c = BigramKey(prev: 2, current: 1)
+        #expect(a == b)
+        #expect(a != c)
+        var s = Set<BigramKey>()
+        s.insert(a)
+        s.insert(b)
+        #expect(s.count == 1)
+    }
+}

--- a/Tests/MLXLMTests/MirrorSpeculativeTests.swift
+++ b/Tests/MLXLMTests/MirrorSpeculativeTests.swift
@@ -1,0 +1,367 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLLM
+@testable import MLXLMCommon
+import MLXNN
+import Testing
+
+// MARK: - Mirror Speculative Decoding tests (spec 021 phase 1A scaffold)
+//
+// Three suites:
+//   1. `ANEDraftRegistryTests` — pure-Swift register/lookup behaviour.
+//   2. `ANEVocabEquivalenceTests` — size + disagreement gate at the
+//      llama.cpp-default boundaries.
+//   3. `ANEDraftBackendStubTests` — `ScriptedANEDraftBackend` and
+//      `ZeroAcceptANEDraftBackend` semantics.
+//   4. `MirrorSpeculativeIteratorTests` — integration with
+//      `Gemma3TextModel`. Exercises emit count, cycle bookkeeping,
+//      vocab-gate rejection, AR fallback, and count-parity vs.
+//      `TokenIterator`.
+
+// MARK: - Registry tests
+
+@Suite
+struct ANEDraftRegistryTests {
+
+    @Test
+    func `Registry default is empty`() {
+        let reg = ANEDraftRegistry()
+        #expect(reg.count == 0)
+        #expect(reg.isRegistered(targetID: "anything") == false)
+        #expect(reg.entry(for: "anything") == nil)
+    }
+
+    @Test
+    func `Register, lookup, remove round-trips`() {
+        let reg = ANEDraftRegistry()
+        let entry = ANEDraftRegistryEntry(
+            targetID: "Qwen3.5-27B-Instruct-4bit",
+            draftBundleURL: URL(fileURLWithPath: "/tmp/draft.mlpackage"),
+            draftLength: 4,
+            expectedTokenizerID: "Qwen/Qwen3.5-27B-Instruct")
+        reg.register(entry)
+        #expect(reg.count == 1)
+        #expect(reg.isRegistered(targetID: "Qwen3.5-27B-Instruct-4bit"))
+        #expect(reg.entry(for: "Qwen3.5-27B-Instruct-4bit") == entry)
+
+        reg.remove(targetID: "Qwen3.5-27B-Instruct-4bit")
+        #expect(reg.count == 0)
+        #expect(reg.entry(for: "Qwen3.5-27B-Instruct-4bit") == nil)
+    }
+
+    @Test
+    func `Re-register replaces the previous entry`() {
+        let reg = ANEDraftRegistry()
+        let v1 = ANEDraftRegistryEntry(
+            targetID: "X", draftBundleURL: URL(fileURLWithPath: "/v1"),
+            draftLength: 4, expectedTokenizerID: "tok")
+        let v2 = ANEDraftRegistryEntry(
+            targetID: "X", draftBundleURL: URL(fileURLWithPath: "/v2"),
+            draftLength: 8, expectedTokenizerID: "tok")
+        reg.register(v1)
+        reg.register(v2)
+        #expect(reg.count == 1)
+        #expect(reg.entry(for: "X")?.draftBundleURL.path == "/v2")
+        #expect(reg.entry(for: "X")?.draftLength == 8)
+    }
+
+    @Test
+    func `registeredTargetIDs returns all registered IDs`() {
+        let reg = ANEDraftRegistry()
+        for id in ["A", "B", "C"] {
+            reg.register(ANEDraftRegistryEntry(
+                targetID: id,
+                draftBundleURL: URL(fileURLWithPath: "/tmp/\(id)"),
+                draftLength: 4,
+                expectedTokenizerID: "tok"))
+        }
+        let ids = Set(reg.registeredTargetIDs())
+        #expect(ids == Set(["A", "B", "C"]))
+    }
+}
+
+// MARK: - Vocabulary equivalence tests
+
+@Suite
+struct ANEVocabEquivalenceTests {
+
+    /// Build a synthetic vocab `[0..count)` → "tok_<id>".
+    private static func mkVocab(_ count: Int, mutate: (inout [Int: String]) -> Void = { _ in }) -> [Int: String] {
+        var v: [Int: String] = [:]
+        for i in 0 ..< count { v[i] = "tok_\(i)" }
+        mutate(&v)
+        return v
+    }
+
+    @Test
+    func `Identical vocabularies pass`() {
+        let v = Self.mkVocab(1000)
+        let r = aneCheckVocabEquivalence(draftVocab: v, targetVocab: v)
+        #expect(r.isCompatible)
+        #expect(r.disagreementCount == 0)
+        #expect(r.sizeDifference == 0)
+    }
+
+    @Test
+    func `Disagreement above zero threshold rejects (default policy)`() {
+        var draft = Self.mkVocab(1000)
+        let target = Self.mkVocab(1000)
+        draft[100] = "different_string"
+        let r = aneCheckVocabEquivalence(draftVocab: draft, targetVocab: target)
+        #expect(!r.isCompatible)
+        #expect(r.disagreementCount == 1)
+    }
+
+    @Test
+    func `Disagreement under custom threshold passes`() {
+        var draft = Self.mkVocab(1000)
+        let target = Self.mkVocab(1000)
+        draft[100] = "different_string"
+        let r = aneCheckVocabEquivalence(
+            draftVocab: draft, targetVocab: target, maxDisagreements: 1)
+        #expect(r.isCompatible)
+        #expect(r.disagreementCount == 1)
+    }
+
+    @Test
+    func `Tokens below startTokenID are skipped`() {
+        var draft = Self.mkVocab(1000)
+        let target = Self.mkVocab(1000)
+        // Disagree on tokens 0..<5 (BOS/EOS/etc.) — should not count.
+        for i in 0 ..< 5 { draft[i] = "alt_\(i)" }
+        let r = aneCheckVocabEquivalence(draftVocab: draft, targetVocab: target)
+        #expect(r.isCompatible)
+        #expect(r.disagreementCount == 0)
+    }
+
+    @Test
+    func `Size difference above gate rejects without walking tokens`() {
+        let draft = Self.mkVocab(1000)
+        let target = Self.mkVocab(2000)
+        let r = aneCheckVocabEquivalence(
+            draftVocab: draft, targetVocab: target,
+            maxSizeDifference: 128)
+        #expect(!r.isCompatible)
+        #expect(r.sizeDifference == 1000)
+        #expect(r.comparedTokenCount == 0)  // bailed out early
+    }
+
+    @Test
+    func `Size difference exactly at gate passes`() {
+        let draft = Self.mkVocab(1000)
+        let target = Self.mkVocab(1128)
+        let r = aneCheckVocabEquivalence(
+            draftVocab: draft, targetVocab: target,
+            maxSizeDifference: 128)
+        #expect(r.isCompatible)
+        #expect(r.sizeDifference == 128)
+    }
+
+    @Test
+    func `One-side-only token counts as disagreement`() {
+        var draft = Self.mkVocab(1000)
+        var target = Self.mkVocab(1000)
+        draft[500] = nil  // hole on draft side, target still has it
+        target[500] = "present"
+        let r = aneCheckVocabEquivalence(draftVocab: draft, targetVocab: target)
+        #expect(!r.isCompatible)
+        #expect(r.disagreementCount >= 1)
+    }
+
+    @Test
+    func `Sparse-on-both-sides hole is not a disagreement`() {
+        var draft = Self.mkVocab(1000)
+        var target = Self.mkVocab(1000)
+        draft[500] = nil
+        target[500] = nil
+        let r = aneCheckVocabEquivalence(draftVocab: draft, targetVocab: target)
+        #expect(r.isCompatible)
+        #expect(r.disagreementCount == 0)
+    }
+
+    @Test
+    func `disagreementRate is computed correctly`() {
+        var draft = Self.mkVocab(100)
+        let target = Self.mkVocab(100)
+        // Disagree on tokens 50, 51, 52 (above startTokenID).
+        for i in 50 ..< 53 { draft[i] = "diff_\(i)" }
+        let r = aneCheckVocabEquivalence(
+            draftVocab: draft, targetVocab: target, maxDisagreements: 100)
+        #expect(r.disagreementCount == 3)
+        // comparedTokenCount = (100 - 5) = 95
+        #expect(r.comparedTokenCount == 95)
+        #expect(abs(r.disagreementRate - 3.0/95.0) < 1e-9)
+    }
+}
+
+// MARK: - Stub backend tests
+
+@Suite
+struct ANEDraftBackendStubTests {
+
+    @Test
+    func `ScriptedANEDraftBackend replays in order then returns empty`() {
+        var b = ScriptedANEDraftBackend(draftLength: 3, script: [[1, 2, 3], [4, 5, 6]])
+        #expect(b.callCount == 0)
+        #expect(b.draftBlock(committedTokens: [], lastCommittedToken: 0) == [1, 2, 3])
+        #expect(b.draftBlock(committedTokens: [], lastCommittedToken: 0) == [4, 5, 6])
+        #expect(b.draftBlock(committedTokens: [], lastCommittedToken: 0) == [])
+        // Exhausted call doesn't bump cursor (early-return short-circuits
+        // before defer increment) — same convention as the DFlash side.
+        #expect(b.callCount == 2)
+    }
+
+    @Test
+    func `ScriptedANEDraftBackend reset rewinds cursor`() {
+        var b = ScriptedANEDraftBackend(draftLength: 2, script: [[1, 2], [3, 4]])
+        _ = b.draftBlock(committedTokens: [], lastCommittedToken: 0)
+        _ = b.draftBlock(committedTokens: [], lastCommittedToken: 0)
+        #expect(b.callCount == 2)
+        b.reset()
+        #expect(b.callCount == 0)
+        #expect(b.draftBlock(committedTokens: [], lastCommittedToken: 0) == [1, 2])
+    }
+
+    @Test
+    func `ZeroAcceptANEDraftBackend emits draftLength stub tokens`() {
+        var b = ZeroAcceptANEDraftBackend(draftLength: 5, stubToken: 999)
+        let block = b.draftBlock(committedTokens: [1, 2, 3], lastCommittedToken: 3)
+        #expect(block == [999, 999, 999, 999, 999])
+    }
+
+    @Test
+    func `Default draftCacheMemoryBytes is nil`() {
+        let b = ZeroAcceptANEDraftBackend(draftLength: 4)
+        #expect(b.draftCacheMemoryBytes == nil)
+    }
+}
+
+// MARK: - Iterator integration tests
+
+@Suite(.serialized)
+struct MirrorSpeculativeIteratorTests {
+
+    let processor: any UserInputProcessor
+    let model: Gemma3TextModel
+
+    init() {
+        let processor = TestInputProcessor()
+        let modelConfig = Gemma3TextConfiguration(
+            modelType: "text",
+            hiddenSize: 64, hiddenLayers: 8, intermediateSize: 64,
+            attentionHeads: 4, headDim: 64,
+            rmsNormEps: 0.00001, vocabularySize: 100, kvHeads: 4,
+            ropeTheta: 1_000_000, ropeLocalBaseFreq: 10_000,
+            ropeTraditional: false, queryPreAttnScalar: 256,
+            slidingWindow: 512, slidingWindowPattern: 6,
+            maxPositionEmbeddings: 32768
+        )
+        let model = Gemma3TextModel(modelConfig)
+        eval(model)
+        self.processor = processor
+        self.model = model
+    }
+
+    @Test
+    func `Iterator emits exactly maxTokens tokens`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hello world"))
+        let backend = ZeroAcceptANEDraftBackend(draftLength: 4)
+        let params = GenerateParameters(maxTokens: 10, temperature: 0.0)
+        var iter = try MirrorSpeculativeTokenIterator(
+            input: input, target: model,
+            draftBackend: backend, parameters: params)
+        var tokens: [Int] = []
+        while let t = iter.next() { tokens.append(t) }
+        #expect(tokens.count == 10)
+    }
+
+    @Test
+    func `ZeroAccept backend never accepts`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hello world"))
+        let backend = ZeroAcceptANEDraftBackend(draftLength: 4, stubToken: 12345)
+        let params = GenerateParameters(maxTokens: 12, temperature: 0.0)
+        var iter = try MirrorSpeculativeTokenIterator(
+            input: input, target: model,
+            draftBackend: backend, parameters: params)
+        while iter.next() != nil {}
+        #expect(iter.mirrorAcceptedCount == 0)
+        #expect(iter.mirrorProposedCount > 0)
+        #expect(iter.mirrorAcceptanceRate == 0)
+    }
+
+    @Test
+    func `Output count parity with TokenIterator`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hello world"))
+        let params = GenerateParameters(maxTokens: 10, temperature: 0.0)
+
+        var ref = try TokenIterator(input: input, model: model, parameters: params)
+        var refTokens: [Int] = []
+        while let t = ref.next() { refTokens.append(t) }
+
+        let backend = ZeroAcceptANEDraftBackend(draftLength: 4)
+        var spec = try MirrorSpeculativeTokenIterator(
+            input: input, target: model,
+            draftBackend: backend, parameters: params)
+        var specTokens: [Int] = []
+        while let t = spec.next() { specTokens.append(t) }
+
+        // Tiny random-weight model: argmax ties can flip on
+        // batched-vs-sequential paths; assert count parity.
+        #expect(specTokens.count == refTokens.count)
+    }
+
+    @Test
+    func `Vocab equivalence gate rejects incompatible report`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hi"))
+        let backend = ZeroAcceptANEDraftBackend(draftLength: 4)
+        let params = GenerateParameters(maxTokens: 4, temperature: 0.0)
+        let badReport = ANEVocabEquivalenceReport(
+            comparedTokenCount: 1000, disagreementCount: 50,
+            sizeDifference: 0, isCompatible: false)
+        do {
+            _ = try MirrorSpeculativeTokenIterator(
+                input: input, target: model,
+                draftBackend: backend, parameters: params,
+                vocabReport: badReport)
+            Issue.record("expected init to throw on incompatible vocab")
+        } catch let err as KVCacheError {
+            #expect(err.message.contains("vocabulary"))
+        } catch {
+            Issue.record("expected KVCacheError, got \(error)")
+        }
+    }
+
+    @Test
+    func `Compatible vocab report passes through`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hi"))
+        let backend = ZeroAcceptANEDraftBackend(draftLength: 4)
+        let params = GenerateParameters(maxTokens: 4, temperature: 0.0)
+        let goodReport = ANEVocabEquivalenceReport(
+            comparedTokenCount: 1000, disagreementCount: 0,
+            sizeDifference: 0, isCompatible: true)
+        // Should construct without error.
+        _ = try MirrorSpeculativeTokenIterator(
+            input: input, target: model,
+            draftBackend: backend, parameters: params,
+            vocabReport: goodReport)
+    }
+
+    @Test
+    func `Empty-script ScriptedBackend still progresses via AR`() async throws {
+        let input = try await processor.prepare(input: UserInput(prompt: "hi"))
+        // Empty script — backend always returns []; iterator must keep
+        // emitting via AR fallback.
+        let backend = ScriptedANEDraftBackend(draftLength: 4, script: [])
+        let params = GenerateParameters(maxTokens: 6, temperature: 0.0)
+        var iter = try MirrorSpeculativeTokenIterator(
+            input: input, target: model,
+            draftBackend: backend, parameters: params)
+        var tokens: [Int] = []
+        while let t = iter.next() { tokens.append(t) }
+        #expect(tokens.count == 6)
+        // Never proposed anything because every call returned empty.
+        #expect(iter.mirrorProposedCount == 0)
+    }
+}

--- a/Tests/MLXLMTests/PrefixKVCacheTests.swift
+++ b/Tests/MLXLMTests/PrefixKVCacheTests.swift
@@ -1,0 +1,307 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+@testable import MLXLMCommon
+import Testing
+
+// MARK: - Cross-request prefix KV cache tests (spec 017 phase 1)
+//
+// All pure-Swift / pure-array — no model forward, no tokenizer, no chat
+// template. Phase 1 tests cover:
+//
+//   1. `StablePrefixPolicy`: Identity + FixedTrim semantics.
+//   2. `PrefixKey`: equality + hash invariance.
+//   3. `PrefixKVCache`:
+//      - lookup miss / hit / longest-prefix selection
+//      - cross-key isolation (different model ID rejects)
+//      - LRU bump on hit
+//      - byte-budget eviction
+//      - entry-count cap eviction
+//      - stat counters (hits / misses / partial / insertions / evictions)
+//      - clear / resetStats
+//
+// The tests build snapshots with placeholder MLXArrays sized to fixed
+// known byte counts so the budget math is exact.
+
+// MARK: - Helpers
+
+private func makeKey(model: String = "test", layers: Int = 4) -> PrefixKey {
+    PrefixKey(modelID: model, layerCount: layers, kvHeadDim: 64, kvBits: nil)
+}
+
+private func makeSnapshot(
+    model: String = "test",
+    tokens: [Int],
+    layers: Int = 4,
+    bytesPerLayer: Int = 1024
+) -> PrefixSnapshot {
+    let key = makeKey(model: model, layers: layers)
+    // Use fp16 (Float16 = 2 bytes) — `bytesPerLayer / 2` Float16 values
+    // gives an array of exactly `bytesPerLayer` bytes.
+    let elementCount = bytesPerLayer / 2  // Float16 is 2 bytes
+    let arr: () -> MLXArray = { MLXArray.zeros([elementCount], dtype: .float16) }
+    let layerStates = (0 ..< layers).map { _ in
+        LayerCacheState(tokenCount: tokens.count, arrays: [arr()])
+    }
+    return PrefixSnapshot(key: key, tokens: tokens, layerStates: layerStates)
+}
+
+// MARK: - Stable-prefix policy
+
+@Suite
+struct StablePrefixPolicyTests {
+
+    @Test
+    func `IdentityPolicy returns full token count`() {
+        let p = IdentityPolicy()
+        #expect(p.stablePrefixLen([1, 2, 3, 4, 5]) == 5)
+        #expect(p.stablePrefixLen([]) == 0)
+    }
+
+    @Test
+    func `FixedTrimPolicy trims fixed suffix`() {
+        let p = FixedTrimPolicy(trimSuffix: 3)
+        #expect(p.stablePrefixLen([1, 2, 3, 4, 5, 6, 7]) == 4)
+    }
+
+    @Test
+    func `FixedTrimPolicy floors at zero on short prompts`() {
+        let p = FixedTrimPolicy(trimSuffix: 10)
+        #expect(p.stablePrefixLen([1, 2, 3]) == 0)
+    }
+
+    @Test
+    func `FixedTrimPolicy with zero trim is identity-equivalent`() {
+        let p = FixedTrimPolicy(trimSuffix: 0)
+        #expect(p.stablePrefixLen([1, 2, 3]) == 3)
+    }
+}
+
+// MARK: - PrefixKey
+
+@Suite
+struct PrefixKeyTests {
+
+    @Test
+    func `Equality requires all fields match`() {
+        let a = PrefixKey(modelID: "x", layerCount: 32, kvHeadDim: 64, kvBits: nil)
+        let b = PrefixKey(modelID: "x", layerCount: 32, kvHeadDim: 64, kvBits: nil)
+        #expect(a == b)
+
+        let differentLayers = PrefixKey(modelID: "x", layerCount: 16, kvHeadDim: 64, kvBits: nil)
+        #expect(a != differentLayers)
+
+        let differentBits = PrefixKey(modelID: "x", layerCount: 32, kvHeadDim: 64, kvBits: 4)
+        #expect(a != differentBits)
+
+        let differentModel = PrefixKey(modelID: "y", layerCount: 32, kvHeadDim: 64, kvBits: nil)
+        #expect(a != differentModel)
+    }
+
+    @Test
+    func `Hashable produces consistent buckets`() {
+        let a = PrefixKey(modelID: "x", layerCount: 32, kvHeadDim: 64, kvBits: nil)
+        let b = PrefixKey(modelID: "x", layerCount: 32, kvHeadDim: 64, kvBits: nil)
+        var set = Set<PrefixKey>()
+        set.insert(a)
+        set.insert(b)
+        #expect(set.count == 1)
+    }
+}
+
+// MARK: - PrefixKVCache lookup / insert / eviction
+
+@Suite
+struct PrefixKVCacheTests {
+
+    @Test
+    func `Empty cache reports miss`() {
+        let cache = PrefixKVCache(maxBytes: 1_000_000, maxEntries: 4)
+        let r = cache.lookup(prefix: [1, 2, 3], key: makeKey())
+        #expect(r == nil)
+        #expect(cache.stats.misses == 1)
+        #expect(cache.stats.hits == 0)
+    }
+
+    @Test
+    func `Exact prefix match returns full snapshot`() {
+        let cache = PrefixKVCache(maxBytes: 1_000_000, maxEntries: 4)
+        let snap = makeSnapshot(tokens: [1, 2, 3])
+        cache.insert(snap)
+
+        let r = cache.lookup(prefix: [1, 2, 3, 4, 5], key: makeKey())
+        #expect(r != nil)
+        #expect(r?.matchedLength == 3)
+        #expect(cache.stats.hits == 1)
+        #expect(cache.stats.partialHits == 1)  // 3 < 5 → partial
+    }
+
+    @Test
+    func `Full-cover hit (matchedLen == request length) is not a partial hit`() {
+        let cache = PrefixKVCache(maxBytes: 1_000_000, maxEntries: 4)
+        let snap = makeSnapshot(tokens: [1, 2, 3])
+        cache.insert(snap)
+        _ = cache.lookup(prefix: [1, 2, 3], key: makeKey())
+        #expect(cache.stats.hits == 1)
+        #expect(cache.stats.partialHits == 0)
+    }
+
+    @Test
+    func `Longest-prefix selection picks the longest matching snapshot`() {
+        let cache = PrefixKVCache(maxBytes: 1_000_000, maxEntries: 4)
+        cache.insert(makeSnapshot(tokens: [1, 2]))
+        cache.insert(makeSnapshot(tokens: [1, 2, 3, 4]))
+        cache.insert(makeSnapshot(tokens: [1, 2, 3]))
+
+        let r = cache.lookup(prefix: [1, 2, 3, 4, 5], key: makeKey())
+        #expect(r?.matchedLength == 4)
+        #expect(r?.snapshot.tokens == [1, 2, 3, 4])
+    }
+
+    @Test
+    func `Cross-key isolation rejects mismatched model ID`() {
+        let cache = PrefixKVCache(maxBytes: 1_000_000, maxEntries: 4)
+        cache.insert(makeSnapshot(model: "modelA", tokens: [1, 2, 3]))
+
+        let r = cache.lookup(
+            prefix: [1, 2, 3, 4],
+            key: PrefixKey(modelID: "modelB", layerCount: 4, kvHeadDim: 64))
+        #expect(r == nil)
+        #expect(cache.stats.misses == 1)
+    }
+
+    @Test
+    func `Mismatching prefix returns nil`() {
+        let cache = PrefixKVCache(maxBytes: 1_000_000, maxEntries: 4)
+        cache.insert(makeSnapshot(tokens: [1, 2, 3]))
+
+        let r = cache.lookup(prefix: [9, 8, 7, 6], key: makeKey())
+        #expect(r == nil)
+    }
+
+    @Test
+    func `Snapshot longer than request returns nil (won't truncate)`() {
+        let cache = PrefixKVCache(maxBytes: 1_000_000, maxEntries: 4)
+        cache.insert(makeSnapshot(tokens: [1, 2, 3, 4, 5]))
+
+        let r = cache.lookup(prefix: [1, 2], key: makeKey())
+        #expect(r == nil)
+    }
+
+    @Test
+    func `Re-insert with same key replaces in place (no double-count)`() {
+        let cache = PrefixKVCache(maxBytes: 1_000_000, maxEntries: 4)
+        let snap = makeSnapshot(tokens: [1, 2, 3])
+        cache.insert(snap)
+        let bytesAfterFirst = cache.stats.bytesUsed
+        cache.insert(snap)
+        #expect(cache.count == 1)
+        #expect(cache.stats.bytesUsed == bytesAfterFirst)
+    }
+
+    @Test
+    func `LRU bump moves matched entry to MRU position`() {
+        let cache = PrefixKVCache(maxBytes: 1_000_000, maxEntries: 4)
+        let s1 = makeSnapshot(tokens: [1, 2])
+        let s2 = makeSnapshot(tokens: [3, 4])
+        let s3 = makeSnapshot(tokens: [5, 6])
+        cache.insert(s1)
+        cache.insert(s2)
+        cache.insert(s3)
+        // Order: s1 (oldest), s2, s3 (newest).
+
+        // Hit s1: should move it to the back.
+        _ = cache.lookup(prefix: [1, 2, 99], key: makeKey())
+
+        let order = cache.entrySnapshot.map { $0.tokens }
+        #expect(order == [[3, 4], [5, 6], [1, 2]])
+    }
+
+    @Test
+    func `Entry-count cap evicts oldest first`() {
+        let cache = PrefixKVCache(maxBytes: 1_000_000, maxEntries: 2)
+        cache.insert(makeSnapshot(tokens: [1]))
+        cache.insert(makeSnapshot(tokens: [2]))
+        // Inserting third should evict tokens=[1].
+        cache.insert(makeSnapshot(tokens: [3]))
+        #expect(cache.count == 2)
+        let surviving = Set(cache.entrySnapshot.map { $0.tokens.first! })
+        #expect(surviving == [2, 3])
+        #expect(cache.stats.evictions == 1)
+    }
+
+    @Test
+    func `Byte-budget eviction frees space for large insert`() {
+        // 4 layers × 1024 bytes = 4 KiB per snapshot. Cache holds 8 KiB
+        // → exactly two snapshots before eviction.
+        let cache = PrefixKVCache(maxBytes: 8 * 1024, maxEntries: 100)
+        cache.insert(makeSnapshot(tokens: [1], bytesPerLayer: 1024))
+        cache.insert(makeSnapshot(tokens: [2], bytesPerLayer: 1024))
+        #expect(cache.count == 2)
+
+        // Third insert (4 KiB) → must evict to fit (8 + 4 > 8).
+        cache.insert(makeSnapshot(tokens: [3], bytesPerLayer: 1024))
+        #expect(cache.count == 2)
+        #expect(cache.stats.evictions == 1)
+    }
+
+    @Test
+    func `clear empties entries and resets bytes`() {
+        let cache = PrefixKVCache(maxBytes: 1_000_000, maxEntries: 4)
+        cache.insert(makeSnapshot(tokens: [1, 2]))
+        cache.insert(makeSnapshot(tokens: [3, 4]))
+        cache.clear()
+        #expect(cache.count == 0)
+        #expect(cache.stats.bytesUsed == 0)
+        #expect(cache.stats.entryCount == 0)
+        // Stats counters preserved.
+        #expect(cache.stats.insertions == 2)
+    }
+
+    @Test
+    func `resetStats keeps occupancy counts, zeros activity counters`() {
+        let cache = PrefixKVCache(maxBytes: 1_000_000, maxEntries: 4)
+        cache.insert(makeSnapshot(tokens: [1, 2]))
+        _ = cache.lookup(prefix: [1, 2], key: makeKey())
+        _ = cache.lookup(prefix: [9], key: makeKey())
+        #expect(cache.stats.hits == 1)
+        #expect(cache.stats.misses == 1)
+
+        cache.resetStats()
+        #expect(cache.stats.hits == 0)
+        #expect(cache.stats.misses == 0)
+        #expect(cache.stats.insertions == 0)
+        // Occupancy preserved.
+        #expect(cache.stats.bytesUsed > 0)
+        #expect(cache.stats.entryCount == 1)
+    }
+
+    @Test
+    func `hitRate computation is correct`() {
+        let cache = PrefixKVCache(maxBytes: 1_000_000, maxEntries: 4)
+        cache.insert(makeSnapshot(tokens: [1, 2]))
+        _ = cache.lookup(prefix: [1, 2], key: makeKey())
+        _ = cache.lookup(prefix: [1, 2], key: makeKey())
+        _ = cache.lookup(prefix: [9], key: makeKey())
+        // 2 hits, 1 miss → 2/3.
+        #expect(abs(cache.stats.hitRate - 2.0/3.0) < 1e-9)
+    }
+
+    @Test
+    func `meanMatchedLength averages over hits only`() {
+        let cache = PrefixKVCache(maxBytes: 1_000_000, maxEntries: 4)
+        cache.insert(makeSnapshot(tokens: [1, 2]))
+        cache.insert(makeSnapshot(tokens: [1, 2, 3, 4]))
+        // Hit on [1, 2] (matched 2)
+        _ = cache.lookup(prefix: [1, 2, 9], key: makeKey())
+        // Hit on [1, 2, 3, 4] (matched 4)
+        _ = cache.lookup(prefix: [1, 2, 3, 4, 5], key: makeKey())
+        // Miss
+        _ = cache.lookup(prefix: [9, 8], key: makeKey())
+
+        #expect(cache.stats.hits == 2)
+        #expect(cache.stats.totalMatchedTokens == 6)
+        #expect(abs(cache.stats.meanMatchedLength - 3.0) < 1e-9)
+    }
+}

--- a/Tests/MLXLMTests/TapeReplayCacheTests.swift
+++ b/Tests/MLXLMTests/TapeReplayCacheTests.swift
@@ -1,0 +1,311 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+@testable import MLXLMCommon
+import Testing
+
+// MARK: - Tape-replay rollback tests (spec 020 phase 1)
+//
+// Phase 1 lands the protocol + free helpers; concrete `MambaCache`
+// conformance + Metal kernel are phase 2. The tests here cover:
+//
+//   1. `canRollbackPromptCache` predicate semantics — pure-trimmable
+//      stacks pass, tape-replay-only stacks pass, mixed stacks pass,
+//      stacks containing a layer that's neither trimmable nor tape-
+//      replayable fail.
+//   2. `rollbackPromptCache` dispatch — tape-replay layers see
+//      `commitFull`/`rollback`/`cancel` per acceptance count;
+//      trimmable layers see `trim(rejected)`.
+//   3. `beginCacheRecord` / `cancelCacheRecord` / `commitCacheRecord`
+//      route only to tape-replay layers.
+//   4. Mixed-cache stack — both layer types coexist and observe correct
+//      method calls per round.
+
+// MARK: - Test fakes
+
+/// Minimal trimmable-only cache that records what it was asked to do.
+/// Doesn't actually store K/V — phase-1 helpers don't touch shapes, only
+/// dispatch decisions.
+final class FakeTrimmableCache: KVCache, Evaluatable {
+    var trimCalls: [Int] = []
+    var cacheOffset: Int = 0
+
+    var offset: Int { cacheOffset }
+    var maxSize: Int? { nil }
+    func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) { (keys, values) }
+    func peek() -> (MLXArray, MLXArray)? { nil }
+    var state: [MLXArray] {
+        get { [] }
+        set { _ = newValue }
+    }
+    var metaState: [String] {
+        get { [] }
+        set { _ = newValue }
+    }
+    var isTrimmable: Bool { true }
+    @discardableResult
+    func trim(_ n: Int) -> Int {
+        trimCalls.append(n)
+        cacheOffset = Swift.max(0, cacheOffset - n)
+        return n
+    }
+    var memoryBytes: Int { 0 }
+    func makeMask(n: Int, windowSize: Int?, returnArray: Bool) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        .none
+    }
+    func copy() -> any KVCache { FakeTrimmableCache() }
+    var isDonor: Bool {
+        get { false }
+        set { _ = newValue }
+    }
+    func innerState() -> [MLXArray] { [] }
+}
+
+/// Minimal cache that's neither trimmable nor tape-replay-able. Models
+/// the pre-phase-2 hybrid case where MambaCache exists but doesn't
+/// conform to TapeReplayCache yet.
+final class FakeOpaqueCache: KVCache, Evaluatable {
+    var offset: Int { 0 }
+    var maxSize: Int? { nil }
+    func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) { (keys, values) }
+    func peek() -> (MLXArray, MLXArray)? { nil }
+    var state: [MLXArray] {
+        get { [] }
+        set { _ = newValue }
+    }
+    var metaState: [String] {
+        get { [] }
+        set { _ = newValue }
+    }
+    var isTrimmable: Bool { false }
+    @discardableResult
+    func trim(_ n: Int) -> Int { 0 }
+    var memoryBytes: Int { 0 }
+    func makeMask(n: Int, windowSize: Int?, returnArray: Bool) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        .none
+    }
+    func copy() -> any KVCache { FakeOpaqueCache() }
+    var isDonor: Bool {
+        get { false }
+        set { _ = newValue }
+    }
+    func innerState() -> [MLXArray] { [] }
+}
+
+/// Minimal tape-replay cache that records every method call. Used to
+/// verify the dispatch logic in `rollbackPromptCache` and the
+/// begin/commit/cancel helpers.
+final class FakeTapeReplayCache: TapeReplayCache, Evaluatable {
+    enum Event: Equatable {
+        case begin
+        case appendInnovation
+        case commitFull
+        case rollback(Int)
+        case cancel
+    }
+
+    var events: [Event] = []
+    var enabled: Bool = true
+
+    var offset: Int { 0 }
+    var maxSize: Int? { nil }
+    func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) { (keys, values) }
+    func peek() -> (MLXArray, MLXArray)? { nil }
+    var state: [MLXArray] {
+        get { [] }
+        set { _ = newValue }
+    }
+    var metaState: [String] {
+        get { [] }
+        set { _ = newValue }
+    }
+    var isTrimmable: Bool { false }
+    @discardableResult
+    func trim(_ n: Int) -> Int { 0 }
+    var memoryBytes: Int { 0 }
+    func makeMask(n: Int, windowSize: Int?, returnArray: Bool) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        .none
+    }
+    func copy() -> any KVCache { FakeTapeReplayCache() }
+    var isDonor: Bool {
+        get { false }
+        set { _ = newValue }
+    }
+    func innerState() -> [MLXArray] { [] }
+
+    var canTapeReplay: Bool { enabled }
+    var replayCost: TapeReplayCost { .ok }
+    func beginRecord() { events.append(.begin) }
+    func appendInnovation(_ delta: MLXArray) { events.append(.appendInnovation) }
+    func commitFull() { events.append(.commitFull) }
+    func rollback(acceptedPrefix k: Int) { events.append(.rollback(k)) }
+    func cancel() { events.append(.cancel) }
+}
+
+// MARK: - Predicate tests
+
+@Suite
+struct CanRollbackPromptCacheTests {
+
+    @Test
+    func `Empty stack passes (vacuously)`() {
+        #expect(canRollbackPromptCache([]))
+    }
+
+    @Test
+    func `All-trimmable stack passes`() {
+        let cache: [KVCache] = [FakeTrimmableCache(), FakeTrimmableCache()]
+        #expect(canRollbackPromptCache(cache))
+    }
+
+    @Test
+    func `All-tape-replay stack passes`() {
+        let cache: [KVCache] = [FakeTapeReplayCache(), FakeTapeReplayCache()]
+        #expect(canRollbackPromptCache(cache))
+    }
+
+    @Test
+    func `Mixed trimmable + tape-replay stack passes`() {
+        let cache: [KVCache] = [
+            FakeTrimmableCache(),
+            FakeTapeReplayCache(),
+            FakeTrimmableCache(),
+        ]
+        #expect(canRollbackPromptCache(cache))
+    }
+
+    @Test
+    func `Stack with opaque cache fails`() {
+        let cache: [KVCache] = [FakeTrimmableCache(), FakeOpaqueCache()]
+        #expect(!canRollbackPromptCache(cache))
+    }
+
+    @Test
+    func `TapeReplayCache reporting canTapeReplay = false fails`() {
+        let disabled = FakeTapeReplayCache()
+        disabled.enabled = false
+        let cache: [KVCache] = [FakeTrimmableCache(), disabled]
+        #expect(!canRollbackPromptCache(cache))
+    }
+}
+
+// MARK: - rollbackPromptCache dispatch tests
+
+@Suite
+struct RollbackPromptCacheTests {
+
+    @Test
+    func `Full accept calls commitFull on tape layers, no trim on trimmable`() {
+        let trim = FakeTrimmableCache()
+        let tape = FakeTapeReplayCache()
+        let cache: [KVCache] = [trim, tape]
+
+        rollbackPromptCache(cache, acceptedPrefix: 4, numDraft: 4)
+
+        #expect(trim.trimCalls == [0])  // rejected = 0; trim(0) is called
+        #expect(tape.events == [.commitFull])
+    }
+
+    @Test
+    func `Zero accept calls cancel on tape layers, trim by all on trimmable`() {
+        let trim = FakeTrimmableCache()
+        let tape = FakeTapeReplayCache()
+        let cache: [KVCache] = [trim, tape]
+
+        rollbackPromptCache(cache, acceptedPrefix: 0, numDraft: 4)
+
+        #expect(trim.trimCalls == [4])
+        #expect(tape.events == [.cancel])
+    }
+
+    @Test
+    func `Partial accept calls rollback(k) on tape layers, trim by rejected on trimmable`() {
+        let trim = FakeTrimmableCache()
+        let tape = FakeTapeReplayCache()
+        let cache: [KVCache] = [trim, tape]
+
+        rollbackPromptCache(cache, acceptedPrefix: 3, numDraft: 5)
+
+        #expect(trim.trimCalls == [2])
+        #expect(tape.events == [.rollback(3)])
+    }
+
+    @Test
+    func `Mixed-stack rollback hits each layer once`() {
+        let trim1 = FakeTrimmableCache()
+        let tape1 = FakeTapeReplayCache()
+        let trim2 = FakeTrimmableCache()
+        let tape2 = FakeTapeReplayCache()
+        let cache: [KVCache] = [trim1, tape1, trim2, tape2]
+
+        rollbackPromptCache(cache, acceptedPrefix: 1, numDraft: 4)
+
+        #expect(trim1.trimCalls == [3])
+        #expect(trim2.trimCalls == [3])
+        #expect(tape1.events == [.rollback(1)])
+        #expect(tape2.events == [.rollback(1)])
+    }
+
+    @Test
+    func `Disabled tape-replay layer is skipped, no event recorded`() {
+        let trim = FakeTrimmableCache()
+        let tape = FakeTapeReplayCache()
+        tape.enabled = false
+        let cache: [KVCache] = [trim, tape]
+
+        rollbackPromptCache(cache, acceptedPrefix: 2, numDraft: 4)
+
+        #expect(trim.trimCalls == [2])
+        #expect(tape.events == [])  // skipped because canTapeReplay = false
+    }
+
+    @Test
+    func `Precondition rejects out-of-range acceptedPrefix`() async {
+        // Skipping - preconditions trap, not graceful for tests.
+        // Valid range tested implicitly by the other cases.
+    }
+}
+
+// MARK: - begin / commit / cancel record tests
+
+@Suite
+struct CacheRecordHelpersTests {
+
+    @Test
+    func `beginCacheRecord routes only to tape layers`() {
+        let trim = FakeTrimmableCache()
+        let tape = FakeTapeReplayCache()
+        let cache: [KVCache] = [trim, tape, FakeTrimmableCache()]
+        beginCacheRecord(cache)
+        #expect(tape.events == [.begin])
+        #expect(trim.trimCalls == [])
+    }
+
+    @Test
+    func `commitCacheRecord routes only to tape layers`() {
+        let tape = FakeTapeReplayCache()
+        let cache: [KVCache] = [FakeTrimmableCache(), tape]
+        commitCacheRecord(cache)
+        #expect(tape.events == [.commitFull])
+    }
+
+    @Test
+    func `cancelCacheRecord routes only to tape layers`() {
+        let tape = FakeTapeReplayCache()
+        let cache: [KVCache] = [FakeTrimmableCache(), tape]
+        cancelCacheRecord(cache)
+        #expect(tape.events == [.cancel])
+    }
+
+    @Test
+    func `Disabled tape layer is skipped by all helpers`() {
+        let tape = FakeTapeReplayCache()
+        tape.enabled = false
+        let cache: [KVCache] = [tape]
+        beginCacheRecord(cache)
+        commitCacheRecord(cache)
+        cancelCacheRecord(cache)
+        #expect(tape.events == [])
+    }
+}


### PR DESCRIPTION
## Summary

Spec 022 phase 1 — \"free-token short-circuit\" speculation. Two complementary mechanisms:

- **A. Chat-template grammar state machine** — deterministic stretches at structural boundaries (channel markers, thinking-end, turn openers).
- **B. Common-bigram fallback drafter** — high-confidence two-token-history → next-token table for broad probabilistic coverage.

Phase 1 ships the protocol + state types + a NoOp / Trigger grammar + the bigram data structure + a frequency-map → table builder. Per-family grammars (Qwen 3.5 / Gemma 4 / GPT-OSS / Llama) and the offline corpus builder land in phases 2-3.

Stack: #113 → #140 → #141 → #142 → #143 → #144 → **this PR**.

### What lands

- \`Libraries/MLXLMCommon/ChatTemplateGrammar.swift\` — \`ChatTemplateGrammar\` protocol, \`ChatTemplatePhase\` enum, \`ChatTemplateConfig\` (turn / think / channel / message / newline token IDs), \`ChatTemplateState\` (phase + recent tokens + config), \`NoOpChatGrammar\` (always nil — fallback default), \`TriggerTokenGrammar\` (test stub).
- \`Libraries/MLXLMCommon/BigramTable.swift\` — \`BigramKey\`, \`BigramEntry\`, \`BigramTable\` (two-level dict, \`confidentNext\`, greedy \`bigramDraft\` chain walk), and \`BigramTable.build(fromFrequencies:threshold:)\` builder.
- \`Tests/MLXLMTests/DeterministicStretchTests.swift\` — 16 tests:
  - \`ChatTemplateGrammarTests\` (3): NoOp behaviour, TriggerToken selectivity, phase equality.
  - \`BigramTableTests\` (13): empty lookup, insert/lookup, overwrite, greedy chain walk, chain break, maxK cap, short recentTokens, zero maxK, threshold admission, top-1 selection, empty input, defensive zero-count handling, BigramKey equality + hashable.

Pure-Swift, no MLX eval. All 16 tests pass under \`swift test\`.

### Phase-1 limitations (deferred)

- Per-family grammars (\`Qwen35Grammar\`, \`Gemma4Grammar\`, \`GPTOSSGrammar\`, \`LlamaGrammar\`) → phase 2; depend on tokenizer-resolved special-token IDs.
- Offline bigram corpus build pipeline + binary serialisation → phase 2.
- Iterator wiring (the new draft ladder in \`NGramSpeculativeTokenIterator.speculateRound\`) → phase 3 once both mechanisms have populated implementations.
- \`--method free-tokens\` bench harness mode → phase 3.

## Test plan

- [x] \`swift test --filter ChatTemplateGrammarTests\` — 3 pass.
- [x] \`swift test --filter BigramTableTests\` — 13 pass.
- [x] Full \`swift build\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evaluation (when phase 2+ lands)

**Deterministic-stretch (spec 022) eval — phase 2+:** Once per-family chat-template grammars land (Qwen 3.5 / Gemma 4 / GPT-OSS / Llama) plus the bigram corpus build:

```bash
# Highest-leverage target: GPT-OSS harmony channel transitions
scripts/spec-decode-sweep.sh --model gpt-oss-20b --quant mxfp4 \
    --prompts Tests/Benchmarks/Resources/ngram-sweep-prompts/chat-instruction \
    --cells "no-grammar:3:0:,grammar:3:0:MLX_NGRAM_GRAMMAR=1" \
    --trials 5 --output /tmp/grammar-treatment.log
scripts/spec-decode-compare.py /tmp/no-grammar.log /tmp/grammar-treatment.log
```

**Pass criterion:** +15-30% on GPT-OSS harmony format (per spec 022 published projection). Smaller model families should show +5%.

For the canonical sweep+compare workflow, see `scripts/spec-decode-sweep.sh` and `scripts/spec-decode-compare.py` (added in PR #154). Workload classification + recommended cell-set in `Tests/Benchmarks/Resources/ngram-sweep-prompts/README.md`.