### PR TITLE
feat(ngram): spec 016 phases 1-2 — cross-request n-gram cache + registry

### DIFF
--- a/Libraries/MLXLMCommon/NGramCacheRegistry.swift
+++ b/Libraries/MLXLMCommon/NGramCacheRegistry.swift
@@ -1,0 +1,272 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+// MARK: - Cross-request n-gram cache + registry (spec 016 phases 1-2)
+//
+// Today's `NGramSpeculativeTokenIterator` rebuilds its lookup table per
+// request from `prompt + history` only. Multi-turn chat throws away the
+// previous turn's lookup at request end, even though every turn shares
+// system prompt + accumulated history. Spec 016 keeps the lookup alive
+// across requests via a process-level registry; with the dynamic tier
+// the lookup grows continuously over a session instead of resetting.
+//
+// **Phase 1-2 scope** (this file):
+//   - `NGramCache` — token-history container with three tiers (context,
+//     dynamic, static). Phase 1 lives in the context tier; phase 2
+//     adds the dynamic-tier promotion lifecycle.
+//   - `NGramCacheRegistry` — process-level singleton keyed by
+//     `(modelID, ngramRange)`. Iterator looks up or creates the cache
+//     for the current model on entry; commits context tokens into the
+//     dynamic tier on exit.
+//   - `NGramCacheThresholds` — per-tier threshold profile (lax /
+//     strict / static), porting llama.cpp's `ngram-cache.cpp`
+//     constants.
+//
+// Phase 3 (disk persistence + static-cache bootstrap) and phase 4
+// (three-tier draft selection in the iterator) land in follow-up PRs.
+
+/// Per-tier confidence thresholds for ngram-cache draft selection. Mirrors
+/// llama.cpp's `draft_min_sample_size_*` and `draft_min_percent_*`
+/// constants from `ngram-cache.cpp`. Each tier has its own profile;
+/// strict is for less-trusted accumulated history, lax for the current
+/// request's own context.
+public struct NGramCacheThresholds: Equatable, Sendable {
+    /// Minimum total observations of the n-gram before its top-1
+    /// continuation is admissible. Index 0 is for ngram size 1, index 1
+    /// for size 2, etc. — same shape as llama.cpp's
+    /// `draft_min_sample_size_*`.
+    public let minSampleSize: [Int]
+
+    /// Minimum percentage (0-100) of the top-1 continuation's share of
+    /// total observations. Same indexing as `minSampleSize`.
+    public let minPercent: [Int]
+
+    public init(minSampleSize: [Int], minPercent: [Int]) {
+        precondition(
+            minSampleSize.count == minPercent.count && !minSampleSize.isEmpty,
+            "minSampleSize and minPercent must be non-empty and same length")
+        for v in minPercent {
+            precondition(v >= 0 && v <= 100,
+                "minPercent values must be in [0, 100] (got \(v))")
+        }
+        self.minSampleSize = minSampleSize
+        self.minPercent = minPercent
+    }
+
+    /// llama.cpp's lax profile (context tier).
+    public static let lax = NGramCacheThresholds(
+        minSampleSize: [2, 2, 1, 1],
+        minPercent: [66, 50, 50, 50])
+
+    /// llama.cpp's strict profile (dynamic tier).
+    public static let strict = NGramCacheThresholds(
+        minSampleSize: [4, 3, 2, 2],
+        minPercent: [75, 66, 66, 66])
+
+    /// Threshold for the static / pre-trained tier. Same shape as
+    /// strict but used as a validator (multiply primary count by static
+    /// count); admission policy is identical.
+    public static let staticTier = NGramCacheThresholds.strict
+
+    /// Look up the threshold pair for a given ngram size. Returns the
+    /// tightest entry available; for sizes above the array length, uses
+    /// the last entry.
+    public func thresholds(forNgramSize n: Int) -> (sampleSize: Int, percent: Int) {
+        precondition(n >= 1, "ngram size must be >= 1 (got \(n))")
+        let idx = Swift.min(n - 1, minSampleSize.count - 1)
+        return (minSampleSize[idx], minPercent[idx])
+    }
+}
+
+/// Tiered n-gram cache for a single (model, ngram-range) pair.
+///
+/// Three tiers:
+///   - `.context`: the current request's history (prompt + accepted
+///     drafts). Reset on every new request — cheap.
+///   - `.dynamic`: accumulated across all prior requests in this
+///     process. Survives request boundaries; subject to LRU-ish
+///     eviction at `maxTokens`.
+///   - `.static`: loaded from disk; read-only at runtime. Phase 3 will
+///     wire load/save; phase 1-2 ship the storage but no I/O.
+///
+/// Phase 1 keeps lookup alive across requests by re-using the same
+/// `NGramCache` instance via the registry. Phase 2 adds the
+/// `commitContext(...)` lifecycle that promotes context tokens into
+/// the dynamic tier at request end.
+public final class NGramCache: @unchecked Sendable {
+
+    public enum Tier: Equatable, Hashable, Sendable {
+        case context
+        case dynamic
+        case `static`
+    }
+
+    public let modelID: String
+    public let ngramRange: ClosedRange<Int>
+    public let maxTokens: Int
+
+    /// Tokens in the current request's context tier. Cleared on each
+    /// `resetContext()` (typically called at the start of a new
+    /// request); promoted into `dynamic` via `commitContext()` at the
+    /// end of a successful generation.
+    public private(set) var context: [Int] = []
+
+    /// Tokens in the dynamic tier — accumulated across requests.
+    /// FIFO-truncated when length exceeds `maxTokens`.
+    public private(set) var dynamic: [Int] = []
+
+    /// Tokens in the static tier — loaded from disk in phase 3.
+    /// Read-only at runtime: callers go through `loadStatic(_:)` to
+    /// hydrate, never mutate directly.
+    public private(set) var staticTokens: [Int] = []
+
+    public init(
+        modelID: String,
+        ngramRange: ClosedRange<Int>,
+        maxTokens: Int = 100_000
+    ) {
+        precondition(modelID.isEmpty == false, "modelID must be non-empty")
+        precondition(ngramRange.lowerBound >= 1,
+            "ngramRange.lowerBound must be >= 1 (got \(ngramRange.lowerBound))")
+        precondition(maxTokens >= 1, "maxTokens must be >= 1 (got \(maxTokens))")
+        self.modelID = modelID
+        self.ngramRange = ngramRange
+        self.maxTokens = maxTokens
+    }
+
+    // MARK: - Context tier
+
+    /// Append tokens to the context tier. Called by the iterator as it
+    /// commits accepted drafts.
+    public func extendContext(_ tokens: [Int]) {
+        context.append(contentsOf: tokens)
+    }
+
+    /// Reset the context tier — the iterator does this when a new
+    /// request starts.
+    public func resetContext() {
+        context.removeAll(keepingCapacity: true)
+    }
+
+    // MARK: - Dynamic tier
+
+    /// Promote `tokens` into the dynamic tier. Called at end of request
+    /// (typically with the iterator's `committedTokens` suffix).
+    /// Truncates the dynamic tier to `maxTokens` from the head if the
+    /// addition exceeds the budget — old history is dropped first.
+    public func commitToDynamic(_ tokens: [Int]) {
+        dynamic.append(contentsOf: tokens)
+        if dynamic.count > maxTokens {
+            // FIFO drop: older tokens fall out first.
+            let drop = dynamic.count - maxTokens
+            dynamic.removeFirst(drop)
+        }
+    }
+
+    // MARK: - Static tier
+
+    /// Replace the static-tier corpus. Phase 3's loader will call this
+    /// on registry construction; for phase 1-2 it's manually invoked
+    /// by tests.
+    public func loadStatic(_ tokens: [Int]) {
+        staticTokens = tokens
+    }
+
+    /// Clear all tiers. Mostly a test convenience.
+    public func clearAll() {
+        context.removeAll(keepingCapacity: true)
+        dynamic.removeAll(keepingCapacity: true)
+        staticTokens.removeAll(keepingCapacity: true)
+    }
+
+    /// Read accessor for a tier — used by the iterator's lookup ladder
+    /// in phase 4 to consult tiers in priority order.
+    public func tokens(in tier: Tier) -> [Int] {
+        switch tier {
+        case .context: return context
+        case .dynamic: return dynamic
+        case .static: return staticTokens
+        }
+    }
+
+    /// Token count by tier. Useful for telemetry and tests.
+    public func count(in tier: Tier) -> Int {
+        switch tier {
+        case .context: return context.count
+        case .dynamic: return dynamic.count
+        case .static: return staticTokens.count
+        }
+    }
+}
+
+// MARK: - Registry
+
+/// Process-level singleton mapping `(modelID, ngramRange)` to
+/// `NGramCache` instances. Iterator construction looks up the cache
+/// for the current model; the dynamic tier survives across iterator
+/// instances on the same model.
+///
+/// Like ``ANEDraftRegistry`` and ``PrefixKVCache``, the shared
+/// instance is `@unchecked Sendable` — phase 1-2 is **not**
+/// thread-safe; callers using shared serving wrap accesses with their
+/// own queue. Phase 4's actor wrapper lands when concurrent serving
+/// is needed.
+public final class NGramCacheRegistry: @unchecked Sendable {
+
+    /// Process-wide shared registry. Production callers default to
+    /// this; tests construct local instances.
+    public static let shared = NGramCacheRegistry()
+
+    private struct Key: Hashable {
+        let modelID: String
+        let lower: Int
+        let upper: Int
+    }
+
+    private var caches: [Key: NGramCache] = [:]
+
+    public init() {}
+
+    /// Get or create the cache for the given (modelID, ngramRange).
+    /// Re-uses an existing cache when its `(modelID, ngramRange)`
+    /// matches; constructs a fresh one otherwise.
+    public func cache(
+        for modelID: String,
+        ngramRange: ClosedRange<Int>,
+        maxTokens: Int = 100_000
+    ) -> NGramCache {
+        let key = Key(
+            modelID: modelID,
+            lower: ngramRange.lowerBound,
+            upper: ngramRange.upperBound)
+        if let existing = caches[key] {
+            return existing
+        }
+        let cache = NGramCache(
+            modelID: modelID,
+            ngramRange: ngramRange,
+            maxTokens: maxTokens)
+        caches[key] = cache
+        return cache
+    }
+
+    /// Number of registered caches. Useful for tests + diagnostics.
+    public var count: Int { caches.count }
+
+    /// Drop a cache by `(modelID, ngramRange)`. Returns true when the
+    /// entry existed.
+    @discardableResult
+    public func remove(modelID: String, ngramRange: ClosedRange<Int>) -> Bool {
+        let key = Key(
+            modelID: modelID,
+            lower: ngramRange.lowerBound,
+            upper: ngramRange.upperBound)
+        return caches.removeValue(forKey: key) != nil
+    }
+
+    /// Clear the entire registry. Mostly for tests at suite teardown.
+    public func clear() {
+        caches.removeAll()
+    }
+}

--- a/Tests/MLXLMTests/NGramCacheRegistryTests.swift
+++ b/Tests/MLXLMTests/NGramCacheRegistryTests.swift
@@ -1,0 +1,187 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+@testable import MLXLMCommon
+import Testing
+
+// MARK: - NGramCache + registry tests (spec 016 phases 1-2)
+
+@Suite
+struct NGramCacheThresholdsTests {
+
+    @Test
+    func `Lax profile matches llama.cpp constants`() {
+        let t = NGramCacheThresholds.lax
+        #expect(t.minSampleSize == [2, 2, 1, 1])
+        #expect(t.minPercent == [66, 50, 50, 50])
+    }
+
+    @Test
+    func `Strict profile matches llama.cpp constants`() {
+        let t = NGramCacheThresholds.strict
+        #expect(t.minSampleSize == [4, 3, 2, 2])
+        #expect(t.minPercent == [75, 66, 66, 66])
+    }
+
+    @Test
+    func `Static-tier profile aliases strict`() {
+        #expect(NGramCacheThresholds.staticTier == NGramCacheThresholds.strict)
+    }
+
+    @Test
+    func `Threshold lookup uses last entry for sizes past array length`() {
+        let t = NGramCacheThresholds.lax
+        let small = t.thresholds(forNgramSize: 1)
+        #expect(small.sampleSize == 2)
+        #expect(small.percent == 66)
+
+        let big = t.thresholds(forNgramSize: 10)
+        #expect(big.sampleSize == 1)
+        #expect(big.percent == 50)
+    }
+}
+
+@Suite
+struct NGramCacheTests {
+
+    @Test
+    func `Initial cache is empty across all tiers`() {
+        let c = NGramCache(modelID: "m", ngramRange: 2 ... 4)
+        #expect(c.count(in: .context) == 0)
+        #expect(c.count(in: .dynamic) == 0)
+        #expect(c.count(in: .static) == 0)
+    }
+
+    @Test
+    func `extendContext appends to context tier`() {
+        let c = NGramCache(modelID: "m", ngramRange: 2 ... 4)
+        c.extendContext([1, 2, 3])
+        c.extendContext([4, 5])
+        #expect(c.tokens(in: .context) == [1, 2, 3, 4, 5])
+        #expect(c.count(in: .context) == 5)
+    }
+
+    @Test
+    func `resetContext clears context but preserves other tiers`() {
+        let c = NGramCache(modelID: "m", ngramRange: 2 ... 4)
+        c.extendContext([1, 2, 3])
+        c.commitToDynamic([10, 20])
+        c.loadStatic([100, 200])
+
+        c.resetContext()
+        #expect(c.count(in: .context) == 0)
+        #expect(c.tokens(in: .dynamic) == [10, 20])
+        #expect(c.tokens(in: .static) == [100, 200])
+    }
+
+    @Test
+    func `commitToDynamic appends and FIFO-truncates at maxTokens`() {
+        let c = NGramCache(modelID: "m", ngramRange: 2 ... 4, maxTokens: 5)
+        c.commitToDynamic([1, 2, 3])
+        c.commitToDynamic([4, 5, 6, 7])  // overflow by 2
+        #expect(c.tokens(in: .dynamic) == [3, 4, 5, 6, 7])
+        #expect(c.count(in: .dynamic) == 5)
+    }
+
+    @Test
+    func `commitToDynamic with single overflowing batch truncates from head`() {
+        let c = NGramCache(modelID: "m", ngramRange: 2 ... 4, maxTokens: 3)
+        c.commitToDynamic([1, 2, 3, 4, 5])
+        #expect(c.tokens(in: .dynamic) == [3, 4, 5])
+    }
+
+    @Test
+    func `loadStatic replaces existing static corpus`() {
+        let c = NGramCache(modelID: "m", ngramRange: 2 ... 4)
+        c.loadStatic([1, 2, 3])
+        c.loadStatic([10, 20])
+        #expect(c.tokens(in: .static) == [10, 20])
+    }
+
+    @Test
+    func `clearAll empties every tier`() {
+        let c = NGramCache(modelID: "m", ngramRange: 2 ... 4)
+        c.extendContext([1])
+        c.commitToDynamic([2])
+        c.loadStatic([3])
+        c.clearAll()
+        #expect(c.count(in: .context) == 0)
+        #expect(c.count(in: .dynamic) == 0)
+        #expect(c.count(in: .static) == 0)
+    }
+}
+
+@Suite
+struct NGramCacheRegistryTests {
+
+    @Test
+    func `Default registry is empty`() {
+        let r = NGramCacheRegistry()
+        #expect(r.count == 0)
+    }
+
+    @Test
+    func `cache(for:) returns the same instance on repeated lookup`() {
+        let r = NGramCacheRegistry()
+        let a = r.cache(for: "modelA", ngramRange: 2 ... 4)
+        let b = r.cache(for: "modelA", ngramRange: 2 ... 4)
+        #expect(a === b)
+        #expect(r.count == 1)
+    }
+
+    @Test
+    func `cache(for:) creates separate instances per model ID`() {
+        let r = NGramCacheRegistry()
+        let a = r.cache(for: "modelA", ngramRange: 2 ... 4)
+        let b = r.cache(for: "modelB", ngramRange: 2 ... 4)
+        #expect(a !== b)
+        #expect(r.count == 2)
+    }
+
+    @Test
+    func `cache(for:) creates separate instances per ngram range`() {
+        let r = NGramCacheRegistry()
+        let a = r.cache(for: "modelA", ngramRange: 2 ... 4)
+        let b = r.cache(for: "modelA", ngramRange: 3 ... 5)
+        #expect(a !== b)
+        #expect(r.count == 2)
+    }
+
+    @Test
+    func `Dynamic-tier persists across cache lookups (the phase-1 win)`() {
+        let r = NGramCacheRegistry()
+        let cache1 = r.cache(for: "modelA", ngramRange: 2 ... 4)
+        cache1.extendContext([1, 2, 3, 4])
+        cache1.commitToDynamic(cache1.tokens(in: .context))
+
+        // Simulate "next request" — different iterator, same registry,
+        // same model. Lookup returns the same cache; dynamic tier
+        // still has the prior turn's tokens.
+        let cache2 = r.cache(for: "modelA", ngramRange: 2 ... 4)
+        #expect(cache2 === cache1)
+        #expect(cache2.tokens(in: .dynamic) == [1, 2, 3, 4])
+    }
+
+    @Test
+    func `remove(modelID:ngramRange:) drops the registered cache`() {
+        let r = NGramCacheRegistry()
+        _ = r.cache(for: "modelA", ngramRange: 2 ... 4)
+        #expect(r.count == 1)
+        let removed = r.remove(modelID: "modelA", ngramRange: 2 ... 4)
+        #expect(removed)
+        #expect(r.count == 0)
+
+        // Idempotent on the next call.
+        let removedAgain = r.remove(modelID: "modelA", ngramRange: 2 ... 4)
+        #expect(!removedAgain)
+    }
+
+    @Test
+    func `clear empties the registry`() {
+        let r = NGramCacheRegistry()
+        _ = r.cache(for: "modelA", ngramRange: 2 ... 4)
+        _ = r.cache(for: "modelB", ngramRange: 3 ... 5)
+        r.clear()
+        #expect(r.count == 0)
+    }
+}


### PR DESCRIPTION
## Summary

Spec 016 phases 1-2 — keep the n-gram lookup alive across requests so multi-turn workloads stop throwing away accumulated history at request boundaries.

Stack: #113 → #140 → #141 → #142 → #143 → #144 → #145 → **this PR**.

### What lands

- \`Libraries/MLXLMCommon/NGramCacheRegistry.swift\`:
  - \`NGramCache\` — tiered token-history container (context / dynamic / static), \`extendContext\`, \`resetContext\`, \`commitToDynamic\` (with FIFO truncation at \`maxTokens\`), \`loadStatic\`, \`clearAll\`.
  - \`NGramCacheRegistry\` — process-level singleton, \`cache(for:ngramRange:maxTokens:)\` returns the same instance per \`(modelID, ngramRange)\` so the dynamic tier survives across iterator lifetimes.
  - \`NGramCacheThresholds\` — per-tier confidence profiles (lax / strict / static), porting llama.cpp's \`ngram-cache.cpp\` constants byte-for-byte.

- \`Tests/MLXLMTests/NGramCacheRegistryTests.swift\` — 18 tests:
  - \`NGramCacheThresholdsTests\` (4)
  - \`NGramCacheTests\` (7)
  - \`NGramCacheRegistryTests\` (7) — including the \"dynamic-tier persists across cache lookups\" assertion that documents the phase-1 win

Pure-Swift, no MLX eval. All 18 tests pass under \`swift test\`.

### Phase scope

- Phase 1 (keep-alive) ✅ — context tier survives across iterator instances via registry shared slot.
- Phase 2 (dynamic-tier promotion) ✅ — \`commitToDynamic\` lifecycle.
- Phase 3 (disk persistence + static-cache CLI tool) → follow-up.
- Phase 4 (three-tier draft-selection ladder in iterator) → follow-up.

Iterator wiring (replace \`NGramLookup\` rebuild on init with registry-resolved \`NGramCache\`) deferred to phase 4 when the three-tier ladder lands — that's where the actual draft wins materialise; phases 1-2 just provision the storage.

## Test plan

- [x] \`swift test --filter NGramCache\` — all 18 tests pass.
- [x] Full \`swift build\` clean.
- [ ] (Phase 4) Wire iterator + bench harness to \`NGramCacheRegistry.shared\`; show +10-30% improvement on multi-turn chat workloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evaluation (when phase 2+ lands)

**N-gram cross-request cache (spec 016) eval — phase 4 (three-tier draft selection):** Once the iterator queries the dynamic + static tiers in addition to the per-request context:

```bash
# Multi-turn workload — the cache fills across requests, so the second
# turn's lookup hits the dynamic tier from the first turn's output.
scripts/spec-decode-sweep.sh --model gemma4-26b-a4b --quant 4bit \
    --prompts Tests/Benchmarks/Resources/ngram-sweep-prompts/multi-turn-code \
    --cells "context-only:3:0:,with-dynamic:3:0:MLX_NGRAM_CACHE_PERSIST=1" \
    --trials 5 --output /tmp/ngram-cache-treatment.log
scripts/spec-decode-compare.py /tmp/context-only.log /tmp/ngram-cache-treatment.log
```

**Pass criterion:** +10-30% on top of base PLD on multi-turn chat (per spec 016 projection). Eval requires the bench harness to issue prompts in sequence (multi-turn mode); current `simple` method is single-turn.

For the canonical sweep+compare workflow, see `scripts/spec-decode-sweep.sh` and `scripts/spec-decode-compare.py` (added in PR #154). Workload classification + recommended cell-set in `Tests/Benchmarks/Resources/ngram-sweep-prompts/README.md`.