### PR TITLE
feat(spec-decode): spec 014 phase 1 scaffold — draft tree primitives

### DIFF
--- a/Libraries/MLXLMCommon/DraftTree.swift
+++ b/Libraries/MLXLMCommon/DraftTree.swift
@@ -1,0 +1,289 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+// MARK: - Draft tree representation (spec 014 phase 1 scaffold)
+//
+// Tree-attention speculative decoding generalises the linear draft —
+// instead of one chain of K candidate tokens, the iterator drafts a
+// **tree** with multiple branches at each level. The verifier processes
+// the tree in one forward pass via a custom attention mask: each node
+// attends only to its ancestors, so siblings are alternative
+// completions of the same prefix.
+//
+// Phase 1 (this file): pure-Swift data structure + mask / position-id
+// builders + longest-matching-path acceptance walk. The MLX-side
+// attention mask construction and the iterator wiring land in phase 2;
+// per-model position-id plumbing lands in phase 3. Phase 1 is fully
+// unit-testable without GPU.
+
+/// Flat-DFS tree of drafted candidate tokens.
+///
+/// The tree's root is the implicit `y` slot at verify-input position 0
+/// (the most recently committed token). `tokens[i]` is node `i`'s
+/// candidate token; `parent[i]` is its parent's index in `tokens`, or
+/// `-1` if `i` is a root child (parent = the implicit `y`). `depth[i]`
+/// is the distance from the root, equal to `parent[i] >= 0 ?
+/// depth[parent[i]] + 1 : 1`.
+///
+/// Invariants enforced at construction:
+///   - `tokens.count == parent.count == depth.count`.
+///   - `parent[i] < i` for all `i` (DFS order — parents come before
+///     children).
+///   - `depth[i] == 1` if `parent[i] == -1`, else `depth[parent[i]] + 1`.
+public struct DraftTree: Equatable, Sendable {
+    public let tokens: [Int]
+    public let parent: [Int]
+    public let depth: [Int]
+
+    public init(tokens: [Int], parent: [Int], depth: [Int]) {
+        precondition(
+            tokens.count == parent.count && tokens.count == depth.count,
+            "DraftTree arrays must have the same count "
+                + "(tokens=\(tokens.count), parent=\(parent.count), depth=\(depth.count))")
+        for i in 0 ..< tokens.count {
+            let p = parent[i]
+            precondition(p >= -1 && p < i,
+                "parent[\(i)]=\(p) must be in [-1, \(i)) (DFS order)")
+            let expected = (p == -1) ? 1 : depth[p] + 1
+            precondition(depth[i] == expected,
+                "depth[\(i)]=\(depth[i]) inconsistent with parent (expected \(expected))")
+        }
+        self.tokens = tokens
+        self.parent = parent
+        self.depth = depth
+    }
+
+    /// Number of tree nodes (excluding the implicit root).
+    public var nodeCount: Int { tokens.count }
+
+    /// Empty tree — equivalent to "no draft this round".
+    public static let empty = DraftTree(tokens: [], parent: [], depth: [])
+
+    /// Build a linear chain of length `D`. parent[i] = i - 1, depth[i] =
+    /// i + 1. Equivalent to today's `linear` shape — kept here for tests
+    /// and as a building block for `topK_root_x_linear`.
+    public static func linear(tokens: [Int]) -> DraftTree {
+        var parent = [Int](repeating: -1, count: tokens.count)
+        var depth = [Int](repeating: 0, count: tokens.count)
+        for i in 0 ..< tokens.count {
+            parent[i] = i - 1
+            depth[i] = i + 1
+        }
+        return DraftTree(tokens: tokens, parent: parent, depth: depth)
+    }
+
+    /// Build a `topK × linear-D` tree: K root branches (each carrying
+    /// the first token from the corresponding chain), each extended
+    /// into a linear chain of depth `D - 1`.
+    ///
+    /// - Parameter chains: K independent draft chains. Each chain's
+    ///   first token becomes a root child; the rest extend that branch
+    ///   linearly. Empty chains are skipped.
+    public static func topKByLinear(chains: [[Int]]) -> DraftTree {
+        var tokens: [Int] = []
+        var parent: [Int] = []
+        var depth: [Int] = []
+        for chain in chains where !chain.isEmpty {
+            // The first token in the chain is a root child (parent = -1,
+            // depth = 1).
+            let rootIndex = tokens.count
+            tokens.append(chain[0])
+            parent.append(-1)
+            depth.append(1)
+            // Subsequent tokens form a linear chain off that root child.
+            for j in 1 ..< chain.count {
+                let prev = tokens.count - 1
+                tokens.append(chain[j])
+                parent.append(prev)
+                depth.append(depth[prev] + 1)
+            }
+            // (Loose end — `rootIndex` not consumed; intent is to make
+            // the chain-start position obvious to readers tracing the
+            // construction.)
+            _ = rootIndex
+        }
+        return DraftTree(tokens: tokens, parent: parent, depth: depth)
+    }
+
+    /// Children-of-each-node lookup, materialised on demand. O(N) to
+    /// build; callers can cache it across uses.
+    public func children() -> [[Int]] {
+        var result = [[Int]](repeating: [], count: nodeCount)
+        var rootChildren: [Int] = []
+        for i in 0 ..< nodeCount {
+            if parent[i] == -1 {
+                rootChildren.append(i)
+            } else {
+                result[parent[i]].append(i)
+            }
+        }
+        // Append a synthetic "root entry" by storing rootChildren in a
+        // companion accessor — keep the array shape `nodeCount` so
+        // index `i` always means "children of node i".
+        return result + [rootChildren]
+    }
+
+    /// Indices of nodes whose parent is the implicit root (`y`).
+    public var rootChildren: [Int] {
+        (0 ..< nodeCount).filter { parent[$0] == -1 }
+    }
+
+    /// Set of all ancestors of node `i` (excluding `i` itself, including
+    /// the implicit root represented by `-1`). Returned as a
+    /// `Set<Int>` for fast mask-construction lookups; the `-1` element
+    /// is omitted from the set (the mask builder treats `y` separately).
+    public func ancestors(of i: Int) -> Set<Int> {
+        precondition(i >= 0 && i < nodeCount, "node index out of range")
+        var result: Set<Int> = []
+        var p = parent[i]
+        while p != -1 {
+            result.insert(p)
+            p = parent[p]
+        }
+        return result
+    }
+}
+
+// MARK: - Tree shape policies (spec 014 §6)
+
+/// Available tree-shape policies. Phase 1 ships the data structures for
+/// all three; the iterator currently only uses `linear`. Phase 2 wires
+/// `topKByLinear`; phase 3 wires `bifurcatingOnTightMargin`.
+public enum DraftTreeShape: Equatable, Sendable {
+    /// One path of depth `D`. Today's behaviour — no tree, equivalent
+    /// to the existing linear draft.
+    case linear(depth: Int)
+
+    /// `K` root branches × linear continuation of depth `D - 1` per
+    /// branch. Total nodes: `K * D`.
+    case topKByLinear(k: Int, depth: Int)
+
+    /// Linear path of depth `D` with sibling-of-top-2 inserted at
+    /// tight-margin positions. Total nodes ≤ `2 * D`.
+    case bifurcatingOnTightMargin(depth: Int, marginEpsilon: Float)
+}
+
+// MARK: - Attention mask construction
+
+/// Build the tree-attention mask in pure Swift, returning a flat
+/// `[T, T]` Bool array (row-major) where `T = 1 + tree.nodeCount`.
+/// Position 0 is the implicit `y` slot; positions `1..<T` are tree
+/// nodes in DFS order.
+///
+/// Mask convention: `mask[i, j] == true` means position `i`'s query
+/// may attend to position `j`'s key. The mask combines:
+///   - Causal: `i` attends to `j` only if `j <= i`.
+///   - Self: `mask[i, i] = true`.
+///   - Tree: tree nodes attend to `y` (column 0) plus all their
+///     ancestors plus self. Sibling positions are NOT visible to each
+///     other.
+///   - `y` self-attends (`mask[0, 0] = true`).
+///
+/// The iterator materialises this as an `MLXArray` of dtype `bool`
+/// before the verify forward; the bool-vs-additive-mask conversion is
+/// MLX-side and not part of this helper.
+public func buildTreeAttentionMask(_ tree: DraftTree) -> [Bool] {
+    let T = 1 + tree.nodeCount
+    var mask = [Bool](repeating: false, count: T * T)
+    // y self-attends.
+    mask[0] = true
+    for i in 0 ..< tree.nodeCount {
+        let row = (i + 1) * T
+        // Tree node attends to y.
+        mask[row + 0] = true
+        // Self-attention.
+        mask[row + (i + 1)] = true
+        // Ancestors.
+        var p = tree.parent[i]
+        while p != -1 {
+            mask[row + (p + 1)] = true
+            p = tree.parent[p]
+        }
+    }
+    return mask
+}
+
+/// Position IDs for the tree's verify input. Position 0 is `y`'s
+/// position (`previousOffset`); position `i + 1` is `previousOffset +
+/// depth[i]`. Siblings share their parent's `depth + 1` so RoPE rotates
+/// them as alternative completions of the same prefix.
+public func buildTreePositionIDs(_ tree: DraftTree, previousOffset: Int) -> [Int] {
+    var ids = [Int](repeating: 0, count: 1 + tree.nodeCount)
+    ids[0] = previousOffset
+    for i in 0 ..< tree.nodeCount {
+        ids[i + 1] = previousOffset + tree.depth[i]
+    }
+    return ids
+}
+
+// MARK: - Acceptance walk (longest-matching-path)
+
+/// Result of accepting along the longest matching root-to-leaf path.
+public struct DraftTreeAcceptance: Equatable, Sendable {
+    /// Depth-ordered indices of accepted nodes (each index is into
+    /// `tree.tokens`). Empty when no root child matches.
+    public let acceptedNodeIndices: [Int]
+
+    /// Bonus token verify-input position — the index in
+    /// `[y] + tree.tokens` whose target argmax is the next emitted
+    /// token. Equals `0` when nothing accepts (emit `targetArgmax[0]`);
+    /// equals `1 + lastAccepted` when accepting deeper.
+    public let bonusVerifyIndex: Int
+
+    public var acceptedCount: Int { acceptedNodeIndices.count }
+}
+
+/// Walk the tree to find the longest path whose tokens match the
+/// target's argmax at each verify position.
+///
+/// The contract:
+///   - `targetArgmax[0]` is what should follow `y`. Look for a root
+///     child whose token equals it; if none, accept zero, bonus is
+///     position 0.
+///   - For each accepted node, look at `targetArgmax[1 + acceptedIdx]`
+///     — that's what should follow this node. Find a child whose
+///     token equals it; descend.
+///   - Stop when no child matches (accept ends here) or the path
+///     reaches a leaf (full accept).
+///
+/// - Parameter tree: the drafted tree.
+/// - Parameter targetArgmax: per-verify-position target argmax —
+///   shape `[1 + tree.nodeCount]`. `targetArgmax[0]` is the
+///   prediction at `y`'s position; `targetArgmax[i + 1]` is the
+///   prediction at tree node `i`'s position.
+public func acceptDraftTree(
+    _ tree: DraftTree,
+    targetArgmax: [Int]
+) -> DraftTreeAcceptance {
+    precondition(
+        targetArgmax.count == 1 + tree.nodeCount,
+        "targetArgmax must have 1 + tree.nodeCount entries "
+            + "(got \(targetArgmax.count), expected \(1 + tree.nodeCount))")
+
+    // Build a children map keyed by token: children-of-node-i has the
+    // shape `[Int: Int]` mapping `token -> node index`. Built lazily —
+    // most accept walks visit only a small fraction of nodes.
+    func childrenOf(_ nodeIdx: Int) -> [Int] {
+        if nodeIdx == -1 { return tree.rootChildren }
+        return (0 ..< tree.nodeCount).filter { tree.parent[$0] == nodeIdx }
+    }
+
+    var accepted: [Int] = []
+    var current: Int = -1  // -1 = implicit root (y)
+    while true {
+        let targetIdx = (current == -1) ? 0 : (1 + current)
+        let want = targetArgmax[targetIdx]
+        let kids = childrenOf(current)
+        guard let pick = kids.first(where: { tree.tokens[$0] == want }) else {
+            break
+        }
+        accepted.append(pick)
+        current = pick
+    }
+
+    let bonusIdx = (accepted.isEmpty) ? 0 : (1 + accepted.last!)
+    return DraftTreeAcceptance(
+        acceptedNodeIndices: accepted,
+        bonusVerifyIndex: bonusIdx)
+}

--- a/Tests/MLXLMTests/DraftTreeTests.swift
+++ b/Tests/MLXLMTests/DraftTreeTests.swift
@@ -1,0 +1,241 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+@testable import MLXLMCommon
+import Testing
+
+// MARK: - Draft tree tests (spec 014 phase 1 scaffold)
+//
+// Pure-Swift; no MLX evaluation. Phase 1 covers:
+//
+//   1. `DraftTree` invariants + builders (linear, topKByLinear).
+//   2. Ancestor + rootChildren accessors.
+//   3. `buildTreeAttentionMask` — causal + self + ancestor + y-column.
+//   4. `buildTreePositionIDs` — depth-aware position IDs.
+//   5. `acceptDraftTree` — longest-matching-path walk in scenarios:
+//      no match, partial match, full match, multi-branch with one
+//      matching, descend-then-stop.
+
+@Suite
+struct DraftTreeBuilderTests {
+
+    @Test
+    func `Empty tree`() {
+        let t = DraftTree.empty
+        #expect(t.nodeCount == 0)
+        #expect(t.tokens == [])
+        #expect(t.rootChildren == [])
+    }
+
+    @Test
+    func `Linear tree of length 4 has chained parents and depths 1-4`() {
+        let t = DraftTree.linear(tokens: [10, 20, 30, 40])
+        #expect(t.nodeCount == 4)
+        #expect(t.parent == [-1, 0, 1, 2])
+        #expect(t.depth == [1, 2, 3, 4])
+        #expect(t.rootChildren == [0])
+    }
+
+    @Test
+    func `topKByLinear with K=2, D=3 produces 2 branches`() {
+        let t = DraftTree.topKByLinear(chains: [[10, 11, 12], [20, 21, 22]])
+        #expect(t.nodeCount == 6)
+        #expect(t.tokens == [10, 11, 12, 20, 21, 22])
+        // Branch 1: indices 0,1,2; parents -1,0,1; depths 1,2,3.
+        // Branch 2: indices 3,4,5; parents -1,3,4; depths 1,2,3.
+        #expect(t.parent == [-1, 0, 1, -1, 3, 4])
+        #expect(t.depth == [1, 2, 3, 1, 2, 3])
+        #expect(t.rootChildren == [0, 3])
+    }
+
+    @Test
+    func `topKByLinear with empty chains is empty`() {
+        let t = DraftTree.topKByLinear(chains: [])
+        #expect(t.nodeCount == 0)
+    }
+
+    @Test
+    func `topKByLinear skips empty chains in the input`() {
+        let t = DraftTree.topKByLinear(chains: [[1, 2], [], [3, 4]])
+        #expect(t.tokens == [1, 2, 3, 4])
+        #expect(t.parent == [-1, 0, -1, 2])
+        #expect(t.rootChildren == [0, 2])
+    }
+
+    @Test
+    func `Ancestors include the chain back to root`() {
+        let t = DraftTree.linear(tokens: [10, 20, 30, 40])
+        #expect(t.ancestors(of: 0) == [])
+        #expect(t.ancestors(of: 3) == [0, 1, 2])
+    }
+
+    @Test
+    func `Ancestors of unrelated branch are disjoint`() {
+        let t = DraftTree.topKByLinear(chains: [[10, 11], [20, 21]])
+        #expect(t.ancestors(of: 1) == [0])  // branch 1's leaf
+        #expect(t.ancestors(of: 3) == [2])  // branch 2's leaf
+    }
+}
+
+// MARK: - Mask construction
+
+@Suite
+struct TreeAttentionMaskTests {
+
+    private static func mask(_ flat: [Bool], _ T: Int, _ row: Int, _ col: Int) -> Bool {
+        flat[row * T + col]
+    }
+
+    @Test
+    func `Empty tree mask is single self-attention slot`() {
+        let m = buildTreeAttentionMask(.empty)
+        #expect(m == [true])
+    }
+
+    @Test
+    func `Linear tree mask is purely causal`() {
+        let t = DraftTree.linear(tokens: [10, 20, 30])
+        let m = buildTreeAttentionMask(t)
+        let T = 4  // 1 + 3 nodes
+        #expect(m.count == T * T)
+        // Each row i should attend to all j <= i.
+        for i in 0 ..< T {
+            for j in 0 ..< T {
+                #expect(Self.mask(m, T, i, j) == (j <= i))
+            }
+        }
+    }
+
+    @Test
+    func `Two-branch tree mask isolates siblings`() {
+        // y → branch A (depth 1, then 2), branch B (depth 1, then 2).
+        let t = DraftTree.topKByLinear(chains: [[10, 11], [20, 21]])
+        let m = buildTreeAttentionMask(t)
+        let T = 5  // y + 4 nodes
+        // Position layout:
+        //   0: y
+        //   1: A0 (parent y, depth 1)
+        //   2: A1 (parent A0, depth 2)
+        //   3: B0 (parent y, depth 1)
+        //   4: B1 (parent B0, depth 2)
+
+        // y sees only itself.
+        for j in 1 ..< T { #expect(!Self.mask(m, T, 0, j)) }
+        #expect(Self.mask(m, T, 0, 0))
+
+        // A0 sees y + self.
+        #expect(Self.mask(m, T, 1, 0))
+        #expect(Self.mask(m, T, 1, 1))
+        for j in 2 ..< T { #expect(!Self.mask(m, T, 1, j)) }
+
+        // A1 sees y + A0 + self; not B0/B1.
+        #expect(Self.mask(m, T, 2, 0))
+        #expect(Self.mask(m, T, 2, 1))
+        #expect(Self.mask(m, T, 2, 2))
+        #expect(!Self.mask(m, T, 2, 3))
+        #expect(!Self.mask(m, T, 2, 4))
+
+        // B0 sees y + self; not A0/A1.
+        #expect(Self.mask(m, T, 3, 0))
+        #expect(!Self.mask(m, T, 3, 1))
+        #expect(!Self.mask(m, T, 3, 2))
+        #expect(Self.mask(m, T, 3, 3))
+        #expect(!Self.mask(m, T, 3, 4))
+
+        // B1 sees y + B0 + self; not A0/A1.
+        #expect(Self.mask(m, T, 4, 0))
+        #expect(!Self.mask(m, T, 4, 1))
+        #expect(!Self.mask(m, T, 4, 2))
+        #expect(Self.mask(m, T, 4, 3))
+        #expect(Self.mask(m, T, 4, 4))
+    }
+}
+
+// MARK: - Position IDs
+
+@Suite
+struct TreePositionIDsTests {
+
+    @Test
+    func `Linear tree position IDs are consecutive`() {
+        let t = DraftTree.linear(tokens: [10, 20, 30])
+        let ids = buildTreePositionIDs(t, previousOffset: 100)
+        #expect(ids == [100, 101, 102, 103])
+    }
+
+    @Test
+    func `Two-branch tree gives siblings the same position ID`() {
+        let t = DraftTree.topKByLinear(chains: [[10, 11], [20, 21]])
+        let ids = buildTreePositionIDs(t, previousOffset: 50)
+        // y at 50; A0 / B0 at 51 (siblings, both depth 1); A1 / B1 at
+        // 52 (depth 2). DFS layout: y, A0, A1, B0, B1.
+        #expect(ids == [50, 51, 52, 51, 52])
+    }
+
+    @Test
+    func `Empty tree position IDs are just the previousOffset`() {
+        let ids = buildTreePositionIDs(.empty, previousOffset: 42)
+        #expect(ids == [42])
+    }
+}
+
+// MARK: - Acceptance walk
+
+@Suite
+struct AcceptDraftTreeTests {
+
+    @Test
+    func `Empty tree accepts zero, bonus is verify position 0`() {
+        let r = acceptDraftTree(.empty, targetArgmax: [99])
+        #expect(r.acceptedCount == 0)
+        #expect(r.bonusVerifyIndex == 0)
+    }
+
+    @Test
+    func `Linear full match accepts every node`() {
+        let t = DraftTree.linear(tokens: [10, 20, 30])
+        // targetArgmax[0]=10 (predicts after y), [1]=20 (after node 0),
+        // [2]=30 (after node 1), [3]=99 (after node 2; bonus).
+        let r = acceptDraftTree(t, targetArgmax: [10, 20, 30, 99])
+        #expect(r.acceptedNodeIndices == [0, 1, 2])
+        #expect(r.bonusVerifyIndex == 3)  // 1 + last accepted
+    }
+
+    @Test
+    func `Linear partial match stops at first mismatch`() {
+        let t = DraftTree.linear(tokens: [10, 20, 30])
+        // Match 10, 20; argmax-after-20 wants 99 but draft has 30.
+        let r = acceptDraftTree(t, targetArgmax: [10, 20, 99, 0])
+        #expect(r.acceptedNodeIndices == [0, 1])
+        #expect(r.bonusVerifyIndex == 2)  // 1 + 1
+    }
+
+    @Test
+    func `Linear no-match accepts zero and bonus is 0`() {
+        let t = DraftTree.linear(tokens: [10, 20, 30])
+        let r = acceptDraftTree(t, targetArgmax: [99, 0, 0, 0])
+        #expect(r.acceptedNodeIndices == [])
+        #expect(r.bonusVerifyIndex == 0)
+    }
+
+    @Test
+    func `Two-branch tree picks the matching branch only`() {
+        // Branch A: [10, 11]; Branch B: [20, 21].
+        let t = DraftTree.topKByLinear(chains: [[10, 11], [20, 21]])
+        // Layout (DFS): A0=10, A1=11, B0=20, B1=21.
+        // targetArgmax: y → 20 (matches B0), then after B0 → 21
+        // (matches B1), then after B1 → 99 (bonus).
+        let r = acceptDraftTree(t, targetArgmax: [20, 0, 0, 21, 99])
+        #expect(r.acceptedNodeIndices == [2, 3])  // B0, B1
+        #expect(r.bonusVerifyIndex == 4)  // 1 + 3
+    }
+
+    @Test
+    func `Two-branch tree descends matching branch then stops at sibling`() {
+        // A: [10, 11]; B: [20, 21]. Match A0 then mismatch on A1.
+        let t = DraftTree.topKByLinear(chains: [[10, 11], [20, 21]])
+        let r = acceptDraftTree(t, targetArgmax: [10, 99, 0, 0, 0])
+        #expect(r.acceptedNodeIndices == [0])
+        #expect(r.bonusVerifyIndex == 1)
+    }
+}


### PR DESCRIPTION
## Summary

Spec 014 phase 1 — pure-Swift primitives for tree-attention speculative decoding.

Tree-attention lets the iterator draft a *tree* of candidate tokens (K branches at each level) and verify the whole tree in one forward pass via a custom attention mask. EAGLE-3-style data shows ~1.6× more accepted tokens per round at K=2, D=4 vs. linear at the same verify-input cost on weight-bandwidth-limited models.

Stack: #113 → #140 → #141 → #142 → #143 → #144 → #145 → #146 → **this PR**.

### What lands

- \`Libraries/MLXLMCommon/DraftTree.swift\`:
  - \`DraftTree\` struct (flat-DFS tokens / parent / depth, init-time invariants).
  - \`DraftTree.linear(tokens:)\` and \`DraftTree.topKByLinear(chains:)\` builders.
  - \`DraftTreeShape\` enum (linear / topKByLinear / bifurcating-on-tight-margin).
  - \`buildTreeAttentionMask(_:)\` — \`[T, T]\` Bool mask (causal × tree-ancestor × y-column × self).
  - \`buildTreePositionIDs(_:previousOffset:)\` — depth-aware; siblings share parent's depth+1.
  - \`acceptDraftTree(_:targetArgmax:)\` — longest-matching-path acceptance walk.

- \`Tests/MLXLMTests/DraftTreeTests.swift\` — 19 tests across four suites: builders (7), mask (3), position IDs (3), acceptance walk (6). All pass.

These primitives are decoder-agnostic — n-gram, DFlash, and Mirror SD will all need a tree representation when they go beyond linear drafts; centralising it here keeps each spec from re-implementing.

### Phase-1 limitations (deferred)

- No MLX-side mask materialisation (phase 2).
- No \`LanguageModel.callAsFunction\` extension to accept caller-supplied position IDs (phase 3).
- No iterator wiring — \`NGramSpeculativeTokenIterator\` still uses linear (phase 2 wires \`topKByLinear\`; phase 4 the full integration + bifurcating).

## Test plan

- [x] \`swift test --filter DraftTree\` — all 19 tests pass.
- [x] Full \`swift build\` clean.
- [ ] (Phase 2) Wire to MLX + iterator; benchmark Gemma 4 26B A4B at K=2, D=4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evaluation (when phase 2+ lands)

**Tree attention (spec 014) eval — phase 2+:** Once the MLX-side attention mask wiring lands and the iterator can verify K=2 root branches in one forward:

```bash
scripts/spec-decode-sweep.sh --model gemma4-26b-a4b --quant 4bit \
    --prompts Tests/Benchmarks/Resources/ngram-sweep-prompts/code-refactor \
    --cells "linear:3:0:,tree-k2:3:0:MLX_NGRAM_TREE_K=2" \
    --trials 5 --output /tmp/tree-treatment.log
scripts/spec-decode-compare.py /tmp/linear.log /tmp/tree-treatment.log
```

**Pass criterion:** +15-25% on input-grounded prompts where PLD already wins (per spec 014 EAGLE-3-style projection).

For the canonical sweep+compare workflow, see `scripts/spec-decode-sweep.sh` and `scripts/spec-decode-compare.py` (added in PR #154). Workload classification + recommended cell-set in `Tests/Benchmarks/Resources/ngram-sweep-prompts/README.md`.