### PR TITLE
feat(spec-decode): spec 019 phase 1 scaffold — PLD+ span selector

### DIFF
--- a/Libraries/MLXLMCommon/AttentionAwareSpanSelector.swift
+++ b/Libraries/MLXLMCommon/AttentionAwareSpanSelector.swift
@@ -1,0 +1,169 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+// MARK: - Attention-aware span selector (spec 019 phase 1 scaffold)
+//
+// Today's `NGramLookup.proposeDraft` tiebreaks multi-candidate matches
+// by recency (most-recent occurrence wins) when more than one prior
+// occurrence has the same n-gram key. PLD+ proposes scoring candidate
+// occurrences by **how likely the model is to "copy from" that position
+// next** — the attention-weighted analog of recency. PLD+'s headline is
+// 30-40% accept-rate improvement on summarisation / QA over plain PLD.
+//
+// Phase 1 (this file) ships:
+//   - `AttentionAwareSpanSelector` protocol — given a list of candidate
+//     occurrence positions and the model's recent hidden states,
+//     return one score per candidate.
+//   - `HiddenStateCosineSelector` — phase-1 scoring uses cosine
+//     similarity of the per-position hidden state vectors at a
+//     configured layer. Works model-agnostic; doesn't need induction-
+//     head identification (phase 2).
+//   - Pure-Swift `cosineSimilarity` helper used by the selector and
+//     unit-tested independently.
+//
+// The model-side `HiddenStateCapture` protocol + per-model conformance
+// land in phase 2 alongside the iterator wiring; this PR is the pure
+// data structures + scoring math.
+
+/// One score per candidate occurrence, indicating how likely the model
+/// is to attend to (or "copy from") that position next. Higher = more
+/// preferred for tiebreaking.
+public protocol AttentionAwareSpanSelector: Sendable {
+    /// - Parameter candidates: list of candidate first-token positions
+    ///   in the lookup history. Each entry is an index into the model's
+    ///   recent token history.
+    /// - Parameter currentPos: the position of the most recently
+    ///   accepted token (the "query position" — what the score is
+    ///   evaluated relative to).
+    /// - Parameter hiddenStates: layer ID → per-position hidden state
+    ///   vectors, shape `[seqLen, hiddenDim]` represented as
+    ///   `[[Float]]`. Phase 1 uses `[Float]` arrays so the protocol is
+    ///   independent of MLX; phase 2 will add an MLX-tensor variant
+    ///   when real model integration lands.
+    /// - Returns: one score per candidate, in the same order. Empty
+    ///   when `candidates` is empty.
+    func score(
+        candidates: [Int],
+        currentPos: Int,
+        hiddenStates: [Int: [[Float]]]
+    ) -> [Float]
+}
+
+/// Phase-1 selector — cosine similarity between the hidden-state
+/// vectors at `candidates[i]` and `currentPos` at the configured
+/// layer. Works without induction-head identification; PLD+'s ablation
+/// shows layers 9-13 work best across model sizes (the spec defaults
+/// us to 11 — middle of most pretrained transformers).
+public struct HiddenStateCosineSelector: AttentionAwareSpanSelector {
+    public let layerID: Int
+
+    public init(layerID: Int = 11) {
+        precondition(layerID >= 0, "layerID must be >= 0 (got \(layerID))")
+        self.layerID = layerID
+    }
+
+    public func score(
+        candidates: [Int],
+        currentPos: Int,
+        hiddenStates: [Int: [[Float]]]
+    ) -> [Float] {
+        guard let layer = hiddenStates[layerID] else {
+            // Layer not captured — return zero scores; caller falls
+            // back to recency tiebreak.
+            return [Float](repeating: 0, count: candidates.count)
+        }
+        guard currentPos > 0, currentPos - 1 < layer.count else {
+            return [Float](repeating: 0, count: candidates.count)
+        }
+        let queryVec = layer[currentPos - 1]
+        return candidates.map { j -> Float in
+            guard j > 0, j - 1 < layer.count else { return 0 }
+            let candVec = layer[j - 1]
+            return cosineSimilarity(queryVec, candVec)
+        }
+    }
+}
+
+/// Recency-tiebreak selector — drop-in default that returns the same
+/// scores PLD's existing tiebreaker would produce (more recent = higher
+/// score, so identical to today's behavior). Lets call sites adopt the
+/// `AttentionAwareSpanSelector` protocol uniformly without flipping
+/// PLD+'s actual scoring on for everyone.
+public struct RecencyTiebreakSelector: AttentionAwareSpanSelector {
+    public init() {}
+    public func score(
+        candidates: [Int],
+        currentPos: Int,
+        hiddenStates: [Int: [[Float]]]
+    ) -> [Float] {
+        candidates.map { Float($0) }
+    }
+}
+
+/// Test stub — returns a fixed mapping from candidate position to score.
+public struct ScriptedSpanSelector: AttentionAwareSpanSelector {
+    public let scoreMap: [Int: Float]
+    public let defaultScore: Float
+
+    public init(scoreMap: [Int: Float], defaultScore: Float = 0) {
+        self.scoreMap = scoreMap
+        self.defaultScore = defaultScore
+    }
+
+    public func score(
+        candidates: [Int],
+        currentPos: Int,
+        hiddenStates: [Int: [[Float]]]
+    ) -> [Float] {
+        candidates.map { scoreMap[$0] ?? defaultScore }
+    }
+}
+
+// MARK: - Cosine similarity (pure-Swift)
+
+/// Cosine similarity of two `[Float]` vectors. Returns 0 when either
+/// vector has zero magnitude (the geometrically degenerate case) — this
+/// is the same convention as `MLXNN.cosineSimilarity` and avoids
+/// returning NaN to callers.
+///
+/// - Precondition: `a.count == b.count`. Mismatched-length vectors are a
+///   programmer error in this context (different layer outputs at the
+///   same model would always be the same dim); we trap rather than
+///   silently truncate.
+public func cosineSimilarity(_ a: [Float], _ b: [Float]) -> Float {
+    precondition(a.count == b.count,
+        "cosineSimilarity: lengths differ (\(a.count) vs \(b.count))")
+    if a.isEmpty { return 0 }
+    var dot: Float = 0
+    var sa: Float = 0
+    var sb: Float = 0
+    for i in 0 ..< a.count {
+        dot += a[i] * b[i]
+        sa += a[i] * a[i]
+        sb += b[i] * b[i]
+    }
+    let denom = (sa * sb).squareRoot()
+    if denom == 0 { return 0 }
+    return dot / denom
+}
+
+/// Pick the highest-scoring candidate. Returns nil when `candidates` is
+/// empty. Ties are broken by `candidates`-order (first-wins) — matches
+/// `[Float].max`'s behaviour on equal values.
+public func pickBestCandidate(
+    candidates: [Int],
+    scores: [Float]
+) -> Int? {
+    precondition(candidates.count == scores.count,
+        "candidates and scores must have the same count "
+            + "(got \(candidates.count) vs \(scores.count))")
+    guard !candidates.isEmpty else { return nil }
+    var bestIdx = 0
+    var bestScore = scores[0]
+    for i in 1 ..< scores.count where scores[i] > bestScore {
+        bestScore = scores[i]
+        bestIdx = i
+    }
+    return candidates[bestIdx]
+}

--- a/Tests/MLXLMTests/AttentionAwareSpanSelectorTests.swift
+++ b/Tests/MLXLMTests/AttentionAwareSpanSelectorTests.swift
@@ -1,0 +1,195 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+@testable import MLXLMCommon
+import Testing
+
+// MARK: - PLD+ attention-aware span selector tests (spec 019 phase 1)
+//
+// Pure-Swift; no MLX evaluation. Phase 1 covers:
+//   - `cosineSimilarity` math correctness on identical / orthogonal /
+//     opposite / zero-vector / mixed-magnitude inputs.
+//   - `pickBestCandidate` selection + tie semantics.
+//   - `HiddenStateCosineSelector` end-to-end with synthetic hidden
+//     states.
+//   - `RecencyTiebreakSelector` matches today's PLD behaviour.
+//   - `ScriptedSpanSelector` returns prescribed scores; default applies.
+
+@Suite
+struct CosineSimilarityTests {
+
+    @Test
+    func `Identical vectors return 1`() {
+        #expect(abs(cosineSimilarity([1, 2, 3], [1, 2, 3]) - 1.0) < 1e-6)
+    }
+
+    @Test
+    func `Opposite vectors return -1`() {
+        #expect(abs(cosineSimilarity([1, 2, 3], [-1, -2, -3]) + 1.0) < 1e-6)
+    }
+
+    @Test
+    func `Orthogonal vectors return 0`() {
+        #expect(abs(cosineSimilarity([1, 0], [0, 1])) < 1e-6)
+    }
+
+    @Test
+    func `Zero magnitude returns 0 (no NaN)`() {
+        #expect(cosineSimilarity([0, 0, 0], [1, 2, 3]) == 0)
+        #expect(cosineSimilarity([1, 2, 3], [0, 0, 0]) == 0)
+        #expect(cosineSimilarity([0, 0], [0, 0]) == 0)
+    }
+
+    @Test
+    func `Empty vectors return 0`() {
+        #expect(cosineSimilarity([], []) == 0)
+    }
+
+    @Test
+    func `Magnitude does not affect cosine`() {
+        let a: [Float] = [1, 2, 3]
+        let b: [Float] = [10, 20, 30]
+        #expect(abs(cosineSimilarity(a, b) - 1.0) < 1e-6)
+    }
+}
+
+// MARK: - Best-candidate picker
+
+@Suite
+struct PickBestCandidateTests {
+
+    @Test
+    func `Empty input returns nil`() {
+        #expect(pickBestCandidate(candidates: [], scores: []) == nil)
+    }
+
+    @Test
+    func `Picks highest-scoring candidate`() {
+        let cands = [10, 20, 30]
+        let scores: [Float] = [0.1, 0.9, 0.5]
+        #expect(pickBestCandidate(candidates: cands, scores: scores) == 20)
+    }
+
+    @Test
+    func `Tie breaks on first-wins`() {
+        let cands = [10, 20, 30]
+        let scores: [Float] = [0.5, 0.5, 0.5]
+        #expect(pickBestCandidate(candidates: cands, scores: scores) == 10)
+    }
+
+    @Test
+    func `Single candidate returns itself`() {
+        #expect(pickBestCandidate(candidates: [42], scores: [0.0]) == 42)
+    }
+}
+
+// MARK: - HiddenStateCosineSelector
+
+@Suite
+struct HiddenStateCosineSelectorTests {
+
+    @Test
+    func `Returns zero scores when layer not captured`() {
+        let s = HiddenStateCosineSelector(layerID: 11)
+        let scores = s.score(
+            candidates: [1, 2, 3],
+            currentPos: 5,
+            hiddenStates: [:])  // empty
+        #expect(scores == [0, 0, 0])
+    }
+
+    @Test
+    func `Returns zero scores when currentPos is invalid`() {
+        let s = HiddenStateCosineSelector(layerID: 11)
+        let layer: [[Float]] = [[1, 0], [0, 1]]
+        // currentPos = 0 → currentPos - 1 = -1, invalid.
+        let scores = s.score(
+            candidates: [1, 2],
+            currentPos: 0,
+            hiddenStates: [11: layer])
+        #expect(scores == [0, 0])
+    }
+
+    @Test
+    func `Identical hidden states score 1`() {
+        let s = HiddenStateCosineSelector(layerID: 11)
+        let layer: [[Float]] = [
+            [1, 2, 3],  // pos 0
+            [1, 2, 3],  // pos 1 — same as pos 0
+            [4, 5, 6],  // pos 2 — different
+        ]
+        // currentPos = 2 → query = layer[1] = [1,2,3].
+        // Candidate 1 → layer[0] = [1,2,3] — identical, score 1.
+        // Candidate 3 → layer[2] = [4,5,6] — different.
+        let scores = s.score(
+            candidates: [1, 3],
+            currentPos: 2,
+            hiddenStates: [11: layer])
+        #expect(abs(scores[0] - 1.0) < 1e-6)
+        #expect(scores[1] < 1.0)
+        #expect(scores[1] > 0)  // non-trivial cosine
+    }
+
+    @Test
+    func `Out-of-range candidate position scores zero`() {
+        let s = HiddenStateCosineSelector(layerID: 11)
+        let layer: [[Float]] = [[1, 2], [3, 4]]
+        // Candidate 99 is out of range.
+        let scores = s.score(
+            candidates: [1, 99],
+            currentPos: 2,
+            hiddenStates: [11: layer])
+        #expect(scores[0] != 0)  // valid
+        #expect(scores[1] == 0)  // out of range → 0
+    }
+}
+
+// MARK: - RecencyTiebreakSelector
+
+@Suite
+struct RecencyTiebreakSelectorTests {
+
+    @Test
+    func `Score equals candidate position (recency-monotone)`() {
+        let s = RecencyTiebreakSelector()
+        let scores = s.score(
+            candidates: [10, 25, 100],
+            currentPos: 200,
+            hiddenStates: [:])
+        #expect(scores == [10, 25, 100])
+    }
+
+    @Test
+    func `Most recent candidate wins through pickBestCandidate`() {
+        let s = RecencyTiebreakSelector()
+        let cands = [10, 25, 100]
+        let scores = s.score(candidates: cands, currentPos: 200, hiddenStates: [:])
+        #expect(pickBestCandidate(candidates: cands, scores: scores) == 100)
+    }
+}
+
+// MARK: - ScriptedSpanSelector
+
+@Suite
+struct ScriptedSpanSelectorTests {
+
+    @Test
+    func `Returns scripted scores in candidate order`() {
+        let s = ScriptedSpanSelector(scoreMap: [10: 0.9, 20: 0.5, 30: 0.1])
+        let scores = s.score(
+            candidates: [30, 10, 20],
+            currentPos: 0,
+            hiddenStates: [:])
+        #expect(scores == [0.1, 0.9, 0.5])
+    }
+
+    @Test
+    func `Unmapped candidates use defaultScore`() {
+        let s = ScriptedSpanSelector(scoreMap: [10: 0.9], defaultScore: -1)
+        let scores = s.score(
+            candidates: [10, 99, 20],
+            currentPos: 0,
+            hiddenStates: [:])
+        #expect(scores == [0.9, -1, -1])
+    }
+}


### PR DESCRIPTION
## Summary

Spec 019 phase 1 scaffold — PLD+ attention-aware span selector. PLD+'s headline is 30-40% accept-rate improvement over plain PLD on summarisation / QA workloads.

Stack: #113 → #140 → #141 → #142 → #143 → #144 → #145 → #146 → #147 → **this PR**.

### What lands

- \`Libraries/MLXLMCommon/AttentionAwareSpanSelector.swift\`:
  - \`AttentionAwareSpanSelector\` protocol.
  - \`HiddenStateCosineSelector\` — cosine over per-position hidden state vectors at a configured layer (default 11 per PLD+ ablation).
  - \`RecencyTiebreakSelector\` — drop-in for today's behaviour, lets call sites adopt the protocol uniformly.
  - \`ScriptedSpanSelector\` — test stub.
  - \`cosineSimilarity(_:_:)\` and \`pickBestCandidate(candidates:scores:)\` helpers.

- \`Tests/MLXLMTests/AttentionAwareSpanSelectorTests.swift\` — 18 tests:
  - \`CosineSimilarityTests\` (6): identical / opposite / orthogonal / zero-magnitude / empty / magnitude-invariance.
  - \`PickBestCandidateTests\` (4): empty / highest / tie-first-wins / single.
  - \`HiddenStateCosineSelectorTests\` (4): missing layer / invalid currentPos / identical / out-of-range.
  - \`RecencyTiebreakSelectorTests\` (2).
  - \`ScriptedSpanSelectorTests\` (2).

All 18 pass. Pure-Swift, no MLX eval.

### Phase-1 limitations (deferred)

- No \`HiddenStateCapture\` model-side hook (phase 2).
- No induction-head identification (phase 2).
- No iterator wiring (phase 2).

The \`[[Float]]\` per-position vector representation lets phase 1 ship without coupling to MLX tensors; phase 2 will add an \`MLXArray\` → \`[[Float]]\` converter when real model hidden states flow through.

## Test plan

- [x] \`swift test --filter Cosine|HiddenStateCosine|Recency|ScriptedSpan|PickBest\` — all 18 pass.
- [x] Full \`swift build\` clean.
- [ ] (Phase 2) Wire \`NGramLookup.proposeDraft\` multi-candidate tiebreak through the selector behind \`MLX_NGRAM_PLDPLUS=1\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evaluation (when phase 2+ lands)

**PLD+ attention-weighted spans (spec 019) eval — phase 2+:** Once the per-model `HiddenStateCapture` conformance lands and the iterator tiebreaks via cosine on hidden states:

```bash
scripts/spec-decode-sweep.sh --model gemma4-26b-a4b --quant 4bit \
    --prompts Tests/Benchmarks/Resources/ngram-sweep-prompts/qa-requote \
    --cells "recency:3:0:,pld-plus:3:0:MLX_NGRAM_PLDPLUS=1" \
    --trials 5 --output /tmp/pld-plus-treatment.log
scripts/spec-decode-compare.py /tmp/recency.log /tmp/pld-plus-treatment.log
```

**Pass criterion:** higher accept rate on multi-candidate hits (per spec 019 PLD+ paper); +5-15% combined when stacked with tree attention (spec 014).

For the canonical sweep+compare workflow, see `scripts/spec-decode-sweep.sh` and `scripts/spec-decode-compare.py` (added in PR #154). Workload classification + recommended cell-set in `Tests/Benchmarks/Resources/ngram-sweep-prompts/README.md`.