### PR TITLE
feat(kvcache): RotatingKVCache.reserve(_:) opt-in workload-size hint

### DIFF
--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -549,6 +549,13 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     private var maxCacheSize: Int
     private var step: Int
     private var idx: Int = 0
+    /// Optional first-allocation size hint set via ``reserve(_:)``. When set,
+    /// the first write allocates `[B, kvHeads, hint, headDim]` upfront
+    /// instead of growing in `step`-sized chunks. Eliminates the per-chunk
+    /// `concatenated` transient surge for callers that know their workload
+    /// size up front (most generation: `prompt + maxTokens`). Capped to
+    /// `maxCacheSize`. `nil` falls back to step-based growth.
+    private var initialAllocSize: Int?
 
     /// Last K/V returned from update() — used by Gemma 4 KV sharing.
     public var lastReturnedKeys: MLXArray?
@@ -561,6 +568,31 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
         self.keep = keep
         self.step = step
         super.init()
+    }
+
+    /// **Opt-in** hint about the expected total token count for this run
+    /// (typically `prompt_length + maxTokens`). Triggers a single up-front
+    /// allocation on the first write instead of step-incremental growth,
+    /// eliminating the per-chunk `concatenated` transient that the lazy path
+    /// produces during multi-token prefill.
+    ///
+    /// - Idempotent: only takes effect before the cache has been written
+    ///   to. After first write, this is a no-op.
+    /// - Cap: clamped to `maxCacheSize`. The cache can still grow past the
+    ///   hint up to `maxCacheSize` if the workload exceeds it (falls back
+    ///   to step-based growth at that point).
+    /// - Floor: never allocates less than `step` (small hints are rounded up).
+    /// - When never called: behaviour is unchanged from the step-incremental
+    ///   default — that's the path callers get by default.
+    ///
+    /// Most useful when `maxKVSize` is set generously (e.g. a model's full
+    /// context window) but the actual workload uses only a fraction — the
+    /// hint sizes the buffer to the workload instead of either growing
+    /// incrementally or pre-allocating the full window.
+    public func reserve(_ size: Int) {
+        guard self.keys == nil else { return }
+        guard size > 0 else { return }
+        initialAllocSize = max(step, min(size, maxCacheSize))
     }
 
     public override func innerState() -> [MLXArray] {
@@ -639,11 +671,27 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
         let vHeadDim = values.dim(3)
         let prev = offset
 
-        // May not have hit the max size yet, so potentially keep growing the cache
+        // Allocate or grow when:
+        //   * The buffer hasn't been created yet, OR
+        //   * The incoming write doesn't fit in the current buffer and we
+        //     haven't reached `maxCacheSize`.
+        // The growth condition uses `prev + S` rather than just `prev` so
+        // multi-token writes (S > 1, e.g. prefill chunks) trigger growth
+        // when needed — the legacy `prev >= buffer.dim(2)` check only
+        // worked for single-token decode writes.
         if self.keys == nil
-            || (prev >= self.keys!.dim(2) && self.keys!.dim(2) < maxCacheSize)
+            || (prev + S > self.keys!.dim(2) && self.keys!.dim(2) < maxCacheSize)
         {
-            let newSize = min(step, maxCacheSize - prev)
+            // First-time allocation respects the `reserve` hint when set, but
+            // never falls below `S` (the incoming write must fit). Subsequent
+            // growth uses `step` and slots between buffer-end and maxCacheSize.
+            let newSize: Int
+            if self.keys == nil {
+                let target = initialAllocSize.map { max($0, S) } ?? max(step, S)
+                newSize = min(target, maxCacheSize - prev)
+            } else {
+                newSize = min(max(step, S), maxCacheSize - self.keys!.dim(2))
+            }
 
             let kShape = [B, nKVHeads, newSize, kHeadDim]
             let vShape = [B, nKVHeads, newSize, vHeadDim]
@@ -690,8 +738,16 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     }
 
     public override func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        // When `reserve` was called, route multi-token writes through
+        // `updateInPlace` too. Its first allocation is already sized for the
+        // workload, so writes go straight into the pre-allocated buffer
+        // without the `updateConcat` per-chunk `concatenated` surge that
+        // compounds at B>1 long-context prefill. Without `reserve`, keep the
+        // legacy split: single-token decode is in-place, multi-token prefill
+        // builds the buffer via `updateConcat`.
+        let useInPlace = keys.dim(2) == 1 || initialAllocSize != nil
         let result =
-            if keys.dim(2) == 1 {
+            if useInPlace {
                 updateInPlace(keys: keys, values: values)
             } else {
                 updateConcat(keys: keys, values: values)

--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ Set on the `GenerateParameters` struct passed to `generate(...)`. Defaults shown
 |---|---|---|
 | `TurboQuantKVCache.useCompressedAttention` | `true` | **B path is the default as of [`c5ca7a3`](https://github.com/ekryski/mlx-swift-lm/commit/c5ca7a3).** Decode runs the fused bulk-dequant Metal kernel + `MLXFast.scaledDotProductAttention` on the compressed cache — within ~3% of `--kv none` on Qwen 9B and faster than `--kv none` at short context. Set the constructor flag to `false` (or use the env override below) for the historic A path that keeps a raw fp16 cache. |
 | `BatchedKVCache.maxBatch` | constructor arg | Max simultaneous decode streams sharing one cache. Must match the request shape. |
+| `RotatingKVCache.reserve(_:)` | not called | **Opt-in workload-size hint.** Pre-allocates the rotating buffer to a known size up front (typically `prompt_length + maxTokens`) instead of growing in `step`-sized chunks (default `step=256`). Idempotent: only takes effect before the first write. Clamped to `maxCacheSize`, floored at `step`. Most useful when `maxKVSize` is generous (e.g. a model's full context window) but the actual workload uses only a fraction — the hint sizes the buffer to the workload instead of growing incrementally or pre-allocating the full window. Behaviour is unchanged when never called. <br/>`let cache = RotatingKVCache(maxSize: 4096)` <br/>`cache.reserve(promptLen + maxTokens)` |
 
 ### Environment variable overrides
 

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -223,6 +223,231 @@ func testRotatingKVCacheReserveGrowsOnOverflow() async throws {
     #expect(cache.innerState()[0].dim(2) >= 256 + 384)
 }
 
+// MARK: - RotatingKVCache under-utilisation + rotation regression coverage
+//
+// Independent of `reserve(_:)` — covers the path the existing 11 tests in
+// KVCacheTests.swift never exercised: step-incremental growth without
+// rotation, and the rotation/wrap behaviour past `maxCacheSize`. Locks the
+// existing semantics so refactors (incl. the spec 006 consolidation into
+// `StandardKVCache`) can prove byte-identical behaviour.
+
+@Test("RotatingKVCache step-incremental growth (under-util, no reserve)")
+func testRotatingKVCacheUnderUtilisationStepGrowth() async throws {
+    // Push 1024 single-token writes. With default step=256 and maxSize=4096
+    // the buffer should grow 256 → 512 → 768 → 1024, never reaching 4096.
+    let cache = RotatingKVCache(maxSize: 4096, step: 256)
+    let token = MLXArray.ones([1, 8, 1, 128], dtype: .bfloat16)
+    for _ in 0 ..< 1024 {
+        _ = cache.update(keys: token, values: token)
+    }
+    #expect(cache.offset == 1024)
+    // Buffer should be 1024 (last step boundary), not full maxCacheSize.
+    #expect(cache.innerState()[0].dim(2) == 1024)
+    #expect(cache.innerState()[0].dim(2) < 4096)
+}
+
+@Test("RotatingKVCache stays trimmable while under maxCacheSize (no eviction)")
+func testRotatingKVCacheUnderUtilisationNoEviction() async throws {
+    // After 1024 writes (< maxSize=4096), the cache should still be in the
+    // pre-rotation phase: isTrimmable=true and offset advances normally.
+    let cache = RotatingKVCache(maxSize: 4096, step: 256)
+    let token = MLXArray.ones([1, 8, 1, 128], dtype: .bfloat16)
+    for _ in 0 ..< 1024 {
+        _ = cache.update(keys: token, values: token)
+    }
+    #expect(cache.isTrimmable == true)
+    // metaState layout: [keep, maxCacheSize, step, offset, idx]
+    #expect(cache.metaState[3] == "1024")
+    let idx = Int(cache.metaState[4])!
+    #expect(idx == 1024)
+    #expect(idx < 4096)
+}
+
+@Test("RotatingKVCache dispatcher unchanged when reserve() is unused")
+func testRotatingKVCacheNoReserveDispatcherUnchanged() async throws {
+    // Locks the back-compat guarantee: when initialAllocSize == nil, the
+    // dispatcher should route S=1 → updateInPlace (step-sized buffer) and
+    // S>1 → updateConcat (buffer == S). Pre-PR behaviour, byte-identical.
+    let single = RotatingKVCache(maxSize: 4096, step: 256)
+    let oneToken = MLXArray.ones([1, 8, 1, 128], dtype: .bfloat16)
+    _ = single.update(keys: oneToken, values: oneToken)
+    // S=1 path: in-place, step-sized buffer.
+    #expect(single.innerState()[0].dim(2) == 256)
+
+    let multi = RotatingKVCache(maxSize: 4096, step: 256)
+    let sixteenTokens = MLXArray.ones([1, 8, 16, 128], dtype: .bfloat16)
+    _ = multi.update(keys: sixteenTokens, values: sixteenTokens)
+    // S>1 path with no reserve: concat — buffer matches the chunk size, not step.
+    #expect(multi.innerState()[0].dim(2) == 16)
+}
+
+@Test("RotatingKVCache rotation kicks in past maxCacheSize")
+func testRotatingKVCacheRotationKicksInPastMax() async throws {
+    // Push 96 single-token writes through a maxSize=64 cache. Rotation
+    // should engage: buffer stays at 64, offset keeps counting upward, peek()
+    // returns the live window in temporal order.
+    let cache = RotatingKVCache(maxSize: 64, step: 16)
+    let token = MLXArray.ones([1, 8, 1, 128], dtype: .bfloat16)
+    for _ in 0 ..< 96 {
+        _ = cache.update(keys: token, values: token)
+    }
+    #expect(cache.offset == 96)
+    #expect(cache.innerState()[0].dim(2) == 64)
+    #expect(cache.isTrimmable == false)
+    let peeked = cache.peek()
+    #expect(peeked != nil)
+    #expect(peeked!.0.dim(2) == 64)
+}
+
+@Test("RotatingKVCache rotation works correctly with reserve()")
+func testRotatingKVCacheRotationWithReserve() async throws {
+    // reserve(maxCacheSize) → pre-allocate full window; then write 2× max
+    // tokens. Buffer stays at maxCacheSize; rotation engages exactly once.
+    let maxSize = 64
+    let cache = RotatingKVCache(maxSize: maxSize, step: 16)
+    cache.reserve(maxSize)
+
+    let token = MLXArray.ones([1, 8, 1, 128], dtype: .bfloat16)
+    for _ in 0 ..< (2 * maxSize) {
+        _ = cache.update(keys: token, values: token)
+    }
+
+    #expect(cache.offset == 2 * maxSize)
+    #expect(cache.innerState()[0].dim(2) == maxSize)
+    // idx should have wrapped (idx != offset means rotation occurred).
+    let idx = Int(cache.metaState[4])!
+    #expect(idx != cache.offset)
+    #expect(idx <= maxSize)
+}
+
+@Test("RotatingKVCache reserve respects keep across rotation")
+func testRotatingKVCacheReserveWithKeepRotation() async throws {
+    // With keep=4, the first 4 slots must be preserved across rotation.
+    // Write distinguishable sentinels into the keep region by going through
+    // ones-only and then zeros-only writes; after rotation the keep region
+    // should still hold the original ones.
+    let cache = RotatingKVCache(maxSize: 32, keep: 4, step: 8)
+    cache.reserve(64)  // clamped to 32
+
+    // First 4 writes: ones (these populate the keep region).
+    let onesToken = MLXArray.ones([1, 8, 1, 128], dtype: .bfloat16)
+    for _ in 0 ..< 4 {
+        _ = cache.update(keys: onesToken, values: onesToken)
+    }
+    // Next 60 writes: zeros (force rotation by exceeding maxCacheSize).
+    let zerosToken = MLXArray.zeros([1, 8, 1, 128], dtype: .bfloat16)
+    for _ in 0 ..< 60 {
+        _ = cache.update(keys: zerosToken, values: zerosToken)
+    }
+
+    #expect(cache.offset == 64)
+    #expect(cache.innerState()[0].dim(2) == 32)
+    // Keep region: positions 0..<4 of the buffer should still be the ones
+    // we wrote — rotation overwrites slots in [keep, maxSize) only.
+    let buffer = cache.innerState()[0]
+    let keepSlice = buffer[.ellipsis, ..<4, 0...]
+    let expected = MLXArray.ones([1, 8, 4, 128], dtype: .bfloat16)
+    eval(keepSlice, expected)
+    #expect(allClose(keepSlice, expected).item(Bool.self))
+}
+
+@Test("RotatingKVCache reserve(maxCacheSize) — exact boundary")
+func testRotatingKVCacheReserveExactMaxBoundary() async throws {
+    // reserve at exactly maxCacheSize: first allocation should be the full
+    // buffer; subsequent writes up to maxCacheSize should not trigger any
+    // re-allocation.
+    let maxSize = 256
+    let cache = RotatingKVCache(maxSize: maxSize, step: 64)
+    cache.reserve(maxSize)
+
+    let chunk = MLXArray.ones([1, 8, 64, 128], dtype: .bfloat16)
+    _ = cache.update(keys: chunk, values: chunk)
+    #expect(cache.innerState()[0].dim(2) == maxSize)
+
+    // Three more 64-token chunks should fit without growth.
+    for _ in 0 ..< 3 {
+        _ = cache.update(keys: chunk, values: chunk)
+    }
+    #expect(cache.innerState()[0].dim(2) == maxSize)
+    #expect(cache.offset == maxSize)
+}
+
+@Test("RotatingKVCache reserve(0) and negative are no-ops")
+func testRotatingKVCacheReserveZeroAndNegativeNoOp() async throws {
+    // reserve(0) and reserve(-N) should be silent no-ops. First write should
+    // produce a step-sized buffer (the legacy default), proving
+    // initialAllocSize stayed nil.
+    let zeroCache = RotatingKVCache(maxSize: 4096, step: 256)
+    zeroCache.reserve(0)
+    let token = MLXArray.ones([1, 8, 1, 128], dtype: .bfloat16)
+    _ = zeroCache.update(keys: token, values: token)
+    #expect(zeroCache.innerState()[0].dim(2) == 256)
+
+    let negativeCache = RotatingKVCache(maxSize: 4096, step: 256)
+    negativeCache.reserve(-5)
+    _ = negativeCache.update(keys: token, values: token)
+    #expect(negativeCache.innerState()[0].dim(2) == 256)
+}
+
+@Test("RotatingKVCache reserve scales with batch dim B>1")
+func testRotatingKVCacheReserveBatchedB2() async throws {
+    // reserve(_:) controls dimension 2 (token dim); batch dim should be
+    // inferred from the first write. Run B=2 and B=4 to confirm.
+    let cacheB2 = RotatingKVCache(maxSize: 4096, step: 256)
+    cacheB2.reserve(800)
+    let chunkB2 = MLXArray.ones([2, 8, 64, 128], dtype: .bfloat16)
+    _ = cacheB2.update(keys: chunkB2, values: chunkB2)
+    #expect(cacheB2.innerState()[0].shape == [2, 8, 800, 128])
+
+    let cacheB4 = RotatingKVCache(maxSize: 4096, step: 256)
+    cacheB4.reserve(800)
+    let chunkB4 = MLXArray.ones([4, 8, 64, 128], dtype: .bfloat16)
+    _ = cacheB4.update(keys: chunkB4, values: chunkB4)
+    #expect(cacheB4.innerState()[0].shape == [4, 8, 800, 128])
+}
+
+@Test("RotatingKVCache reserve allocates once for chunked writes within hint")
+func testRotatingKVCacheReserveAllocationOnceOnly() async throws {
+    // reserve(2048) + three 256-token chunks (768 total) → buffer should
+    // remain at 2048 after every write. Proxy for "no concat happened".
+    let cache = RotatingKVCache(maxSize: 4096, step: 256)
+    cache.reserve(2048)
+
+    let chunk = MLXArray.ones([1, 8, 256, 128], dtype: .bfloat16)
+    for _ in 0 ..< 3 {
+        _ = cache.update(keys: chunk, values: chunk)
+        #expect(cache.innerState()[0].dim(2) == 2048)
+    }
+    #expect(cache.offset == 768)
+}
+
+@Test("RotatingKVCache no-reserve back-compat: full grow + rotate cycle")
+func testRotatingKVCacheBackcompatExistingPath() async throws {
+    // Smoke-test the legacy growth + rotation path with default settings.
+    // Push 33 single-token writes through maxSize=32, default step=256.
+    // Step gets clamped against maxSize-prev so the buffer grows to 32 then
+    // rotation engages on the 33rd write.
+    let cache = RotatingKVCache(maxSize: 32)
+    let token = MLXArray.ones([1, 8, 1, 128], dtype: .bfloat16)
+
+    for _ in 0 ..< 32 {
+        _ = cache.update(keys: token, values: token)
+    }
+    // Pre-rotation: buffer at maxSize, offset == maxSize.
+    #expect(cache.offset == 32)
+    #expect(cache.innerState()[0].dim(2) == 32)
+
+    // 33rd write triggers rotation.
+    _ = cache.update(keys: token, values: token)
+    #expect(cache.offset == 33)
+    #expect(cache.innerState()[0].dim(2) == 32)
+    #expect(cache.isTrimmable == false)
+    // peek() should still return the maxSize window in temporal order.
+    let peeked = cache.peek()
+    #expect(peeked != nil)
+    #expect(peeked!.0.dim(2) == 32)
+}
+
 /// CacheList.copy() produces independent sub-caches.
 @Test
 func testCacheListCopyIsIndependent() async throws {

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -131,6 +131,98 @@ func testCacheCopyOnEmptyCache(creator: (() -> any KVCache)) async throws {
     #expect(copied.state.count == empty.state.count)
 }
 
+// MARK: - RotatingKVCache.reserve regression coverage
+
+@Test("RotatingKVCache.reserve preallocates the buffer to the hinted size")
+func testRotatingKVCacheReservePreallocates() async throws {
+    let cache = RotatingKVCache(maxSize: 4096, step: 256)
+    cache.reserve(800)
+
+    let keys = MLXArray.ones([1, 8, 64, 128], dtype: .bfloat16)
+    _ = cache.update(keys: keys, values: keys)
+
+    // Buffer should be 800 (the hint, capped above step), not 256 (default step).
+    #expect(cache.innerState()[0].shape == [1, 8, 800, 128])
+}
+
+@Test("RotatingKVCache.reserve is no-op after first write")
+func testRotatingKVCacheReserveIsIdempotentAfterWrite() async throws {
+    let cache = RotatingKVCache(maxSize: 4096, step: 256)
+    let keys = MLXArray.ones([1, 8, 64, 128], dtype: .bfloat16)
+    _ = cache.update(keys: keys, values: keys)
+
+    // Cache already populated with step-sized buffer; reserve should not retroactively grow it.
+    let originalSize = cache.innerState()[0].dim(2)
+    cache.reserve(2048)
+    #expect(cache.innerState()[0].dim(2) == originalSize)
+}
+
+@Test("RotatingKVCache.reserve clamps to maxCacheSize")
+func testRotatingKVCacheReserveClampsToMax() async throws {
+    let cache = RotatingKVCache(maxSize: 256, step: 64)
+    cache.reserve(10000)  // way over maxCacheSize
+
+    let keys = MLXArray.ones([1, 8, 32, 128], dtype: .bfloat16)
+    _ = cache.update(keys: keys, values: keys)
+
+    #expect(cache.innerState()[0].dim(2) == 256)
+}
+
+@Test("RotatingKVCache.reserve floor: at least step")
+func testRotatingKVCacheReserveFloorIsStep() async throws {
+    let cache = RotatingKVCache(maxSize: 4096, step: 256)
+    cache.reserve(100)  // smaller than step
+
+    let keys = MLXArray.ones([1, 8, 32, 128], dtype: .bfloat16)
+    _ = cache.update(keys: keys, values: keys)
+
+    // Buffer should be at least step (256) even though hint was 100.
+    #expect(cache.innerState()[0].dim(2) >= 256)
+}
+
+@Test("RotatingKVCache.reserve buffer fits multi-token writes within hint")
+func testRotatingKVCacheReserveFitsPrefillChunks() async throws {
+    // Simulates the typical iterator wiring: hint = prompt + maxTokens, then
+    // multi-token prefill writes the prompt in chunks. Each chunk must land
+    // in the pre-allocated buffer without triggering a grow.
+    let cache = RotatingKVCache(maxSize: 4096, step: 256)
+    let promptLen = 1024
+    let maxTokens = 128
+    cache.reserve(promptLen + maxTokens)
+
+    // Two prefill chunks of 512 each.
+    let chunk1 = MLXArray.ones([1, 8, 512, 128], dtype: .bfloat16)
+    let chunk2 = MLXArray.zeros([1, 8, 512, 128], dtype: .bfloat16)
+
+    _ = cache.update(keys: chunk1, values: chunk1)
+    _ = cache.update(keys: chunk2, values: chunk2)
+
+    // After both writes, the buffer should still be the originally allocated size
+    // (no growth needed) and the offset should reflect both writes.
+    #expect(cache.offset == 1024)
+    #expect(cache.innerState()[0].dim(2) == promptLen + maxTokens)
+}
+
+@Test("RotatingKVCache.reserve grows past hint when workload exceeds it")
+func testRotatingKVCacheReserveGrowsOnOverflow() async throws {
+    // If the actual workload exceeds the hinted size, the cache should fall
+    // back to step-based growth — the hint isn't a hard cap, just a
+    // first-allocation size.
+    let cache = RotatingKVCache(maxSize: 4096, step: 256)
+    cache.reserve(512)
+
+    // First chunk fits in the hint.
+    let chunk1 = MLXArray.ones([1, 8, 256, 128], dtype: .bfloat16)
+    _ = cache.update(keys: chunk1, values: chunk1)
+    #expect(cache.innerState()[0].dim(2) == 512)
+
+    // Second chunk overflows the 512-token hint and must grow the buffer.
+    let chunk2 = MLXArray.zeros([1, 8, 384, 128], dtype: .bfloat16)
+    _ = cache.update(keys: chunk2, values: chunk2)
+    #expect(cache.offset == 256 + 384)
+    #expect(cache.innerState()[0].dim(2) >= 256 + 384)
+}
+
 /// CacheList.copy() produces independent sub-caches.
 @Test
 func testCacheListCopyIsIndependent() async throws {


### PR DESCRIPTION
## Summary

Adds a public `reserve(_ size: Int)` method to `RotatingKVCache` that lets callers preallocate the cache buffer to a known size up-front instead of growing in `step`-sized chunks.

```swift
let cache = RotatingKVCache(maxSize: 4096)
cache.reserve(promptLen + maxTokens)
```

The hint is most useful when `maxKVSize` is set generously (e.g. a model's full 128k context window) but the actual workload uses only a fraction. Today's lazy path correctly grows to the actual usage size — but it does so via repeated `concatenated` calls, each holding the old + new buffer transiently. The `reserve` hint replaces that with a single up-front allocation sized to the workload. Without `reserve`, behaviour is unchanged.

## Internals

- `RotatingKVCache.updateInPlace`'s growth condition is fixed from `prev >= self.keys!.dim(2)` to `prev + S > self.keys!.dim(2)` so multi-token writes (`S > 1`) trigger growth correctly. The legacy condition only fired when `prev` was already at/past the buffer end, which only worked for single-token decode writes — multi-token writes were exclusively handled via `updateConcat`. The fix lets `updateInPlace` handle both, which is what the `reserve` path needs.
- `RotatingKVCache.update`'s dispatcher routes multi-token writes through `updateInPlace` when `reserve` has been called (the buffer is sized for the workload, no concat needed). Without `reserve`, dispatch is unchanged: `S=1` → `updateInPlace`, `S>1` → `updateConcat`.

## Test plan

- [x] `swift test --filter KVCacheTests` — 17/17 pass (11 existing + 6 new `reserve()` regression tests).
- [x] `swift test --filter BatchTokenIteratorTests` — 3/3 pass.
- [x] `swift build --build-tests` clean.

The 6 new tests cover:

| Test | Asserts |
|---|---|
| `testRotatingKVCacheReservePreallocates` | First write produces a buffer of exactly the hinted size (above step floor). |
| `testRotatingKVCacheReserveIsIdempotentAfterWrite` | Calling `reserve` after the first write doesn't retroactively grow the buffer. |
| `testRotatingKVCacheReserveClampsToMax` | Hints larger than `maxCacheSize` cap correctly. |
| `testRotatingKVCacheReserveFloorIsStep` | Hints smaller than `step` round up to `step`. |
| `testRotatingKVCacheReserveFitsPrefillChunks` | Two prefill chunks both fit in the pre-allocated buffer with no grow. |
| `testRotatingKVCacheReserveGrowsOnOverflow` | Workloads exceeding the hint fall back to step-based growth (the hint isn't a hard cap). |

## Behaviour change

Default path is unchanged — callers that don't call `reserve` get the same lazy step-incremental growth as before. The growth-condition fix in `updateInPlace` is a strict generalization (the old condition was a subset of the new one for `S=1`).

## Out of scope

- Iterator wiring. `TokenIterator` and `BatchTokenIterator` are not changed — callers that want the hint can construct a `RotatingKVCache` themselves (or pull one out via `model.newCache(...)`) and call `reserve` before passing it in.
- The companion `BatchedKVCache` type is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)