### PR TITLE
feat(lfm2): consolidate text decoder into MLXLMCommon namespace (WS-C #2)

### DIFF
--- a/Libraries/MLXLLM/Models/LFM2.swift
+++ b/Libraries/MLXLLM/Models/LFM2.swift
@@ -4,6 +4,10 @@
 //
 //  Created by John Mai on 2025/7/12.
 //
+//  Layer stack lifted into MLXLMCommon.LFM2 namespace during issue #168
+//  consolidation pass (2026-05-06). This file owns only the LLM-side
+//  outer model wrapper.
+//
 
 // port of https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/lfm2.py
 
@@ -12,365 +16,26 @@ import MLX
 import MLXLMCommon
 import MLXNN
 
-public struct LFM2Configuration: Codable, Sendable {
-    let modelType: String
-    let vocabularySize: Int
-    let hiddenSize: Int
-    let hiddenLayers: Int
-    let attentionHeads: Int
-    let kvHeads: Int
-    let maxPositionEmbeddings: Int?
-    let normEps: Float
-    let convBias: Bool
-    let convLCache: Int
-    private let _blockDim: Int?
-    var blockDim: Int { _blockDim ?? hiddenSize }
-    private let _blockFFDim: Int?
-    var blockFFDim: Int { _blockFFDim ?? hiddenSize }
-    let blockMultipleOf: Int
-    let blockFFNDimMultiplier: Float
-    let blockAutoAdjustFFDim: Bool
-    private let _fullAttnIdxs: [Int]?
-    private let layerTypes: [String]?
-    private let ropeParameters: [String: StringOrNumber]?
-    var fullAttnIdxs: [Int] {
-        if let fullAttnIdxs = _fullAttnIdxs {
-            return fullAttnIdxs
-        }
-
-        if let layerTypes {
-            return layerTypes.enumerated().compactMap { index, layerType in
-                layerType == "full_attention" ? index : nil
-            }
-        }
-
-        return Array(0 ..< hiddenLayers)
-    }
-    let ropeTheta: Float
-    var headDimensions: Int { hiddenSize / attentionHeads }
-
-    enum CodingKeys: String, CodingKey {
-        case modelType = "model_type"
-        case vocabularySize = "vocab_size"
-        case hiddenSize = "hidden_size"
-        case hiddenLayers = "num_hidden_layers"
-        case attentionHeads = "num_attention_heads"
-        case kvHeads = "num_key_value_heads"
-        case maxPositionEmbeddings = "max_position_embeddings"
-        case normEps = "norm_eps"
-        case convBias = "conv_bias"
-        case convLCache = "conv_L_cache"
-        case _blockDim = "block_dim"
-        case _blockFFDim = "block_ff_dim"
-        case blockMultipleOf = "block_multiple_of"
-        case blockFFNDimMultiplier = "block_ffn_dim_multiplier"
-        case blockAutoAdjustFFDim = "block_auto_adjust_ff_dim"
-        case _fullAttnIdxs = "full_attn_idxs"
-        case layerTypes = "layer_types"
-        case ropeTheta = "rope_theta"
-        case ropeParameters = "rope_parameters"
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        self.modelType = try container.decodeIfPresent(String.self, forKey: .modelType) ?? "lfm2"
-        self.vocabularySize =
-            try container.decodeIfPresent(Int.self, forKey: .vocabularySize) ?? 65536
-        self.hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
-        self.hiddenLayers = try container.decode(Int.self, forKey: .hiddenLayers)
-        self.attentionHeads = try container.decode(Int.self, forKey: .attentionHeads)
-        self.kvHeads = try container.decode(Int.self, forKey: .kvHeads)
-        self.maxPositionEmbeddings = try container.decodeIfPresent(
-            Int.self, forKey: .maxPositionEmbeddings)
-        self.normEps = try container.decode(Float.self, forKey: .normEps)
-        self.convBias = try container.decodeIfPresent(Bool.self, forKey: .convBias) ?? false
-        self.convLCache = try container.decodeIfPresent(Int.self, forKey: .convLCache) ?? 3
-        self._blockDim = try container.decodeIfPresent(Int.self, forKey: ._blockDim)
-        self._blockFFDim = try container.decodeIfPresent(Int.self, forKey: ._blockFFDim)
-        self.blockMultipleOf =
-            try container.decodeIfPresent(Int.self, forKey: .blockMultipleOf) ?? 256
-        self.blockFFNDimMultiplier =
-            try container.decodeIfPresent(Float.self, forKey: .blockFFNDimMultiplier) ?? 1.0
-        self.blockAutoAdjustFFDim =
-            try container.decodeIfPresent(Bool.self, forKey: .blockAutoAdjustFFDim) ?? true
-        self._fullAttnIdxs = try container.decodeIfPresent([Int].self, forKey: ._fullAttnIdxs)
-        self.layerTypes = try container.decodeIfPresent([String].self, forKey: .layerTypes)
-        self.ropeParameters = try container.decodeIfPresent(
-            [String: StringOrNumber].self, forKey: .ropeParameters)
-
-        let ropeTheta = try container.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 1000000.0
-        self.ropeTheta = ropeParameters?["rope_theta"]?.asFloat() ?? ropeTheta
-    }
-}
-
-class LFM2Attention: Module {
-    let args: LFM2Configuration
-    let scale: Float
-    let headDim: Int
-
-    @ModuleInfo(key: "q_proj") var qProj: Linear
-    @ModuleInfo(key: "k_proj") var kProj: Linear
-    @ModuleInfo(key: "v_proj") var vProj: Linear
-    @ModuleInfo(key: "out_proj") var outProj: Linear
-
-    @ModuleInfo(key: "q_layernorm") var qLayerNorm: RMSNorm
-    @ModuleInfo(key: "k_layernorm") var kLayerNorm: RMSNorm
-
-    let rope: RoPE
-
-    public init(_ args: LFM2Configuration) {
-        self.args = args
-
-        let dim = args.hiddenSize
-        let heads = args.attentionHeads
-        let kvHeads = args.kvHeads
-        self.headDim = args.headDimensions
-
-        self.scale = pow(Float(headDim), -0.5)
-
-        _qProj.wrappedValue = Linear(dim, heads * headDim, bias: false)
-        _kProj.wrappedValue = Linear(dim, kvHeads * headDim, bias: false)
-        _vProj.wrappedValue = Linear(dim, kvHeads * headDim, bias: false)
-        _outProj.wrappedValue = Linear(heads * headDim, dim, bias: false)
-
-        _qLayerNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: args.normEps)
-        _kLayerNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: args.normEps)
-
-        self.rope = RoPE(
-            dimensions: headDim,
-            traditional: false,
-            base: args.ropeTheta
-        )
-    }
-
-    public func callAsFunction(
-        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
-    ) -> MLXArray {
-        let (B, L) = (x.dim(0), x.dim(1))
-
-        var queries = qProj(x)
-        var keys = kProj(x)
-        var values = vProj(x)
-
-        queries = qLayerNorm(queries.reshaped(B, L, args.attentionHeads, -1)).transposed(0, 2, 1, 3)
-        keys = kLayerNorm(keys.reshaped(B, L, args.kvHeads, -1)).transposed(0, 2, 1, 3)
-        values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
-
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
-
-        let output = attentionWithCacheUpdate(
-            queries: queries,
-            keys: keys,
-            values: values,
-            cache: cache,
-            scale: scale,
-            mask: mask
-        )
-        .transposed(0, 2, 1, 3)
-        .reshaped(B, L, -1)
-
-        return outProj(output)
-    }
-}
-
-class LFM2ShortConv: Module {
-    let args: LFM2Configuration
-    let layerIdx: Int
-    let lCache: Int
-    let bias: Bool
-
-    @ModuleInfo(key: "conv") var conv: Conv1d
-    @ModuleInfo(key: "in_proj") var inProj: Linear
-    @ModuleInfo(key: "out_proj") var outProj: Linear
-
-    public init(_ args: LFM2Configuration, layerIdx: Int) {
-        self.args = args
-        self.layerIdx = layerIdx
-        self.lCache = args.convLCache
-        self.bias = args.convBias
-
-        _conv.wrappedValue = Conv1d(
-            inputChannels: args.hiddenSize,
-            outputChannels: args.hiddenSize,
-            kernelSize: lCache,
-            groups: args.hiddenSize,
-            bias: bias
-        )
-
-        _inProj.wrappedValue = Linear(args.hiddenSize, 3 * args.hiddenSize, bias: bias)
-        _outProj.wrappedValue = Linear(args.hiddenSize, args.hiddenSize, bias: bias)
-    }
-
-    public func callAsFunction(_ x: MLXArray, cache: SSMStateCache?) -> MLXArray {
-        let BCx = inProj(x)
-        let BCxSplit = BCx.split(parts: 3, axis: -1)
-        let B = BCxSplit[0]
-        let C = BCxSplit[1]
-        let x = BCxSplit[2]
-        var Bx = B * x
-
-        var state: MLXArray? = nil
-        if let cache {
-            state = cache[0]
-        }
-        if state == nil {
-            state = MLXArray.zeros([Bx.dim(0), lCache - 1, args.hiddenSize], dtype: Bx.dtype)
-        }
-
-        Bx = concatenated([state!, Bx], axis: -2)
-        if let cache {
-            cache[0] = Bx[0..., (Bx.dim(1) - (lCache - 1))..., 0...].contiguous()
-        }
-
-        let convOut = conv(Bx)
-        let y = C * convOut
-        return outProj(y)
-    }
-}
-
-class LFM2MLP: Module, UnaryLayer {
-    @ModuleInfo(key: "w1") var w1: Linear
-    @ModuleInfo(key: "w2") var w2: Linear
-    @ModuleInfo(key: "w3") var w3: Linear
-
-    public init(
-        dim: Int,
-        ffDim: Int,
-        multipleOf: Int,
-        autoAdjustFFDim: Bool,
-        ffnDimMultiplier: Float?
-    ) {
-        var adjustedFFDim = ffDim
-
-        if autoAdjustFFDim {
-            adjustedFFDim = Int(Float(2 * ffDim) / 3.0)
-            if let multiplier = ffnDimMultiplier {
-                adjustedFFDim = Int(multiplier * Float(adjustedFFDim))
-            }
-            adjustedFFDim = multipleOf * ((adjustedFFDim + multipleOf - 1) / multipleOf)
-        }
-
-        _w1.wrappedValue = Linear(dim, adjustedFFDim, bias: false)
-        _w2.wrappedValue = Linear(adjustedFFDim, dim, bias: false)
-        _w3.wrappedValue = Linear(dim, adjustedFFDim, bias: false)
-    }
-
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
-        w2(silu(w1(x)) * w3(x))
-    }
-}
-
-class LFM2DecoderLayer: Module {
-    let isAttentionLayer: Bool
-
-    @ModuleInfo(key: "self_attn") var attention: LFM2Attention?
-    @ModuleInfo(key: "conv") var conv: LFM2ShortConv?
-    @ModuleInfo(key: "feed_forward") var feedForward: LFM2MLP
-    @ModuleInfo(key: "operator_norm") var operatorNorm: RMSNorm
-    @ModuleInfo(key: "ffn_norm") var ffnNorm: RMSNorm
-
-    public init(_ args: LFM2Configuration, layerIdx: Int) {
-        self.isAttentionLayer = args.fullAttnIdxs.contains(layerIdx)
-
-        if isAttentionLayer {
-            _attention.wrappedValue = LFM2Attention(args)
-        } else {
-            _conv.wrappedValue = LFM2ShortConv(args, layerIdx: layerIdx)
-        }
-
-        _feedForward.wrappedValue = LFM2MLP(
-            dim: args.blockDim,
-            ffDim: args.blockFFDim,
-            multipleOf: args.blockMultipleOf,
-            autoAdjustFFDim: args.blockAutoAdjustFFDim,
-            ffnDimMultiplier: args.blockFFNDimMultiplier
-        )
-        _operatorNorm.wrappedValue = RMSNorm(dimensions: args.hiddenSize, eps: args.normEps)
-        _ffnNorm.wrappedValue = RMSNorm(dimensions: args.hiddenSize, eps: args.normEps)
-    }
-
-    public func callAsFunction(
-        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
-    ) -> MLXArray {
-        let r: MLXArray
-        if isAttentionLayer {
-            r = attention!(operatorNorm(x), mask: mask, cache: cache)
-        } else {
-            r = conv!(operatorNorm(x), cache: cache as? SSMStateCache)
-        }
-        let h = x + r
-        let out = h + feedForward(ffnNorm(h))
-        return out
-    }
-}
-
-public class LFM2ModelInner: Module {
-    let args: LFM2Configuration
-    let vocabularySize: Int
-    let numHiddenLayers: Int
-
-    fileprivate let layers: [LFM2DecoderLayer]
-
-    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
-    @ModuleInfo(key: "embedding_norm") var embeddingNorm: RMSNorm
-
-    public init(_ args: LFM2Configuration) {
-        self.args = args
-        self.vocabularySize = args.vocabularySize
-        self.numHiddenLayers = args.hiddenLayers
-
-        precondition(vocabularySize > 0)
-
-        _embedTokens.wrappedValue = Embedding(
-            embeddingCount: vocabularySize, dimensions: args.hiddenSize)
-
-        self.layers = (0 ..< numHiddenLayers).map { i in
-            LFM2DecoderLayer(args, layerIdx: i)
-        }
-
-        _embeddingNorm.wrappedValue = RMSNorm(dimensions: args.hiddenSize, eps: args.normEps)
-    }
-
-    public func callAsFunction(
-        _ inputs: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
-        cache: [KVCache]? = nil, inputEmbeddings: MLXArray? = nil
-    ) -> MLXArray {
-        var h = inputEmbeddings ?? embedTokens(inputs)
-
-        let mask =
-            mask
-            ?? {
-                let firstAttnIdx = args.fullAttnIdxs.first ?? 0
-                let c = cache != nil && firstAttnIdx < cache!.count ? cache![firstAttnIdx] : nil
-                return createAttentionMask(h: h, cache: c)
-            }()
-
-        for (i, layer) in layers.enumerated() {
-            h = layer(h, mask: mask, cache: cache?[i])
-        }
-
-        return embeddingNorm(h)
-    }
-}
+/// Back-compat alias. The configuration moved into `LFM2.Configuration`
+/// in MLXLMCommon during the issue #168 consolidation pass; existing
+/// callers that referenced `LFM2Configuration` continue to compile.
+public typealias LFM2Configuration = LFM2.Configuration
 
 public class LFM2Model: Module, LLMModel, KVCacheDimensionProvider {
     public let vocabularySize: Int
     public let kvHeads: [Int]
 
-    public let model: LFM2ModelInner
-    let configuration: LFM2Configuration
+    public let model: LFM2.ModelInner
+    let configuration: LFM2.Configuration
 
-    public init(_ args: LFM2Configuration) {
+    public init(_ args: LFM2.Configuration) {
         self.configuration = args
         self.vocabularySize = args.vocabularySize
-
         self.kvHeads = (0 ..< args.hiddenLayers).map { layerIdx in
             args.fullAttnIdxs.contains(layerIdx) ? args.kvHeads : 0
         }
-
-        self.model = LFM2ModelInner(args)
+        self.model = LFM2.ModelInner(args)
+        super.init()
     }
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
@@ -379,21 +44,19 @@ public class LFM2Model: Module, LLMModel, KVCacheDimensionProvider {
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
-        var sanitizedWeights: [String: MLXArray] = [:]
-
+        var sanitized: [String: MLXArray] = [:]
         for (name, param) in weights {
-            var sanitizedParam = param
-
-            if name.contains("conv.weight") {
-                if param.shape[param.shape.count - 1] > param.dim(1) {
-                    sanitizedParam = param.transposed(0, 2, 1)
-                }
+            var p = param
+            // Conv1d weight layout adjustment: HF-format is [out, kernel, in],
+            // MLX expects [out, in, kernel] for grouped conv.
+            if name.contains("conv.weight"),
+                p.shape[p.shape.count - 1] > p.dim(1)
+            {
+                p = p.transposed(0, 2, 1)
             }
-
-            sanitizedWeights[name] = sanitizedParam
+            sanitized[name] = p
         }
-
-        return sanitizedWeights
+        return sanitized
     }
 
     public func newCache(parameters: GenerateParameters?) -> [KVCache] {

--- a/Libraries/MLXLMCommon/Models/LFM2.swift
+++ b/Libraries/MLXLMCommon/Models/LFM2.swift
@@ -1,0 +1,356 @@
+// Copyright © 2026 Apple Inc.
+//
+// Shared LFM 2 text-decoder building blocks. Both `MLXLLM/Models/LFM2.swift`
+// and `MLXVLM/Models/LFM2VL.swift` consume this namespace.
+//
+// Consolidation reference: issue #168.
+
+import Foundation
+import MLX
+import MLXNN
+
+/// Public namespace for the LFM 2 text decoder. The outer LLM and VLM model
+/// classes live in their respective targets and share this layer stack.
+public enum LFM2 {
+
+    // MARK: - Configuration
+
+    /// JSON config parser shared across LLM and VLM LFM 2 variants. Decodes
+    /// every numeric/bool field with sensible defaults so both LFM2-text
+    /// repos and LFM2-VL nested `text_config` repos load cleanly.
+    public struct Configuration: Codable, Sendable {
+        public let modelType: String
+        public let vocabularySize: Int
+        public let hiddenSize: Int
+        public let hiddenLayers: Int
+        public let attentionHeads: Int
+        public let kvHeads: Int
+        public let maxPositionEmbeddings: Int?
+        public let normEps: Float
+        public let convBias: Bool
+        public let convLCache: Int
+
+        // Optional with hiddenSize fallback (per-model overrides).
+        private let _blockDim: Int?
+        public var blockDim: Int { _blockDim ?? hiddenSize }
+        private let _blockFFDim: Int?
+        public var blockFFDim: Int { _blockFFDim ?? hiddenSize }
+
+        public let blockMultipleOf: Int
+        public let blockFFNDimMultiplier: Float
+        public let blockAutoAdjustFFDim: Bool
+
+        // Either explicit `full_attn_idxs` or derived from `layer_types`.
+        private let _fullAttnIdxs: [Int]?
+        private let layerTypes: [String]?
+        public var fullAttnIdxs: [Int] {
+            if let _fullAttnIdxs { return _fullAttnIdxs }
+            if let layerTypes {
+                return layerTypes.enumerated().compactMap { idx, type in
+                    type == "full_attention" ? idx : nil
+                }
+            }
+            return Array(0 ..< hiddenLayers)
+        }
+
+        public let ropeTheta: Float
+        // Stored so the auto-synthesized `encode(to:)` is happy; the value is
+        // also folded into `ropeTheta` at decode time when present.
+        public let ropeParameters: [String: StringOrNumber]?
+
+        public var headDimensions: Int { hiddenSize / attentionHeads }
+
+        enum CodingKeys: String, CodingKey {
+            case modelType = "model_type"
+            case vocabularySize = "vocab_size"
+            case hiddenSize = "hidden_size"
+            case hiddenLayers = "num_hidden_layers"
+            case attentionHeads = "num_attention_heads"
+            case kvHeads = "num_key_value_heads"
+            case maxPositionEmbeddings = "max_position_embeddings"
+            case normEps = "norm_eps"
+            case convBias = "conv_bias"
+            case convLCache = "conv_L_cache"
+            case _blockDim = "block_dim"
+            case _blockFFDim = "block_ff_dim"
+            case blockMultipleOf = "block_multiple_of"
+            case blockFFNDimMultiplier = "block_ffn_dim_multiplier"
+            case blockAutoAdjustFFDim = "block_auto_adjust_ff_dim"
+            case _fullAttnIdxs = "full_attn_idxs"
+            case layerTypes = "layer_types"
+            case ropeTheta = "rope_theta"
+            case ropeParameters = "rope_parameters"
+        }
+
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            self.modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "lfm2"
+            self.vocabularySize = try c.decodeIfPresent(Int.self, forKey: .vocabularySize) ?? 65536
+            self.hiddenSize = try c.decode(Int.self, forKey: .hiddenSize)
+            self.hiddenLayers = try c.decode(Int.self, forKey: .hiddenLayers)
+            self.attentionHeads = try c.decode(Int.self, forKey: .attentionHeads)
+            self.kvHeads = try c.decode(Int.self, forKey: .kvHeads)
+            self.maxPositionEmbeddings = try c.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings)
+            self.normEps = try c.decodeIfPresent(Float.self, forKey: .normEps) ?? 1.0e-5
+            self.convBias = try c.decodeIfPresent(Bool.self, forKey: .convBias) ?? false
+            self.convLCache = try c.decodeIfPresent(Int.self, forKey: .convLCache) ?? 3
+            self._blockDim = try c.decodeIfPresent(Int.self, forKey: ._blockDim)
+            self._blockFFDim = try c.decodeIfPresent(Int.self, forKey: ._blockFFDim)
+            self.blockMultipleOf = try c.decodeIfPresent(Int.self, forKey: .blockMultipleOf) ?? 256
+            self.blockFFNDimMultiplier = try c.decodeIfPresent(Float.self, forKey: .blockFFNDimMultiplier) ?? 1.0
+            self.blockAutoAdjustFFDim = try c.decodeIfPresent(Bool.self, forKey: .blockAutoAdjustFFDim) ?? true
+            self._fullAttnIdxs = try c.decodeIfPresent([Int].self, forKey: ._fullAttnIdxs)
+            self.layerTypes = try c.decodeIfPresent([String].self, forKey: .layerTypes)
+            // `rope_theta` may be top-level OR nested in `rope_parameters`.
+            let topRopeTheta = try c.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 1_000_000.0
+            self.ropeParameters = try c.decodeIfPresent(
+                [String: StringOrNumber].self, forKey: .ropeParameters)
+            self.ropeTheta = self.ropeParameters?["rope_theta"]?.asFloat() ?? topRopeTheta
+        }
+    }
+
+    // MARK: - Attention
+
+    public class Attention: Module {
+        let scale: Float
+        let headDim: Int
+        let heads: Int
+        let kvHeads: Int
+
+        @ModuleInfo(key: "q_proj") var qProj: Linear
+        @ModuleInfo(key: "k_proj") var kProj: Linear
+        @ModuleInfo(key: "v_proj") var vProj: Linear
+        @ModuleInfo(key: "out_proj") var outProj: Linear
+
+        @ModuleInfo(key: "q_layernorm") var qLayerNorm: RMSNorm
+        @ModuleInfo(key: "k_layernorm") var kLayerNorm: RMSNorm
+
+        let rope: RoPE
+
+        public init(_ config: Configuration) {
+            let dim = config.hiddenSize
+            self.heads = config.attentionHeads
+            self.kvHeads = config.kvHeads
+            self.headDim = config.headDimensions
+            self.scale = pow(Float(headDim), -0.5)
+
+            self._qProj.wrappedValue = Linear(dim, heads * headDim, bias: false)
+            self._kProj.wrappedValue = Linear(dim, kvHeads * headDim, bias: false)
+            self._vProj.wrappedValue = Linear(dim, kvHeads * headDim, bias: false)
+            self._outProj.wrappedValue = Linear(heads * headDim, dim, bias: false)
+
+            self._qLayerNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: config.normEps)
+            self._kLayerNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: config.normEps)
+
+            self.rope = RoPE(dimensions: headDim, traditional: false, base: config.ropeTheta)
+            super.init()
+        }
+
+        public func callAsFunction(
+            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+        ) -> MLXArray {
+            let (B, L) = (x.dim(0), x.dim(1))
+
+            var queries = qProj(x)
+            var keys = kProj(x)
+            var values = vProj(x)
+
+            queries = qLayerNorm(queries.reshaped(B, L, heads, -1)).transposed(0, 2, 1, 3)
+            keys = kLayerNorm(keys.reshaped(B, L, kvHeads, -1)).transposed(0, 2, 1, 3)
+            values = values.reshaped(B, L, kvHeads, -1).transposed(0, 2, 1, 3)
+
+            queries = applyRotaryPosition(rope, to: queries, cache: cache)
+            keys = applyRotaryPosition(rope, to: keys, cache: cache)
+
+            let output = attentionWithCacheUpdate(
+                queries: queries, keys: keys, values: values,
+                cache: cache, scale: scale, mask: mask
+            )
+            .transposed(0, 2, 1, 3)
+            .reshaped(B, L, -1)
+            return outProj(output)
+        }
+    }
+
+    // MARK: - Short Conv (LFM2's hybrid SSM-style layer)
+
+    public class ShortConv: Module {
+        let lCache: Int
+        let hiddenSize: Int
+
+        @ModuleInfo(key: "conv") var conv: Conv1d
+        @ModuleInfo(key: "in_proj") var inProj: Linear
+        @ModuleInfo(key: "out_proj") var outProj: Linear
+
+        public init(_ config: Configuration, layerIdx: Int) {
+            self.lCache = config.convLCache
+            self.hiddenSize = config.hiddenSize
+            let bias = config.convBias
+
+            self._conv.wrappedValue = Conv1d(
+                inputChannels: config.hiddenSize, outputChannels: config.hiddenSize,
+                kernelSize: lCache, groups: config.hiddenSize, bias: bias)
+            self._inProj.wrappedValue = Linear(config.hiddenSize, 3 * config.hiddenSize, bias: bias)
+            self._outProj.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: bias)
+            super.init()
+        }
+
+        public func callAsFunction(_ x: MLXArray, cache: SSMStateCache?) -> MLXArray {
+            let BCx = inProj(x)
+            let parts = BCx.split(parts: 3, axis: -1)
+            let B = parts[0]
+            let C = parts[1]
+            let xPart = parts[2]
+            var Bx = B * xPart
+
+            var state: MLXArray? = nil
+            if let cache { state = cache[0] }
+            if state == nil {
+                state = MLXArray.zeros([Bx.dim(0), lCache - 1, hiddenSize], dtype: Bx.dtype)
+            }
+
+            Bx = concatenated([state!, Bx], axis: -2)
+            if let cache {
+                cache[0] = Bx[0..., (Bx.dim(1) - (lCache - 1))..., 0...].contiguous()
+            }
+
+            let convOut = conv(Bx)
+            let y = C * convOut
+            return outProj(y)
+        }
+    }
+
+    // MARK: - MLP
+
+    public class MLP: Module, UnaryLayer {
+        @ModuleInfo(key: "w1") var w1: Linear
+        @ModuleInfo(key: "w2") var w2: Linear
+        @ModuleInfo(key: "w3") var w3: Linear
+
+        public init(
+            dim: Int, ffDim: Int, multipleOf: Int, autoAdjustFFDim: Bool, ffnDimMultiplier: Float?
+        ) {
+            var adjustedFFDim = ffDim
+            if autoAdjustFFDim {
+                adjustedFFDim = Int(Float(2 * ffDim) / 3.0)
+                if let multiplier = ffnDimMultiplier {
+                    adjustedFFDim = Int(multiplier * Float(adjustedFFDim))
+                }
+                adjustedFFDim = multipleOf * ((adjustedFFDim + multipleOf - 1) / multipleOf)
+            }
+            self._w1.wrappedValue = Linear(dim, adjustedFFDim, bias: false)
+            self._w2.wrappedValue = Linear(adjustedFFDim, dim, bias: false)
+            self._w3.wrappedValue = Linear(dim, adjustedFFDim, bias: false)
+            super.init()
+        }
+
+        public func callAsFunction(_ x: MLXArray) -> MLXArray {
+            w2(silu(w1(x)) * w3(x))
+        }
+    }
+
+    // MARK: - DecoderLayer
+
+    public class DecoderLayer: Module {
+        public let isAttentionLayer: Bool
+
+        @ModuleInfo(key: "self_attn") var attention: Attention?
+        @ModuleInfo(key: "conv") var conv: ShortConv?
+        @ModuleInfo(key: "feed_forward") var feedForward: MLP
+        @ModuleInfo(key: "operator_norm") var operatorNorm: RMSNorm
+        @ModuleInfo(key: "ffn_norm") var ffnNorm: RMSNorm
+
+        public init(_ config: Configuration, layerIdx: Int) {
+            self.isAttentionLayer = config.fullAttnIdxs.contains(layerIdx)
+
+            if isAttentionLayer {
+                self._attention.wrappedValue = Attention(config)
+            } else {
+                self._conv.wrappedValue = ShortConv(config, layerIdx: layerIdx)
+            }
+
+            self._feedForward.wrappedValue = MLP(
+                dim: config.blockDim,
+                ffDim: config.blockFFDim,
+                multipleOf: config.blockMultipleOf,
+                autoAdjustFFDim: config.blockAutoAdjustFFDim,
+                ffnDimMultiplier: config.blockFFNDimMultiplier)
+            self._operatorNorm.wrappedValue = RMSNorm(
+                dimensions: config.hiddenSize, eps: config.normEps)
+            self._ffnNorm.wrappedValue = RMSNorm(
+                dimensions: config.hiddenSize, eps: config.normEps)
+            super.init()
+        }
+
+        public func callAsFunction(
+            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+        ) -> MLXArray {
+            let r: MLXArray
+            if isAttentionLayer {
+                r = attention!(operatorNorm(x), mask: mask, cache: cache)
+            } else {
+                r = conv!(operatorNorm(x), cache: cache as? SSMStateCache)
+            }
+            let h = x + r
+            let out = h + feedForward(ffnNorm(h))
+            return out
+        }
+    }
+
+    // MARK: - ModelInner
+
+    /// Shared transformer backbone (embed → N hybrid attention/short-conv
+    /// blocks → norm). Both LLM and VLM outer model classes wrap this.
+    public class ModelInner: Module {
+        public let config: Configuration
+        public let vocabularySize: Int
+        public let numHiddenLayers: Int
+
+        public let layers: [DecoderLayer]
+
+        @ModuleInfo(key: "embed_tokens") public var embedTokens: Embedding
+        @ModuleInfo(key: "embedding_norm") public var embeddingNorm: RMSNorm
+
+        public init(_ config: Configuration) {
+            self.config = config
+            self.vocabularySize = config.vocabularySize
+            self.numHiddenLayers = config.hiddenLayers
+            precondition(vocabularySize > 0)
+
+            self._embedTokens.wrappedValue = Embedding(
+                embeddingCount: vocabularySize, dimensions: config.hiddenSize)
+            self.layers = (0 ..< numHiddenLayers).map { i in
+                DecoderLayer(config, layerIdx: i)
+            }
+            self._embeddingNorm.wrappedValue = RMSNorm(
+                dimensions: config.hiddenSize, eps: config.normEps)
+            super.init()
+        }
+
+        public func callAsFunction(
+            _ inputs: MLXArray,
+            mask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
+            cache: [KVCache]? = nil,
+            inputEmbeddings: MLXArray? = nil
+        ) -> MLXArray {
+            var h = inputEmbeddings ?? embedTokens(inputs)
+
+            // The default mask draws from the first attention layer's cache —
+            // short-conv layers use SSMStateCache and don't contribute a key
+            // length to the attention mask.
+            let resolvedMask =
+                mask
+                ?? {
+                    let firstAttnIdx = config.fullAttnIdxs.first ?? 0
+                    let c = cache != nil && firstAttnIdx < cache!.count
+                        ? cache![firstAttnIdx] : nil
+                    return createAttentionMask(h: h, cache: c)
+                }()
+
+            for (i, layer) in layers.enumerated() {
+                h = layer(h, mask: resolvedMask, cache: cache?[i])
+            }
+            return embeddingNorm(h)
+        }
+    }
+}

--- a/Libraries/MLXVLM/Models/LFM2VL.swift
+++ b/Libraries/MLXVLM/Models/LFM2VL.swift
@@ -288,263 +288,28 @@ private enum Vision {
 }
 
 // MARK: - Language Model Components (LFM2)
+//
+// LFM 2 layer stack (Attention, ShortConv, MLP, DecoderLayer,
+// ModelInner) lifted into MLXLMCommon.LFM2 namespace during the
+// issue #168 consolidation pass. The VLM target consumes the shared
+// types via the namespace; the only LFM 2-specific text-side type that
+// remains here is `Language.LanguageModel`, which adds the LMOutput
+// wrap + the conv-weight-shape sanitize.
 
 private enum Language {
 
-    fileprivate class LFM2Attention: Module {
-        let scale: Float
-        let headDim: Int
-        let heads: Int
-        let kvHeads: Int
-
-        @ModuleInfo(key: "q_proj") var qProj: Linear
-        @ModuleInfo(key: "k_proj") var kProj: Linear
-        @ModuleInfo(key: "v_proj") var vProj: Linear
-        @ModuleInfo(key: "out_proj") var outProj: Linear
-
-        @ModuleInfo(key: "q_layernorm") var qLayerNorm: RMSNorm
-        @ModuleInfo(key: "k_layernorm") var kLayerNorm: RMSNorm
-
-        let rope: RoPE
-
-        init(_ config: LFM2VLConfiguration.TextConfiguration) {
-            let dim = config.hiddenSize
-            self.heads = config.attentionHeads
-            self.kvHeads = config.kvHeads
-            self.headDim = dim / heads
-            self.scale = pow(Float(headDim), -0.5)
-
-            self._qProj.wrappedValue = Linear(dim, heads * headDim, bias: false)
-            self._kProj.wrappedValue = Linear(dim, kvHeads * headDim, bias: false)
-            self._vProj.wrappedValue = Linear(dim, kvHeads * headDim, bias: false)
-            self._outProj.wrappedValue = Linear(heads * headDim, dim, bias: false)
-
-            self._qLayerNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: config.normEps)
-            self._kLayerNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: config.normEps)
-
-            self.rope = RoPE(
-                dimensions: headDim,
-                traditional: false,
-                base: config.ropeTheta
-            )
-        }
-
-        func callAsFunction(
-            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
-        ) -> MLXArray {
-            let (B, L) = (x.dim(0), x.dim(1))
-
-            var queries = qProj(x)
-            var keys = kProj(x)
-            var values = vProj(x)
-
-            queries = qLayerNorm(queries.reshaped(B, L, heads, -1)).transposed(0, 2, 1, 3)
-            keys = kLayerNorm(keys.reshaped(B, L, kvHeads, -1)).transposed(0, 2, 1, 3)
-            values = values.reshaped(B, L, kvHeads, -1).transposed(0, 2, 1, 3)
-
-            if let cache {
-                queries = rope(queries, offset: cache.offset)
-                keys = rope(keys, offset: cache.offset)
-            } else {
-                queries = rope(queries)
-                keys = rope(keys)
-            }
-
-            let output = attentionWithCacheUpdate(
-                queries: queries,
-                keys: keys,
-                values: values,
-                cache: cache,
-                scale: scale,
-                mask: mask
-            )
-            .transposed(0, 2, 1, 3)
-            .reshaped(B, L, -1)
-
-            return outProj(output)
-        }
-    }
-
-    fileprivate class LFM2ShortConv: Module {
-        let lCache: Int
-        let hiddenSize: Int
-
-        @ModuleInfo(key: "conv") var conv: Conv1d
-        @ModuleInfo(key: "in_proj") var inProj: Linear
-        @ModuleInfo(key: "out_proj") var outProj: Linear
-
-        init(_ config: LFM2VLConfiguration.TextConfiguration, layerIdx: Int) {
-            self.lCache = config.convLCache
-            self.hiddenSize = config.hiddenSize
-            let bias = config.convBias
-
-            self._conv.wrappedValue = Conv1d(
-                inputChannels: config.hiddenSize,
-                outputChannels: config.hiddenSize,
-                kernelSize: lCache,
-                groups: config.hiddenSize,
-                bias: bias
-            )
-
-            self._inProj.wrappedValue = Linear(config.hiddenSize, 3 * config.hiddenSize, bias: bias)
-            self._outProj.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: bias)
-        }
-
-        func callAsFunction(_ x: MLXArray, cache: SSMStateCache?) -> MLXArray {
-            let BCx = inProj(x)
-            let BCxSplit = BCx.split(parts: 3, axis: -1)
-            let B = BCxSplit[0]
-            let C = BCxSplit[1]
-            let xPart = BCxSplit[2]
-            var Bx = B * xPart
-
-            var state: MLXArray? = nil
-            if let cache {
-                state = cache[0]
-            }
-            if state == nil {
-                state = MLXArray.zeros([Bx.dim(0), lCache - 1, hiddenSize], dtype: Bx.dtype)
-            }
-
-            Bx = concatenated([state!, Bx], axis: -2)
-            if let cache {
-                cache[0] = Bx[0..., (Bx.dim(1) - (lCache - 1))..., 0...]
-            }
-
-            let convOut = conv(Bx)
-            let y = C * convOut
-            return outProj(y)
-        }
-    }
-
-    fileprivate class LFM2MLP: Module, UnaryLayer {
-        @ModuleInfo(key: "w1") var w1: Linear
-        @ModuleInfo(key: "w2") var w2: Linear
-        @ModuleInfo(key: "w3") var w3: Linear
-
-        init(_ config: LFM2VLConfiguration.TextConfiguration) {
-            var adjustedFFDim = config.blockFFDim
-
-            if config.blockAutoAdjustFFDim {
-                adjustedFFDim = Int(Float(2 * adjustedFFDim) / 3.0)
-                adjustedFFDim = Int(config.blockFFNDimMultiplier * Float(adjustedFFDim))
-                adjustedFFDim =
-                    config.blockMultipleOf
-                    * ((adjustedFFDim + config.blockMultipleOf - 1) / config.blockMultipleOf)
-            }
-
-            self._w1.wrappedValue = Linear(config.blockDim, adjustedFFDim, bias: false)
-            self._w2.wrappedValue = Linear(adjustedFFDim, config.blockDim, bias: false)
-            self._w3.wrappedValue = Linear(config.blockDim, adjustedFFDim, bias: false)
-        }
-
-        func callAsFunction(_ x: MLXArray) -> MLXArray {
-            w2(silu(w1(x)) * w3(x))
-        }
-    }
-
-    fileprivate class LFM2DecoderLayer: Module {
-        let isAttentionLayer: Bool
-
-        @ModuleInfo(key: "self_attn") var attention: LFM2Attention?
-        @ModuleInfo(key: "conv") var conv: LFM2ShortConv?
-        @ModuleInfo(key: "feed_forward") var feedForward: LFM2MLP
-        @ModuleInfo(key: "operator_norm") var operatorNorm: RMSNorm
-        @ModuleInfo(key: "ffn_norm") var ffnNorm: RMSNorm
-
-        init(_ config: LFM2VLConfiguration.TextConfiguration, layerIdx: Int) {
-            self.isAttentionLayer = config.fullAttnIdxs.contains(layerIdx)
-
-            if isAttentionLayer {
-                self._attention.wrappedValue = LFM2Attention(config)
-            } else {
-                self._conv.wrappedValue = LFM2ShortConv(config, layerIdx: layerIdx)
-            }
-
-            self._feedForward.wrappedValue = LFM2MLP(config)
-            self._operatorNorm.wrappedValue = RMSNorm(
-                dimensions: config.hiddenSize, eps: config.normEps)
-            self._ffnNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.normEps)
-        }
-
-        func callAsFunction(
-            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
-        ) -> MLXArray {
-            let r: MLXArray
-            if isAttentionLayer {
-                r = attention!(operatorNorm(x), mask: mask, cache: cache)
-            } else {
-                r = conv!(operatorNorm(x), cache: cache as? SSMStateCache)
-            }
-            let h = x + r
-            let out = h + feedForward(ffnNorm(h))
-            return out
-        }
-    }
-
-    fileprivate class LFM2ModelInner: Module {
-        let config: LFM2VLConfiguration.TextConfiguration
-        let vocabularySize: Int
-        let numHiddenLayers: Int
-
-        let layers: [LFM2DecoderLayer]
-
-        @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
-        @ModuleInfo(key: "embedding_norm") var embeddingNorm: RMSNorm
-
-        init(_ config: LFM2VLConfiguration.TextConfiguration) {
-            self.config = config
-            self.vocabularySize = config.vocabularySize
-            self.numHiddenLayers = config.hiddenLayers
-
-            precondition(vocabularySize > 0)
-
-            self._embedTokens.wrappedValue = Embedding(
-                embeddingCount: vocabularySize, dimensions: config.hiddenSize)
-
-            self.layers = (0 ..< numHiddenLayers).map { i in
-                LFM2DecoderLayer(config, layerIdx: i)
-            }
-
-            self._embeddingNorm.wrappedValue = RMSNorm(
-                dimensions: config.hiddenSize, eps: config.normEps)
-        }
-
-        func callAsFunction(
-            _ inputs: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
-            cache: [KVCache]? = nil, inputEmbeddings: MLXArray? = nil
-        ) -> MLXArray {
-            var h = inputEmbeddings ?? embedTokens(inputs)
-
-            let mask =
-                mask
-                ?? {
-                    let firstAttnIdx = config.fullAttnIdxs.first ?? 0
-                    let c =
-                        cache != nil && firstAttnIdx < cache!.count ? cache![firstAttnIdx] : nil
-                    return createAttentionMask(h: h, cache: c)
-                }()
-
-            for (i, layer) in layers.enumerated() {
-                h = layer(h, mask: mask, cache: cache?[i])
-            }
-
-            return embeddingNorm(h)
-        }
-    }
-
     fileprivate class LanguageModel: Module, KVCacheDimensionProvider {
-        let config: LFM2VLConfiguration.TextConfiguration
+        let config: LFM2.Configuration
         let modelType: String
-        let model: LFM2ModelInner
+        let model: LFM2.ModelInner
 
         var kvHeads: [Int]
 
-        init(_ config: LFM2VLConfiguration.TextConfiguration) {
+        init(_ config: LFM2.Configuration) {
             self.config = config
             self.modelType = config.modelType
 
-            self.model = LFM2ModelInner(config)
+            self.model = LFM2.ModelInner(config)
 
             self.kvHeads = (0 ..< config.hiddenLayers).map { layerIdx in
                 config.fullAttnIdxs.contains(layerIdx) ? config.kvHeads : 0
@@ -1035,6 +800,17 @@ public class LFM2VL: Module, VLMModel, KVCacheDimensionProvider {
 
         let result = languageModel(nil, cache: cache, inputsEmbeds: inputEmbeddings)
 
+        // Mirror the Gemma 3 / Gemma 4 VLM prefill-sync barrier: a hard
+        // eval() on cache + logits before returning `.logits(result)` so the
+        // iterator's first decode forward doesn't read pending K/V writes.
+        // The pre-consolidation private LFM2ModelInner *may* have masked the
+        // issue here (it did for Gemma 3 — see PR #172); preempting now.
+        var cacheArrays: [MLXArray] = []
+        for c in cache {
+            cacheArrays.append(contentsOf: c.innerState())
+        }
+        eval(cacheArrays + [result.logits])
+
         return .logits(result)
     }
 
@@ -1103,67 +879,10 @@ public class LFM2VL: Module, VLMModel, KVCacheDimensionProvider {
 /// Configuration for ``LFM2VL``
 public struct LFM2VLConfiguration: Codable, Sendable {
 
-    public struct TextConfiguration: Codable, Sendable {
-        public let modelType: String
-        public let hiddenSize: Int
-        public let hiddenLayers: Int
-        public let attentionHeads: Int
-        public let kvHeads: Int
-        public let vocabularySize: Int
-        private let _normEps: Float?
-        public var normEps: Float { _normEps ?? 1e-5 }
-        private let _convBias: Bool?
-        public var convBias: Bool { _convBias ?? false }
-        private let _convLCache: Int?
-        public var convLCache: Int { _convLCache ?? 3 }
-        private let _blockDim: Int?
-        public var blockDim: Int { _blockDim ?? hiddenSize }
-        private let _blockFFDim: Int?
-        public var blockFFDim: Int { _blockFFDim ?? hiddenSize }
-        private let _blockMultipleOf: Int?
-        public var blockMultipleOf: Int { _blockMultipleOf ?? 256 }
-        private let _blockFFNDimMultiplier: Float?
-        public var blockFFNDimMultiplier: Float { _blockFFNDimMultiplier ?? 1.0 }
-        private let _blockAutoAdjustFFDim: Bool?
-        public var blockAutoAdjustFFDim: Bool { _blockAutoAdjustFFDim ?? true }
-        private let _fullAttnIdxs: [Int]?
-        private let layerTypes: [String]?
-        public var fullAttnIdxs: [Int] {
-            if let fullAttnIdxs = _fullAttnIdxs {
-                return fullAttnIdxs
-            }
-
-            if let layerTypes {
-                return layerTypes.enumerated().compactMap { index, layerType in
-                    layerType == "full_attention" ? index : nil
-                }
-            }
-
-            return Array(0 ..< hiddenLayers)
-        }
-        private let _ropeTheta: Float?
-        public var ropeTheta: Float { _ropeTheta ?? 1000000.0 }
-
-        enum CodingKeys: String, CodingKey {
-            case modelType = "model_type"
-            case hiddenSize = "hidden_size"
-            case hiddenLayers = "num_hidden_layers"
-            case attentionHeads = "num_attention_heads"
-            case kvHeads = "num_key_value_heads"
-            case vocabularySize = "vocab_size"
-            case _normEps = "norm_eps"
-            case _convBias = "conv_bias"
-            case _convLCache = "conv_L_cache"
-            case _blockDim = "block_dim"
-            case _blockFFDim = "block_ff_dim"
-            case _blockMultipleOf = "block_multiple_of"
-            case _blockFFNDimMultiplier = "block_ffn_dim_multiplier"
-            case _blockAutoAdjustFFDim = "block_auto_adjust_ff_dim"
-            case _fullAttnIdxs = "full_attn_idxs"
-            case layerTypes = "layer_types"
-            case _ropeTheta = "rope_theta"
-        }
-    }
+    /// Text-config alias — the underlying parser lives in
+    /// `MLXLMCommon.LFM2.Configuration` and is shared between the LLM and
+    /// VLM targets (issue #168 consolidation).
+    public typealias TextConfiguration = LFM2.Configuration
 
     public struct VisionConfiguration: Codable, Sendable {
         public let modelType: String


### PR DESCRIPTION
Second of 8 model-family consolidation PRs from issue #168. Lifts the
LFM 2 hybrid attention/short-conv layer stack into a public `LFM2`
namespace under `MLXLMCommon/Models/LFM2.swift`.

## What's shared

- `LFM2.Configuration` — handles both top-level and nested `rope_parameters` decoding, accepts both LLM and VLM JSON shapes.
- `LFM2.Attention` — uses `applyRotaryPosition` for `BatchPositionedKVCache` compat (LLM-side pattern).
- `LFM2.ShortConv` — SSMStateCache-backed hybrid layer.
- `LFM2.MLP` — gated SwiGLU with auto-adjust ffDim.
- `LFM2.DecoderLayer` — dispatches to Attention or ShortConv based on `fullAttnIdxs.contains(layerIdx)`.
- `LFM2.ModelInner` — embed → N hybrid blocks → norm, supports `inputEmbeddings` for vision-fusion.

## Per-target wrappers

- **`MLXLLM/Models/LFM2.swift`**: `LFM2Model: LLMModel` shrinks to a thin wrapper around `LFM2.ModelInner` + tied lm_head (`embedTokens.asLinear(out)`). Back-compat typealias `LFM2Configuration = LFM2.Configuration`.
- **`MLXVLM/Models/LFM2VL.swift`**: `Language.LanguageModel` keeps its `LMOutput` wrap + conv-weight transpose sanitize, now wrapping `LFM2.ModelInner`. The duplicated `Language.LFM2*` layer classes are gone. `LFM2VLConfiguration.TextConfiguration` is now a typealias to `LFM2.Configuration`. Preemptive prefill-sync `eval()` barrier added to `LFM2VL.prepare` mirroring the Gemma 3 / Gemma 4 VLM fix from #169.

Net diff: **+405 / -667** lines (~262-line reduction).

## Verification

- `swift build` clean across MLXLMCommon, MLXLLM, MLXVLM.
- `swift test --configuration release`: 203/204 (the 1 "failure" is the env-driven `InferenceBenchmark.benchmark()` scaffold; pre-existing).
- LLM smoke `mlx-community/LFM2-1.2B-4bit --method simple`: `"My name is AI Assistant..."` (254 tok/s)
- VLM smoke `mlx-community/LFM2-VL-1.6B-4bit --method vision`: `"The image shows a golden retriever..."` (292 tok/s, validation passes — "dog" in 136-token output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)