### PR TITLE
feat(qwen3): consolidate MLP + add VLM prefill-sync barrier (WS-C #5)

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen3.swift
+++ b/Libraries/MLXLLM/Models/Qwen3.swift
@@ -228,21 +228,10 @@ class Qwen3Attention: Module {
     }
 }
 
-class Qwen3MLP: Module, UnaryLayer {
-    @ModuleInfo(key: "gate_proj") var gate: Linear
-    @ModuleInfo(key: "down_proj") var down: Linear
-    @ModuleInfo(key: "up_proj") var up: Linear
-
-    public init(dimensions: Int, hiddenDimensions: Int) {
-        _gate.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
-        _down.wrappedValue = Linear(hiddenDimensions, dimensions, bias: false)
-        _up.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
-    }
-
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
-        down(silu(gate(x)) * up(x))
-    }
-}
+// `Qwen3MLP` is now an alias for the shared `Qwen3.MLP` in MLXLMCommon.
+// Issue #168 consolidation pass — the SwiGLU MLP is bit-identical between
+// the Qwen 3 LLM and Qwen3VL.
+typealias Qwen3MLP = Qwen3.MLP
 
 class Qwen3TransformerBlock: Module {
     @ModuleInfo(key: "self_attn") var attention: Qwen3Attention

--- a/Libraries/MLXLMCommon/Models/Qwen3.swift
+++ b/Libraries/MLXLMCommon/Models/Qwen3.swift
@@ -1,0 +1,81 @@
+// Copyright © 2026 Apple Inc.
+//
+// Shared Qwen 3 building blocks. The Qwen 3 family has substantive
+// architectural divergence between LLM and VLM that prevents a full
+// layer-stack consolidation in this PR:
+//
+// - LLM `Qwen3Attention` uses standard `applyRotaryPosition(rope, ...)`
+//   and ships alpha-side perf work (`batchedForward`,
+//   `fullyBatchedForward` for batched inference).
+// - VLM `Qwen3VL` Attention uses M-RoPE (multimodal rotary): takes a
+//   `positionIds` array, computes `(cos, sin)` via a custom
+//   `RotaryEmbedding` class, and applies via
+//   `Qwen3VLLanguage.applyMultimodalRotary(q:k:cos:sin:)`.
+//
+// Forcing a single shared Attention would either gut the LLM's batched
+// forward optimisations or require a closure/protocol-based dispatch
+// that costs an indirection on the LLM hot path. Instead, this
+// namespace lifts the small set of pieces that ARE genuinely shareable
+// (configuration adapter + the SwiGLU MLP) and leaves Attention /
+// DecoderLayer / ModelInner per-target.
+//
+// Future work (aligned with `IMPLEMENTATION-PLAN.md`):
+//
+// - **M-RoPE shared helper** — once a second VLM family adopts the
+//   same M-RoPE pattern (Qwen3VL is currently the only one in tree
+//   that needs it; Qwen 2.5 VL still uses standard rope), lift the
+//   `applyMultimodalRotary` + position-id construction to a shared
+//   helper and have both VLMs consume it.
+// - **Issue #115 (QKV batched fusion)** — when this lands, the
+//   LLM's `batchedForward` paths simplify to a single fused matmul,
+//   reducing the per-target divergence enough to enable a fuller
+//   Attention consolidation.
+//
+// Consolidation reference: issue #168.
+
+import Foundation
+import MLX
+import MLXNN
+
+/// Public namespace for the Qwen 3 text decoder. The layer-stack
+/// classes are intentionally NOT included here; see file-level note.
+public enum Qwen3 {
+
+    // MARK: - LayerArgs (adapter)
+
+    /// Minimum field set the shared MLP needs from any of the consuming
+    /// configurations. Each consumer's config provides a `var layerArgs:
+    /// Qwen3.LayerArgs` accessor.
+    public struct LayerArgs: Sendable {
+        public let hiddenSize: Int
+        public let intermediateSize: Int
+        public let rmsNormEps: Float
+
+        public init(hiddenSize: Int, intermediateSize: Int, rmsNormEps: Float) {
+            self.hiddenSize = hiddenSize
+            self.intermediateSize = intermediateSize
+            self.rmsNormEps = rmsNormEps
+        }
+    }
+
+    // MARK: - MLP
+
+    /// SwiGLU MLP — gate_proj / up_proj / down_proj with silu(gate) * up.
+    /// Bit-identical between the LLM and VLM Qwen 3 implementations.
+    public class MLP: Module, UnaryLayer {
+        @ModuleInfo(key: "gate_proj") var gate: Linear
+        @ModuleInfo(key: "down_proj") var down: Linear
+        @ModuleInfo(key: "up_proj") var up: Linear
+
+        public init(dimensions: Int, hiddenDimensions: Int) {
+            self._gate.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
+            self._down.wrappedValue = Linear(hiddenDimensions, dimensions, bias: false)
+            self._up.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
+            super.init()
+        }
+
+        public func callAsFunction(_ x: MLXArray) -> MLXArray {
+            down(silu(gate(x)) * up(x))
+        }
+    }
+}

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -1074,21 +1074,11 @@ enum Qwen3VLLanguage {
         }
     }
 
-    final class MLP: Module, UnaryLayer {
-        @ModuleInfo(key: "gate_proj") var gate: Linear
-        @ModuleInfo(key: "up_proj") var up: Linear
-        @ModuleInfo(key: "down_proj") var down: Linear
-
-        init(dimensions: Int, hiddenDimensions: Int) {
-            _gate.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
-            _up.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
-            _down.wrappedValue = Linear(hiddenDimensions, dimensions, bias: false)
-        }
-
-        func callAsFunction(_ x: MLXArray) -> MLXArray {
-            down(silu(gate(x)) * up(x))
-        }
-    }
+    /// Language-side MLP. Bit-identical to the LLM-side `Qwen3MLP`; both
+    /// resolve to `MLXLMCommon.Qwen3.MLP` via this alias (issue #168
+    /// consolidation). Vision-tower MLP at line 566 is a separate class
+    /// (different output dim / activation function) and stays local.
+    typealias MLP = Qwen3.MLP
 
     final class DecoderLayer: Module {
 
@@ -1674,6 +1664,20 @@ public final class Qwen3VL: Module, VLMModel, KVCacheDimensionProvider {
             pixelValues: pixelValues,
             imageGridTHW: imageFrames,
             videoGridTHW: videoFrames)
+
+        // Mirror the Gemma 3 / Gemma 4 / Mistral 3 / LFM 2 prefill-sync
+        // barrier (PR #172 / issue #169): hard `eval()` on cache + logits
+        // before returning `.logits(...)` so the iterator's first decode
+        // forward doesn't read pending K/V writes. Without this, Qwen3VL
+        // 4-bit prefills produce single-token-loop garbage on
+        // `Qwen3-VL-2B-Instruct-4bit` ("A Agro Agro Agro..." flood).
+        var cacheArrays: [MLXArray] = []
+        if let typedCache {
+            for c in typedCache {
+                cacheArrays.append(contentsOf: c.innerState())
+            }
+        }
+        eval(cacheArrays + [languageOutput.logits])
 
         return .logits(languageOutput)
     }


### PR DESCRIPTION
WS-C #5 of issue #168. Modest but real consolidation — the Qwen 3 family has substantive architectural divergence (LLM uses standard RoPE + alpha batched-forward perf work; Qwen3VL uses M-RoPE) that prevents a full layer-stack share in this PR. Lifts the truly-shared piece (SwiGLU MLP) and ships a real bug fix surfaced by VLM smoke verification.

## What's shared

- `Qwen3.MLP` — gate_proj / up_proj / down_proj SwiGLU; bit-identical between LLM `Qwen3MLP` and VLM `Qwen3VLLanguage.MLP`.
- `Qwen3.LayerArgs` — adapter struct.

## What's NOT shared (and why — perf-preservation)

- **LLM Attention** ships alpha-side `batchedForward` / `fullyBatchedForward` (single-matmul batched projections + per-request RoPE + `BatchedKVCache` fast paths). Forcing a unified shared Attention with the VLM's M-RoPE dispatch would either regress these batched paths or impose closure/protocol indirection on the LLM hot path.
- **VLM Attention** uses M-RoPE (multimodal rotary): takes `positionIds`, computes `(cos, sin)` via `Qwen3VLVision.VisionRotaryEmbedding`, applies via `Qwen3VLLanguage.applyMultimodalRotary`.

## Companion bug fix (real value of this PR)

`mlx-community/Qwen3-VL-2B-Instruct-4bit --method vision` produced a single-token loop on alpha:
```
Output: A Agro Agro Agro Agro Agro Agro Agro Agro Agro Agro Agro Agro... (200 tokens)
```

Same class of prefill-sync bug as Gemma 3 / Gemma 4 / Mistral 3 / LFM 2 VLMs (see [PR #172](https://github.com/ekryski/mlx-swift-lm/pull/172) / [issue #169](https://github.com/ekryski/mlx-swift-lm/issues/169)). Qwen3VL `prepare(...)` returned `.logits(languageOutput)` without an `eval()` barrier, leaving prefill K/V writes pending when the iterator's first decode forward fired.

Fix: hard `eval(cacheArrays + [logits])` before returning. Bug verified pre-existing on alpha by checkout — not introduced by this consolidation.

## Future-work alignment (per IMPLEMENTATION-PLAN.md)

- **M-RoPE shared helper** — once a second VLM family adopts the same M-RoPE pattern (Qwen 2.5 VL currently uses standard rope), lift `applyMultimodalRotary` + position-id construction to a shared helper and have both VLMs consume it.
- **Issue [#115](https://github.com/ekryski/mlx-swift-lm/issues/115) (QKV batched fusion)** — when this lands, the LLM's `batchedForward` paths simplify to a single fused matmul, reducing per-target divergence enough to enable a fuller Attention consolidation. Track on that issue.

## Verification

- `swift build` clean across MLXLMCommon / MLXLLM / MLXVLM.
- LLM smoke `mlx-community/Qwen3-1.7B-4bit --method simple` (`What is 2+2?`): emits `<think>` thinking-mode prefix, 117 tokens at 158 tok/s.
- VLM smoke `mlx-community/Qwen3-VL-2B-Instruct-4bit --method vision`: `"A full-length, medium-sized, golden retriever stands on a rounded, gray stone..."` (validation passes — keyword "dog" present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)