### PR TITLE
feat(gemma4): lift specialised RMSNorm variants into MLXLMCommon (WS-C #7)

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4.swift
+++ b/Libraries/MLXLLM/Models/Gemma4.swift
@@ -205,6 +205,12 @@ private func gemma4TopK(_ a: MLXArray, k: Int, axis: Int = -1) -> (
 // v_norm uses MLXFast.rmsNorm with a ones weight (no learnable scale).
 // This fuses the 3-dispatch manual implementation (square, mean, rsqrt*mul)
 // into a single optimized kernel dispatch.
+//
+// Functionally equivalent to `MLXLMCommon.Gemma4.RMSNormNoScale`
+// (which the VLM uses); the LLM keeps the inline call to preserve
+// the fused-norm-rope hot path that wraps it. The MLXNN.RMSNorm uses
+// elsewhere in this file are likewise functionally equivalent to
+// `MLXLMCommon.Gemma4.RMSNormZeroShift`.
 
 // MARK: - ProportionalRoPE
 

--- a/Libraries/MLXLMCommon/Models/Gemma4.swift
+++ b/Libraries/MLXLMCommon/Models/Gemma4.swift
@@ -1,0 +1,98 @@
+// Copyright © 2026 Apple Inc.
+//
+// Shared Gemma 4 building blocks. Like Qwen 3 (PR #177) and GLM 4
+// (PR #178), the Gemma 4 family has substantive architectural
+// divergence between LLM and VLM that prevents a full layer-stack
+// consolidation in this PR. The LLM has alpha-branch perf work — most
+// importantly compiled QKV projection, the `MLXFast.rmsNormRoPE` fused
+// norm+rope kernel path (gated by `_fusedInvFreqs`), the conditional
+// `Gemma4SharedMLP` gate+down compile (tuned ON for dense E2B/E4B/31B,
+// OFF for MoE 26B-A4B per a measured ~10% regression), the fused
+// logit softcap and the fused gelu+mul PLE projection. Forcing a
+// unified `Attention` / `MLP` / `DecoderLayer` would either silently
+// regress these or impose an indirection on the LLM hot path.
+//
+// What lives here is bit-identical and has no perf-sensitive
+// instantiation pattern: the two specialised RMSNorm variants the
+// VLM defines as private final classes. The LLM currently uses
+// `MLXNN.RMSNorm` directly (which initialises weight=ones and calls
+// the same `MLXFast.rmsNorm` kernel — functionally equivalent to
+// `RMSNormZeroShift`) and an inline `MLXFast.rmsNorm(weight: .mlxNone)`
+// for v_norm (functionally equivalent to `RMSNormNoScale`); both
+// equivalences are documented in the LLM file so the deliberate
+// non-share is auditable rather than accidental.
+//
+// Future-work alignment with `IMPLEMENTATION-PLAN.md`:
+//
+// - **Spec 024 — KV cache write fusion** (Tier 4 follow-up). Gemma 4
+//   E2B was the trigger model for the 60-copy decode-path regression.
+//   The shared K/V update pattern lifted by that spec is what would
+//   eventually justify a consolidated `Gemma4DecoderLayer` here.
+// - **Spec 029 — ANE LM head + Gemma 4 PLE projection**. PLE
+//   projection is the natural ANE-offload boundary; a consolidated
+//   `Gemma4Backbone` would expose it cleanly to the dispatch shim.
+// - **Issue #115 — `MLXFast.batchedQKVQuantizedGEMV`** and
+//   **issue #117 — RMSNorm + GEMV fusion**. Today the LLM uses
+//   `MLXFast.rmsNormRoPE` (a similar fused kernel) only for Gemma 4;
+//   when those two issues land, both attention paths converge on the
+//   same primitive and an `Attention` consolidation becomes safe.
+// - **Cross-family M-RoPE helper** (deferred from PR #177 / #178).
+//   Gemma 4 doesn't need it (no multimodal positionIds stack), but
+//   the helper landing for Qwen3VL / GlmOcr unblocks the same kind of
+//   second-pass consolidation here.
+//
+// Consolidation reference: issue #168.
+
+import Foundation
+import MLX
+import MLXNN
+
+/// Public namespace for the Gemma 4 text decoder. Layer-stack classes
+/// (Attention / MLP / DecoderLayer / Backbone) are intentionally NOT
+/// included here; see file-level note.
+public enum Gemma4 {
+
+    // MARK: - RMSNorm variants
+
+    /// RMSNorm with no learnable scale — `weight` is `.mlxNone` and the
+    /// kernel applies pure `x / rms(x)`. Used for the value projection
+    /// (v_norm) and for the MoE router's input norm in the Gemma 4 text
+    /// decoder. Bit-identical between the LLM (which calls
+    /// `MLXFast.rmsNorm(weight: .mlxNone)` inline) and the VLM (which
+    /// wraps the same call in a `private final class`).
+    public final class RMSNormNoScale: Module, UnaryLayer {
+        public let eps: Float
+
+        public init(eps: Float = 1e-6) {
+            self.eps = eps
+            super.init()
+        }
+
+        public func callAsFunction(_ x: MLXArray) -> MLXArray {
+            MLXFast.rmsNorm(x, weight: MLXArray.mlxNone, eps: eps)
+        }
+    }
+
+    /// RMSNorm with a learnable weight initialised to ones — `out =
+    /// x / rms(x) * weight`, *no* `(1 + weight)` shift (as in the
+    /// original Gemma 1/2 family). Functionally equivalent to
+    /// `MLXNN.RMSNorm`; the explicit class exists so the VLM's
+    /// `Gemma4Text*` decoder can reuse the same name shape as the
+    /// upstream Python port and so any future Gemma 4-specific norm
+    /// kernel (e.g. issue #117 RMSNorm+GEMV fusion) has one type to
+    /// dispatch through.
+    public final class RMSNormZeroShift: Module, UnaryLayer {
+        public let eps: Float
+        @ModuleInfo public var weight: MLXArray
+
+        public init(dimensions: Int, eps: Float = 1e-6) {
+            self.eps = eps
+            self._weight.wrappedValue = MLXArray.ones([dimensions])
+            super.init()
+        }
+
+        public func callAsFunction(_ x: MLXArray) -> MLXArray {
+            MLXFast.rmsNorm(x, weight: weight, eps: eps)
+        }
+    }
+}

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -447,33 +447,16 @@ public struct Gemma4Configuration: Codable, Sendable {
 
 // MARK: - Text
 
-private final class Gemma4RMSNormNoScale: Module, UnaryLayer {
-    let eps: Float
-
-    init(eps: Float = 1e-6) {
-        self.eps = eps
-        super.init()
-    }
-
-    func callAsFunction(_ x: MLXArray) -> MLXArray {
-        MLXFast.rmsNorm(x, weight: MLXArray.mlxNone, eps: eps)
-    }
-}
-
-private final class Gemma4RMSNormZeroShift: Module, UnaryLayer {
-    let eps: Float
-    @ModuleInfo var weight: MLXArray
-
-    init(dimensions: Int, eps: Float = 1e-6) {
-        self.eps = eps
-        self._weight.wrappedValue = MLXArray.ones([dimensions])
-        super.init()
-    }
-
-    func callAsFunction(_ x: MLXArray) -> MLXArray {
-        MLXFast.rmsNorm(x, weight: weight, eps: eps)
-    }
-}
+// Lifted to `MLXLMCommon.Gemma4` — see file-level note in
+// `Libraries/MLXLMCommon/Models/Gemma4.swift`. The two classes are
+// bit-identical between LLM and VLM; only the VLM wraps them in
+// dedicated types, while the LLM uses `MLXNN.RMSNorm` directly
+// (functionally equivalent to `RMSNormZeroShift`) and an inline
+// `MLXFast.rmsNorm(weight: .mlxNone)` (functionally equivalent to
+// `RMSNormNoScale`). The deliberate non-share on the LLM side
+// preserves its compiled-QKV / fused-norm-rope hot paths.
+private typealias Gemma4RMSNormNoScale = MLXLMCommon.Gemma4.RMSNormNoScale
+private typealias Gemma4RMSNormZeroShift = MLXLMCommon.Gemma4.RMSNormZeroShift
 
 private final class Gemma4TextMLP: Module, UnaryLayer {
     @ModuleInfo(key: "gate_proj") var gateProj: Linear


### PR DESCRIPTION
## Summary

WS-C #7: lift the two specialised RMSNorm variants the VLM defines as `private final` (`Gemma4RMSNormNoScale`, `Gemma4RMSNormZeroShift`) into a new public `MLXLMCommon.Gemma4` namespace. Conservative scope on purpose — see the **why only the norm classes** section.

## Why only the norm classes

The LLM has substantial alpha-branch perf work that we explicitly **preserve** rather than consolidate away:

- compiled QKV projection
- the `MLXFast.rmsNormRoPE` fused norm+rope kernel path (gated by `_fusedInvFreqs`)
- the conditional `Gemma4SharedMLP` gate+down compile (tuned ON for dense E2B/E4B/31B, OFF for MoE 26B-A4B per a measured ~10% regression)
- the fused logit softcap and the fused gelu+mul PLE projection

Forcing a unified `Attention` / `MLP` / `DecoderLayer` would either silently regress these or impose an indirection on the LLM hot path. The VLM's `Gemma4Text*` decoder is the upstream Python-port shape without the alpha surgery; lifting only the bit-identical norm classes leaves the per-target instantiation pattern intact.

Functional equivalences are now annotated in [Libraries/MLXLLM/Models/Gemma4.swift](Libraries/MLXLLM/Models/Gemma4.swift) so the deliberate non-share is auditable rather than accidental:

- `MLXNN.RMSNorm` (LLM, used everywhere) ≡ `MLXLMCommon.Gemma4.RMSNormZeroShift` — both init `weight = ones` and call `MLXFast.rmsNorm(x, weight, eps)`.
- inline `MLXFast.rmsNorm(weight: .mlxNone)` (LLM, used for v_norm) ≡ `MLXLMCommon.Gemma4.RMSNormNoScale`.

## What's shared

- `MLXLMCommon.Gemma4.RMSNormNoScale` — `MLXFast.rmsNorm(weight: .mlxNone)`. Used by VLM `Gemma4TextAttention.v_norm` and `Gemma4TextRouter.norm`.
- `MLXLMCommon.Gemma4.RMSNormZeroShift` — `MLXFast.rmsNorm(weight: weight)` with `weight = ones` initialisation, no `(1 + weight)` shift (per the original Gemma 1/2 family). Used by every layer norm + q_norm + k_norm in the VLM text decoder.

## What's NOT shared (documented in the file-level note)

- **Attention / MLP / DecoderLayer / Backbone** — alpha-branch perf rationale above.
- **`ProportionalRoPE`** — the LLM defines a Gemma 4-tuned variant (inf-padded freqs to pass-through unrotated dims) at [Libraries/MLXLLM/Models/Gemma4.swift:221](Libraries/MLXLLM/Models/Gemma4.swift#L221); the VLM dispatches via `initializeRope` to `MLXLMCommon.RoPEUtils.ProportionalRoPE` (general-purpose, split-pair algorithm). The two intentionally diverge to match the upstream Python ports; unifying them is a correctness check out of scope for this sprint.

## KV-shared MLP gap (per WS-C plan)

Both LLM (`Gemma4SharedMLP`) and VLM (`Gemma4TextMLP`) implement the double-wide MLP path identically: `useDoubleWideMlp` is consulted but only activates when `numKvSharedLayers > 0`. Default config values diverge — LLM defaults to `false`, VLM to `true` — but both are functionally equivalent for the current model set (no shipped Gemma 4 checkpoint sets `numKvSharedLayers > 0`). Documenting here rather than fixing — `useDoubleWideMlp` is genuinely unused without KV sharing and the field-decay isn't user-visible.

## Future-work alignment with `IMPLEMENTATION-PLAN.md`

- **Spec 024 — KV cache write fusion** (Tier 4). Gemma 4 E2B was the trigger model for the 60-copy decode-path regression; the shared K/V update pattern that spec lifts is what would justify a consolidated `Gemma4DecoderLayer` here.
- **Spec 029 — ANE LM head + Gemma 4 PLE projection**. PLE projection is the natural ANE-offload boundary; a consolidated `Gemma4Backbone` would expose it cleanly.
- **Issue #115 — `MLXFast.batchedQKVQuantizedGEMV`** + **issue #117 — RMSNorm + GEMV fusion**. Today the LLM uses `MLXFast.rmsNormRoPE` (a similar fused kernel) only for Gemma 4; when those issues land, both attention paths converge on the same primitive and an `Attention` consolidation becomes safe.
- **Cross-family M-RoPE helper** (deferred from PR #177 / #178). Gemma 4 doesn't need it (no multimodal positionIds stack), but the helper's landing for Qwen3VL / GlmOcr unblocks the same kind of second-pass consolidation here.

## Verification (M1 Max 64GB)

- `swift build` clean across LLM + VLM + Common targets.
- `swift test --filter Gemma4` — **7/7 tests pass** (configuration dual decoding + UserInput modality ordering + nested rope params).
- **LLM smoke** \`mlx-community/gemma-4-e2b-it-4bit\`, kv=none, simple: 307.3 tok/s prefill, 92.0 tok/s decode, 126ms TTFT, 2.60GB peak. Coherent output: _"Hello! I am a helpful assistant. I can help you with various tasks like answering questions, generating text, summarizing information, and more. How c…"_
- **VLM smoke** \`mlx-community/gemma-4-e2b-it-4bit\`, kv=none, vision: 449.2 tok/s prefill, 103.1 tok/s decode, 666ms TTFT, 4.65GB peak. Coherent output: _"This is a photograph of a dog, likely a Golden Retriever, standing outdoors in front of a house."_ — issue #169 prefill-sync barrier still working (no `<pad>` flood).

## Test plan

- [x] \`swift build\` clean
- [x] \`swift test --filter Gemma4\` passes 7/7
- [x] \`./scripts/benchmark.sh --model gemma4-e2b --quant 4bit --kv none --method simple\` produces coherent text output, decode tok/s within ±2% of pre-PR
- [x] \`./scripts/benchmark.sh --model gemma4-e2b --quant 4bit --kv none --method vision\` produces coherent dog description with no \`<pad>\` flood

Closes one of the 8 WS-C consolidation entries listed under issue #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)