### PR TITLE
feat(qwen35): lift VLM SwiGLU MLP into MLXLMCommon + fix VLM prefill-sync (WS-C #8)

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -622,6 +622,11 @@ final class Qwen35DecoderLayer: Module {
         if args.numExperts > 0 {
             _mlp.wrappedValue = Qwen35SparseMoeBlock(args)
         } else {
+            // Uses the fused `gate_up_proj` `Qwen3NextMLP` rather than
+            // the separate-projection `MLXLMCommon.Qwen35.MLP` the VLM
+            // imports — alpha-branch perf path. See file-level note in
+            // `Libraries/MLXLMCommon/Models/Qwen35.swift` for why the
+            // non-share is deliberate.
             _mlp.wrappedValue = Qwen3NextMLP(
                 dimensions: args.hiddenSize,
                 hiddenDimensions: args.intermediateSize

--- a/Libraries/MLXLMCommon/Models/Qwen35.swift
+++ b/Libraries/MLXLMCommon/Models/Qwen35.swift
@@ -1,0 +1,100 @@
+// Copyright © 2026 Apple Inc.
+//
+// Shared Qwen 3.5 building blocks. The Qwen 3.5 family is the
+// trickiest of the WS-C consolidation sprint because it is a hybrid
+// model — `GatedDeltaNet` (GDN) SSM blocks alternate with standard
+// attention blocks via a `layer_types` config — and because the LLM
+// has substantial alpha-branch perf work that we explicitly preserve:
+//
+// - **Fused `gate_up_proj` MLP** (`Qwen3NextMLP` in
+//   `Libraries/MLXLLM/Models/Qwen3Next.swift`): the LLM merges the
+//   per-expert `gate_proj` and `up_proj` linears into a single
+//   `gate_up_proj` matmul at sanitize time (see `fuseGateUpWeights`
+//   in `Libraries/MLXLLM/Models/Qwen35.swift`). Forcing the VLM to
+//   use this would change its weight-loading shape; forcing the LLM
+//   onto the separate-projection class would silently regress decode.
+// - **Fused GDN decode dispatch**
+//   (`Qwen35GatedDeltaNet.callAsFunction` decode S==1 path): dispatches
+//   `fusedGatedDeltaUpdate` (single Metal kernel) instead of the
+//   ops-based `gatedDeltaUpdate`, saving 4–6 dispatches/layer/token.
+//   Plus `.contiguous()` safety on the conv-state slice that prevents
+//   the 9 GB lazy-chain blow-up at long contexts. The VLM's GDN runs
+//   the slower ops path everywhere and has no such safety calls; the
+//   two GDN classes are *near*-identical but not interchangeable.
+// - **Batched speculative-decoding paths** (`fullyBatchedForward` on
+//   both `Qwen35Attention` and `Qwen35GatedDeltaNet`): LLM-only.
+// - **Turbo KV boundary-layer skip** in
+//   `Qwen35TextModel.newCache(parameters:)`: preserves first-N /
+//   last-N attention layers uncompressed. Not in the VLM (which has
+//   no turbo path).
+//
+// What lives here is the **standard separate-projection SwiGLU MLP**
+// the VLM uses for both its dense decoder layers and the
+// `SparseMoeBlock.sharedExpert`. It is bit-identical to other
+// Qwen-family MLPs (Qwen 2 / Qwen 3 — both already lifted via PR
+// #175 / #177), shipped here with the `Qwen35.` namespace prefix so
+// the consolidation pattern stays per-family rather than relying on
+// cross-family typealias chains.
+//
+// Future-work alignment with `IMPLEMENTATION-PLAN.md`:
+//
+// - **Spec 020 phase 2 — `SSMStateCache: TapeReplayCache` + Metal
+//   kernel** (Tier 1). Both LLM
+//   (`Libraries/MLXLLM/Models/Qwen35.swift` `newCache(parameters:)`)
+//   and VLM (`Libraries/MLXVLM/Models/Qwen35.swift`
+//   `LanguageModel.makeCache`) instantiate `SSMStateCache()` inline
+//   for hybrid linear-attention layers. Phase 2 will need to update
+//   both factories. The right time to lift them into a single
+//   `Qwen35.makeHybridCache(...)` helper here is when phase 2 lands —
+//   the helper signature is shaped by the new `TapeReplayCache`
+//   protocol, which doesn't exist yet.
+// - **Spec 028 — chunkwise WY GatedDeltaNet prefill** (Tier 4). The
+//   LLM's fused decode path is the natural target for the chunkwise
+//   variant; once spec 028 lands, the GDN class becomes a candidate
+//   for cross-target lift.
+// - **Issue #115 — `MLXFast.batchedQKVQuantizedGEMV`**, **issue #117
+//   — RMSNorm + GEMV fusion**. Same pattern as Qwen 3 (PR #177): once
+//   the LLM's `fullyBatchedForward` paths simplify to a single fused
+//   matmul, an `Attention` consolidation becomes safe.
+// - **Cross-family M-RoPE helper** (deferred from PR #177 / #178).
+//   The VLM's `Qwen35Language.RotaryEmbedding` is the same M-RoPE
+//   shape as Qwen3VL / GlmOcr; the helper landing for those unblocks
+//   the same kind of second-pass consolidation here.
+//
+// Consolidation reference: issue #168.
+
+import Foundation
+import MLX
+import MLXNN
+
+/// Public namespace for the Qwen 3.5 text decoder. Only the standard
+/// separate-projection SwiGLU MLP is included; see file-level note for
+/// why everything else is per-target.
+public enum Qwen35 {
+
+    // MARK: - MLP
+
+    /// Standard SwiGLU MLP — `gate_proj` / `up_proj` / `down_proj` with
+    /// `silu(gate) * up`. Bit-identical to the Qwen 3 / Qwen 2 standard
+    /// SwiGLU; shipped under the `Qwen35.` prefix to keep the
+    /// consolidation-namespace boundary per-family. Used by the VLM's
+    /// dense `DecoderLayer.mlp` and by its `SparseMoeBlock.sharedExpert`.
+    /// The LLM uses its alpha-branch fused-`gate_up_proj` variant
+    /// (`Qwen3NextMLP`) instead — see file-level note.
+    public class MLP: Module, UnaryLayer {
+        @ModuleInfo(key: "gate_proj") var gate: Linear
+        @ModuleInfo(key: "down_proj") var down: Linear
+        @ModuleInfo(key: "up_proj") var up: Linear
+
+        public init(dimensions: Int, hiddenDimensions: Int) {
+            self._gate.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
+            self._down.wrappedValue = Linear(hiddenDimensions, dimensions, bias: false)
+            self._up.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
+            super.init()
+        }
+
+        public func callAsFunction(_ x: MLXArray) -> MLXArray {
+            down(silu(gate(x)) * up(x))
+        }
+    }
+}

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1147,6 +1147,21 @@ public class Qwen35: Module, VLMModel {
             videoGridTHW: videoFrames
         )
 
+        // Issue #181: Qwen 3.5 VLM's prefill leaves K/V (standard
+        // attention) and SSM-state (GatedDeltaNet linear-attention)
+        // writes pending in the command buffer. Without an eval barrier
+        // here, the iterator's first decode forward reads the cache
+        // before those writes commit, producing a token-loop ("The!!!…")
+        // on vision input. Mirrors the same fix landed for Gemma 3 /
+        // Gemma 4 / Mistral 3 / LFM 2 / Qwen 3 VL — `innerState()` on
+        // `SSMStateCache` (via `ArraysCache`) returns the conv + recurrent
+        // tensors, so the same iteration covers the hybrid stack.
+        var cacheArrays: [MLXArray] = []
+        for c in cache {
+            cacheArrays.append(contentsOf: c.innerState())
+        }
+        eval(cacheArrays + [output.logits])
+
         return .logits(output)
     }
 

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -554,22 +554,12 @@ enum Qwen35Language {
         }
     }
 
-    final class MLP: Module, UnaryLayer {
-        @ModuleInfo(key: "gate_proj") var gateProj: Linear
-        @ModuleInfo(key: "down_proj") var downProj: Linear
-        @ModuleInfo(key: "up_proj") var upProj: Linear
-
-        init(dimensions: Int, hiddenDimensions: Int) {
-            _gateProj.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
-            _downProj.wrappedValue = Linear(hiddenDimensions, dimensions, bias: false)
-            _upProj.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
-            super.init()
-        }
-
-        func callAsFunction(_ x: MLXArray) -> MLXArray {
-            downProj(silu(gateProj(x)) * upProj(x))
-        }
-    }
+    // Lifted to `MLXLMCommon.Qwen35.MLP` — see file-level note in
+    // `Libraries/MLXLMCommon/Models/Qwen35.swift`. Bit-identical
+    // separate-projection SwiGLU MLP; the deliberate non-share with
+    // the LLM (which uses its fused-`gate_up_proj` `Qwen3NextMLP`) is
+    // documented in that file.
+    typealias MLP = MLXLMCommon.Qwen35.MLP
 
     final class GatedDeltaNet: Module {
         let hiddenSize: Int


### PR DESCRIPTION
## Summary

Final WS-C consolidation: lift the VLM's standard separate-projection SwiGLU MLP (`gate_proj` / `up_proj` / `down_proj`) into a new public `MLXLMCommon.Qwen35` namespace. Conservative scope on purpose — Qwen 3.5 is the trickiest of the eight families because of its hybrid GatedDeltaNet (GDN) + Attention stack and the LLM's substantial alpha-branch perf work.

**Also fixes [#181](https://github.com/ekryski/mlx-swift-lm/issues/181)**: the VLM's `prepare` was returning `.logits(...)` without flushing the pending prefill K/V + SSM-state writes, producing a token-loop on vision input. The bug surfaced during VLM smoke verification of this PR, but is pre-existing on alpha; folding the fix in here because the smoke run is what found it and the patch lives in the same file the typealias already touches.

## Why the LLM doesn't share the lifted MLP

The LLM uses `Qwen3NextMLP` (defined in [Libraries/MLXLLM/Models/Qwen3Next.swift](Libraries/MLXLLM/Models/Qwen3Next.swift)), which is a **fused** `gate_up_proj` matmul producing `2 * intermediate` outputs in a single linear. The LLM's `Qwen35Model.sanitize` merges incoming `gate_proj` + `up_proj` weights into the fused layout (see `fuseGateUpWeights`). Forcing the VLM onto this shape would change its weight-loading path; forcing the LLM onto the separate-projection class would silently regress decode. Both classes are now annotated to point at the file-level note that documents the deliberate split.

## Other LLM-only alpha-branch perf work explicitly preserved

- **Fused GDN decode dispatch** (`Qwen35GatedDeltaNet` decode S==1 path): `fusedGatedDeltaUpdate` saves 4–6 dispatches per layer per token, and `.contiguous()` safety on the conv-state slice prevents the 9 GB lazy-chain blow-up at long contexts. The VLM's GDN runs the slower ops path everywhere.
- **`fullyBatchedForward`** on both `Qwen35Attention` and `Qwen35GatedDeltaNet` — LLM-only batched speculative-decoding paths.
- **Turbo KV boundary-layer skip** in `Qwen35TextModel.newCache(parameters:)` — preserves first-N / last-N attention layers uncompressed.

## What's shared

- `MLXLMCommon.Qwen35.MLP` — standard SwiGLU MLP, used by the VLM's dense `DecoderLayer.mlp` and by its `SparseMoeBlock.sharedExpert`. Bit-identical to other Qwen-family MLPs (Qwen 2 / Qwen 3, lifted in PR #175 / #177); shipped under the `Qwen35.` prefix to keep the consolidation-namespace boundary per-family rather than relying on cross-family typealias chains.

## VLM prefill-sync fix (#181)

Same race we hit and fixed for Gemma 3 / Gemma 4 / Mistral 3 / LFM 2 / Qwen 3 VL (canonical fix #169), with one wrinkle: Qwen 3.5 is hybrid GDN+Attention, so its linear-attention layers store SSM conv + recurrent state via `SSMStateCache`, not the standard `keys` / `values`. The barrier works unmodified because `SSMStateCache: ArraysCache` already overrides `innerState()` to return its `cache` array (see [Libraries/MLXLMCommon/KVCache.swift:1206](Libraries/MLXLMCommon/KVCache.swift#L1206)) — so the same eval call covers both attention K/V and SSM state on the hybrid stack.

## Future-work alignment with `IMPLEMENTATION-PLAN.md`

- **Spec 020 phase 2 — `SSMStateCache: TapeReplayCache` + Metal kernel** (Tier 1). Both LLM (`Qwen35TextModel.newCache(parameters:)`) and VLM (`Qwen35Language.LanguageModel.makeCache`) instantiate `SSMStateCache()` inline for hybrid linear-attention layers. Phase 2 will need to update both factories. The right time to lift them into a single `Qwen35.makeHybridCache(...)` helper here is **when phase 2 lands** — the helper signature is shaped by the new `TapeReplayCache` protocol, which doesn't exist yet. Doing it now would lock in the wrong shape.
- **Spec 028 — chunkwise WY GatedDeltaNet prefill** (Tier 4). The LLM's fused decode path is the natural target for the chunkwise variant; once spec 028 lands, the GDN class becomes a candidate for cross-target lift.
- **Issue #115 (QKV batched fusion)** + **issue #117 (RMSNorm + GEMV fusion)**. Same pattern as Qwen 3 (PR #177): once the LLM's `fullyBatchedForward` paths simplify to a single fused matmul, an `Attention` consolidation becomes safe.
- **Cross-family M-RoPE helper** (deferred from PR #177 / #178). The VLM's `Qwen35Language.RotaryEmbedding` is the same M-RoPE shape as Qwen3VL / GlmOcr; the helper landing for those unblocks the same kind of second-pass consolidation here.

## Verification (M1 Max 64GB)

- `swift build` clean across LLM + VLM + Common targets.
- `swift test --filter ToolTests` — **39/39** tests pass.
- **LLM smoke** \`mlx-community/Qwen3.5-0.8B-4bit\`, kv=none, simple: 131.4 tok/s prefill, 162.8 tok/s decode, 314ms TTFT, 611MB peak. Coherent: _"I am **Qwen3.5**. I can help with various tasks including:"_

- **VLM smoke** \`mlx-community/Qwen3.5-27B-4bit\`, kv=none, vision, dog image, prompt _"Describe what you see in this image."_:

  | Run | Prefill | Decode | TTFT | Peak | Output |
  |---|---|---|---|---|---|
  | alpha (commit 7cc47e2) | 48.3 tok/s | 16.5 tok/s | 12033ms | 17.23GB | `"The!!!!!!!!!!!!!!!!!!!!!!!!!!!!…"` (200-token "!" loop, fails dog) |
  | This branch, pre-#181 fix | 43.7 tok/s | 16.6 tok/s | 13254ms | 17.24GB | `"The! </think> This is a full-body, eye-level photograph of a golden retriever…"` (leading-token glitch) |
  | **This branch + #181 fix (HEAD)** | 44.6 tok/s | 16.3 tok/s | 12998ms | 17.24GB | `"The user wants a description of the image. 1. Identify the main subject: It's a Golden Retriever dog. 2. Describe the dog's appearance…"` — clean, dog ID matched |

  The eval barrier is a one-time sync at end of prefill; perf delta vs pre-fix is within noise.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift test --filter ToolTests\` passes
- [x] \`./scripts/benchmark.sh --model qwen35-0.8b --quant 4bit --kv none --method simple\` produces coherent text output
- [x] \`./scripts/benchmark.sh --model mlx-community/Qwen3.5-27B-4bit --kv none --method vision --vision-prompt "Describe what you see in this image." --vision-expect dog\` produces coherent dog description (no token loop)

Closes the eighth and final WS-C consolidation entry under issue #168, plus #181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)