### PR TITLE
docs(specs): rebase 017 + 020 onto post-spec-006 KV-cache hierarchy

### DIFF
--- a/specs/017-prefix-kv-cache.md
+++ b/specs/017-prefix-kv-cache.md
@@ -28,7 +28,7 @@ public struct PrefixSnapshot: Sendable {
 }
 ```
 
-`LayerCacheState` is a sum type covering `KVCacheSimple`, `RotatingKVCache`, `QuantizedKVCache`, `TurboQuantKVCache`, and `MambaCache`. Each cache type already has a `.state: [MLXArray]` accessor; serialisation is trivial.
+`LayerCacheState` is a sum type covering the post-spec-006 cache hierarchy: `StandardKVCache` (unbounded or windowed), `AffineQuantizedKVCache`, `TurboQuantizedKVCache`, and `SSMStateCache`. Each cache type already has a `.state: [MLXArray]` accessor; the typed-surface exposed via `KVStorageKind` (raw / affineQuantized / turboCompressed / ssm / composite) lets the dispatch decide per-cache serialisation cost up front.
 
 ### 2. Cache
 
@@ -87,7 +87,7 @@ Hydration is a deep copy of the snapshot's MLXArrays into a fresh `[KVCache]` so
 
 After generation completes, the iterator's cache holds the full request state. We snapshot at the **stable prefix boundary** for the *next* request — that is, we trim the assistant response from the cache before snapshotting.
 
-For trimmable caches, this is `trimPromptCache(cache, numTokens: cache.offset - stablePrefixLen)`. For hybrid caches with non-trimmable Mamba layers, see spec 020 (tape-replay rollback) — without that, hybrid models can only snapshot at request *start* (before the assistant turn) which still helps.
+For trimmable caches, this is `trimPromptCache(cache, numTokens: cache.offset - stablePrefixLen)`. For hybrid caches with non-trimmable `SSMStateCache` layers (Qwen 3.5 / Qwen 3 Next / Nemotron-H / Jamba), see spec 020 (tape-replay rollback) — without that, hybrid models can only snapshot at request *start* (before the assistant turn) which still helps.
 
 ### 6. Eviction
 
@@ -122,30 +122,31 @@ vLLM reports 2–10× TTFT improvement on multi-turn chat with APC enabled. dfla
 
 ## Phasing
 
-1. **Phase 1** — `KVCacheSimple` + `RotatingKVCache` only; no Mamba. Token-exact prefix matching, no stable-prefix trim. Validates the snapshot/restore plumbing on Gemma 4 / GPT-OSS / Llama / Phi.
-2. **Phase 2** — `LastAssistantOpenerPolicy` + chat-aware stable prefix. Where multi-turn wins start.
-3. **Phase 3** — `MambaCache` snapshot via spec 020's tape-replay rollback (or a much simpler full-state checkpoint if 020 isn't shipped yet — Mamba state is small).
-4. **Phase 4** — Disk persistence (write snapshots to `~/.cache/mlx-swift-lm/prefix/`). Optional; mostly useful for bench reproducibility. **Realised upstream as `prefix_l2.py`** — see References.
+1. **Phase 1** — `StandardKVCache` (unbounded + windowed) only; no `SSMStateCache`. Token-exact prefix matching, no stable-prefix trim. Validates the snapshot/restore plumbing on Gemma 4 / GPT-OSS / Llama / Phi.
+2. **Phase 1B** — Per-class `serialise()` / `hydrate(from:)` on each concrete cache type (`StandardKVCache`, `AffineQuantizedKVCache`, `TurboQuantizedKVCache`). Wires `Evaluate.generate` lookup + hydrate + insert.
+3. **Phase 2** — `LastAssistantOpenerPolicy` + chat-aware stable prefix. Where multi-turn wins start.
+4. **Phase 3** — `SSMStateCache` snapshot via spec 020's tape-replay rollback (or a much simpler full-state checkpoint if 020 isn't shipped yet — SSM state is small).
+5. **Phase 4** — Disk persistence (write snapshots to `~/.cache/mlx-swift-lm/prefix/`). Optional; mostly useful for bench reproducibility. **Realised upstream as `prefix_l2.py`** — see References.
 
-## Phase 1 status (delivered)
+## Phase 1 status (PR #144, ready for review)
 
-Phase 1 landed in commit `69f72b5` on `alpha`:
+Phase 1 lives in [PR #144](https://github.com/ekryski/mlx-swift-lm/pull/144), rebased onto current `alpha` (post spec-006 / WS-A–D / consolidation sprint):
 
 - `Libraries/MLXLMCommon/PrefixKVCache.swift` (332 lines) — `PrefixKey`, `LayerCacheState` (opaque `[MLXArray]`), `PrefixSnapshot`, `PrefixCacheLookupResult`, `PrefixCacheStats`, `PrefixKVCache` class with `lookup` / `insert` / `clear` / `resetStats` + LRU eviction + byte-budget cap.
 - `Libraries/MLXLMCommon/StablePrefixPolicy.swift` (56 lines) — `StablePrefixPolicy` protocol + `IdentityPolicy` + `FixedTrimPolicy`.
 - `Tests/MLXLMTests/PrefixKVCacheTests.swift` — 21 tests covering exact/partial match, cross-model isolation, mismatch miss, LRU bump, byte-budget eviction, entry-count eviction, hitRate, meanMatchedLength.
 
-**Open work for phase 1B (per-cache serialise/hydrate):**
+**Open work for phase 1B (per-class `serialise` / `hydrate`):**
 
-- `LayerCacheState.arrays: [MLXArray]` is **opaque** ([PrefixKVCache.swift:73](../Libraries/MLXLMCommon/PrefixKVCache.swift)) — phase 1B replaces this with a typed `LayerCacheSnapshot` enum so hydration validates shape + dtype per cache class.
-- No `serialise()` / `hydrate(from:)` methods yet on `KVCacheSimple` / `RotatingKVCache` / `QuantizedKVCache` / `TurboQuantKVCache`. Each cache's existing `state: [MLXArray]` accessor is the starting point. Defer `MambaCache` to phase 3 (depends on spec 020).
-- `Evaluate.swift` is **not wired** — no calls to `prefixCache.lookup` or `.insert` in the generate path. Wire-in callsites: [Evaluate.swift:2092](../Libraries/MLXLMCommon/Evaluate.swift) (`generate(input:cache:parameters:context:wiredMemoryTicket:)`) and the analogous draft-model variant at line 2196.
+- `LayerCacheState.arrays: [MLXArray]` is **opaque** in `PrefixKVCache.swift` — phase 1B replaces this with a typed `LayerCacheSnapshot` enum so hydration validates shape + dtype per cache class. The enum dispatches via `KVStorageKind` (`.raw` / `.affineQuantized(bits:groupSize:)` / `.turboCompressed(keyBits:valueBits:)` / `.ssm` / `.composite`) — same axis the runtime already exposes for cache-typed dispatch.
+- No `serialise()` / `hydrate(from:)` methods yet on `StandardKVCache` / `AffineQuantizedKVCache` / `TurboQuantizedKVCache`. Each cache's existing `state: [MLXArray]` accessor is the starting point: `serialise()` returns the cache's `state` plus enough metaState (`maxSize`, `keep`, `groupSize`, `bits`, `keyBits`, `valueBits`, `compressedWriteOffset`, `rotatingIdx` etc.) to round-trip. `hydrate(from:)` is the constructor-shaped inverse. Defer `SSMStateCache` to phase 3 (depends on spec 020 phase 2).
+- `Evaluate.swift` is **not wired** — no calls to `prefixCache.lookup` or `.insert` in the generate path. Wire-in callsites: `generate(input:cache:parameters:context:wiredMemoryTicket:)` (currently around line 2065 in alpha; symbol-level edit) and the analogous draft-model variant.
 
 **Open work for phase 2 (chat-aware stable prefix):**
 
 - `LastAssistantOpenerPolicy` is **not** implemented — only `IdentityPolicy` + `FixedTrimPolicy` ship in phase 1. Phase 2 adds it with sentinel encodings for Qwen (`<|im_start|>assistant\n`), Gemma 4 (`<start_of_turn>model\n`), GPT-OSS (`<|start|>assistant<|channel|>`), pre-encoded at construction since the protocol's `stablePrefixLen(_:)` takes only `[Int]`.
 
-**Built against spec 006 PR 1 surface:** phase 1B's per-class serialise/hydrate methods target the post-spec-006 cache hierarchy (`StandardKVCache`, `AffineQuantizedKVCache`, `TurboQuantizedKVCache`) — the typealiases keep old class names working but new methods live on the new classes. Mamba layers stay as-is (outside spec 006's scope).
+**Built against the post-spec-006 KV-cache hierarchy:** phase 1B's per-class `serialise()` / `hydrate(from:)` methods target the post-spec-006 cache classes (`StandardKVCache`, `AffineQuantizedKVCache`, `TurboQuantizedKVCache`) — the legacy names (`KVCacheSimple` / `RotatingKVCache` / `QuantizedKVCache` / `TurboQuantKVCache`) are gone. `SSMStateCache` (renamed from `MambaCache`) gets its round-trip in phase 3 once spec 020 phase 2 lands the tape-replay infrastructure.
 
 ## dflash-mlx upstream updates since spec drafted
 
@@ -154,7 +155,7 @@ This spec was drafted against `bstnxbt/dflash-mlx@engine-v2`. Commit [`bc24ab0`]
 - **Cache subpackage** at [`dflash_mlx/cache/`](https://github.com/bstnxbt/dflash-mlx/tree/main/dflash_mlx/cache) replaces the single `prefix_cache.py`. Files we mirror conceptually:
   - [`fingerprints.py`](https://github.com/bstnxbt/dflash-mlx/blob/main/dflash_mlx/cache/fingerprints.py) — `DFlashPrefixKey` with `target_model_id`, `draft_model_id`, `capture_layer_ids: tuple[int, ...]`, `draft_sink_size`, `draft_window_size`, `target_fa_window`, `format_version: int = 1`. Phase 1B extends our `PrefixKey` with `captureLayerIds: [Int]?` (nil = all layers cached) and `formatVersion: Int = 1`.
   - [`snapshot.py`](https://github.com/bstnxbt/dflash-mlx/blob/main/dflash_mlx/cache/snapshot.py) — `DFlashPrefixSnapshot` carries chunked `target_hidden_chunks` + `target_hidden_chunk_spans` (sink + tail trim, not full hidden state) for the DFlash draft. Phase 1B reserves the shape: replace `lastHidden: MLXArray?` with `targetHiddenChunks: [(MLXArray, ClosedRange<Int>)]?` + `targetHiddenTotalLen: Int?`. Defaults to `nil` since we don't ship DFlash yet — reserves the on-wire shape without forcing a `formatVersion` bump later.
-  - [`policies.py`](https://github.com/bstnxbt/dflash-mlx/blob/main/dflash_mlx/cache/policies.py) — `target_cache_is_serializable(...)` returns `False` for **any `RotatingKVCache`**. Confirms our open-question 3: refuse to snapshot wrapped (post-rotation) rotating caches. Document explicitly + assert in `serialise()`.
+  - [`policies.py`](https://github.com/bstnxbt/dflash-mlx/blob/main/dflash_mlx/cache/policies.py) — `target_cache_is_serializable(...)` returns `False` for any cache whose Python equivalent is a `RotatingKVCache`. Our equivalent is **a windowed `StandardKVCache` (`eviction == .window(...)`) whose `offset` exceeds `maxSize`** — the rotating buffer has wrapped, so the serialised state would no longer be a faithful prefix snapshot. Confirms our open-question 3: refuse to snapshot wrapped windowed caches. Document explicitly + assert in `serialise()`.
   - [`prefix_l1.py`](https://github.com/bstnxbt/dflash-mlx/blob/main/dflash_mlx/cache/prefix_l1.py) — `DFlashPrefixCache` with richer stats: `exact_hits`, `prefix_hits`, `misses`, `insertions`, `evictions`, `byte_budget_evictions`, `skipped_too_long`, `prefix_prunes`, `cross_kind_prunes`, `prefill_tokens_saved`, `fingerprint_rejects`, `l2_hits`, `l2_misses`. Phase 1B extends `PrefixCacheStats` with `exactHits`, `byteBudgetEvictions`, `skippedTooLong`, `fingerprintRejects`, `prefillTokensSaved`. Defer L2 fields until phase 4.
   - `prefix_l2.py` (26 KB) — disk persistence layer, our phase 4 realised upstream. Recent commit [`8d8545d`](https://github.com/bstnxbt/dflash-mlx/commit/8d8545d) "keep MLX work out of async L2 writer" sets the discipline for phase 4: L1 sync read/write; L2 async-write only, sync-read on miss; no MLX work on the async writer.
 - **Multi-turn benchmark template**: [`benchmark/bench_prefix_cache_multiturn.py`](https://github.com/bstnxbt/dflash-mlx/blob/main/benchmark/bench_prefix_cache_multiturn.py) — turn 1 cold (warmup), turns 2-N measured for hit-rate + saved prefill tokens. Mirror this in `Tests/Benchmarks/InferenceBenchmark.swift`'s new `multi-turn-cached` method.
@@ -163,7 +164,7 @@ This spec was drafted against `bstnxbt/dflash-mlx@engine-v2`. Commit [`bc24ab0`]
 
 1. **Cross-process sharing.** vLLM's APC is per-process; the same prefix served across multiple instances is recomputed. For our single-process desktop / iOS setting this isn't a concern.
 2. **Quantised-cache snapshot fidelity.** Restoring a snapshot with a different KV quantisation than the runtime configures should fail loudly. Plumb through `PrefixKey`.
-3. **Rotating cache wrap.** If the snapshot was taken when offset > maxKVSize (sliding-window layers wrapped), the snapshot semantics get tricky — replay would diverge from a fresh prefill. Easiest fix: refuse to snapshot wrapped rotating caches. Document.
+3. **Windowed cache wrap.** If the snapshot was taken when `offset > maxSize` (sliding-window layers wrapped under `eviction == .window(...)`), the snapshot semantics get tricky — replay would diverge from a fresh prefill. Easiest fix: refuse to snapshot wrapped windowed caches in `StandardKVCache.serialise()`. Document.
 
 ## References
 

--- a/specs/020-tape-replay-rollback-generalised.md
+++ b/specs/020-tape-replay-rollback-generalised.md
@@ -54,11 +54,11 @@ public protocol TapeReplayCache: KVCache {
 
 `update(...)` becomes mode-aware: outside a recording session it behaves as today; inside one, it also calls `appendInnovation(...)` with the delta from the current input.
 
-### 2. MambaCache conformance
+### 2. SSMStateCache conformance
 
-This is the load-bearing change. Today `MambaCache.isTrimmable` is `false`. After this spec lands:
+This is the load-bearing change. Today `SSMStateCache.isTrimmable` is `false`. After this spec lands:
 
-- `MambaCache: TapeReplayCache` — supports beginRecord/append/rollback.
+- `SSMStateCache: TapeReplayCache` — supports beginRecord/append/rollback.
 - `isTrimmable` stays false (semantic: positional trim is not supported), but `canTapeReplay` is true.
 
 The Metal kernel for `rollback(acceptedPrefix:)` lives in `Sources/Cmlx/mlx-generated/metal/mamba_replay.metal` and matches dflash-mlx's `tape-replay rollback` Metal kernel byte-for-byte where possible.
@@ -100,32 +100,34 @@ For verify windows above ~32 tokens this becomes large; cap the tape size at `ML
 
 ## Implementation phases
 
-1. **Phase 1 — Protocol + KVCacheSimple no-op conformance.** Land the protocol; concrete trimmable caches conform with `appendInnovation = noop`, `rollback = trim`, `commitFull = noop`. Iterator unchanged. Validates the API on a workload that already works.
+1. **Phase 1 — Protocol + dispatch helpers (no concrete conformance).** Land the protocol; concrete trimmable `KVCache`s (`StandardKVCache` / `AffineQuantizedKVCache`) get the `rollbackPromptCache(...)` free-function dispatch which routes to existing `trim(...)` semantics on `isTrimmable` caches. Iterators unchanged. Validates the API contract on workloads that already work.
 
-2. **Phase 2 — MambaCache + Metal kernel.** This is the meat. Port dflash-mlx's recurrent-rollback Metal kernel. Test against per-token equivalence with a sequential (no rollback) reference run.
+2. **Phase 2 — SSMStateCache + Metal kernel.** This is the meat. Port dflash-mlx's recurrent-rollback Metal kernel. Test against per-token equivalence with a sequential (no rollback) reference run.
 
 3. **Phase 3 — Wire into NGramSpeculativeTokenIterator.** Replace the `canTrimPromptCache` gate with `canRollbackPromptCache`. Run the full benchmark suite on Qwen 3.5 / 3.6 — this is where PLD's coverage doubles overnight.
 
 4. **Phase 4 — Wire into DFlashSpeculativeTokenIterator.** Spec 015's phase 3 already uses tape-replay; refactor it to use the protocol from this spec rather than its own private path. One implementation, two consumers.
 
-5. **Phase 5 — Wire into PrefixKVCache.** With tape replay, `MambaCache` becomes serialisable for prefix snapshots: snapshot the state, plus enough history to rebuild it. Spec 017 phase 3 depends on this.
+5. **Phase 5 — Wire into PrefixKVCache.** With tape replay, `SSMStateCache` becomes serialisable for prefix snapshots: snapshot the state, plus enough history to rebuild it. Spec 017 phase 3 depends on this.
 
-## Phase 1 status (delivered)
+## Phase 1 status (PR #143, ready for review)
 
-Phase 1 landed in commit `0a84aec` on `alpha`:
+Phase 1 lives in [PR #143](https://github.com/ekryski/mlx-swift-lm/pull/143), rebased onto current `alpha` (post spec-006 / WS-A–D / consolidation sprint):
 
 - `Libraries/MLXLMCommon/TapeReplayCache.swift` — `TapeReplayCache` protocol + dispatch helpers (`canRollbackPromptCache`, `beginCacheRecord`, `commitCacheRecord`, `rollbackPromptCache`, `cancelCacheRecord`), `TapeReplayCost` enum (`.o1` / `.ok` / `.reforward`).
-- `Tests/MLXLMTests/TapeReplayCacheTests.swift` — 16 fake-cache tests across three suites (`CanRollbackPromptCacheTests`, `RollbackPromptCacheTests`, `CacheRecordHelpersTests`).
+- `Tests/MLXLMTests/TapeReplayCacheTests.swift` — 16 fake-cache tests across three suites (`CanRollbackPromptCacheTests`, `RollbackPromptCacheTests`, `CacheRecordHelpersTests`). Pure-Swift, no MLX evaluation, no metallib needed.
 
-**Open work for phase 2 (kernel + MambaCache conformance):**
+**Open work for phase 2 (kernel + `SSMStateCache` conformance):**
 
-- `MambaCache` ([Libraries/MLXLMCommon/KVCache.swift:1323-1368](../Libraries/MLXLMCommon/KVCache.swift)) does **not** yet conform — it exposes only the legacy `snapshot()` / `restore()` / `discardSnapshot()` hooks (the pre-tape DFlash design). Phase 2 adds tape buffer storage + `appendInnovation` / `commitFull` / `rollback(acceptedPrefix:)` / `cancel` implementations.
-- The protocol's `appendInnovation(_ delta: MLXArray)` signature is **too narrow** for the GDN recurrence — upstream's [`tape_replay_kernel`](https://github.com/bstnxbt/dflash-mlx/blob/main/dflash_mlx/kernels.py) takes three tape arrays per step (`tape, k, g`) plus the current `state`, not a single delta. Phase 2 should generalise `appendInnovation` to take `[MLXArray]` (or a typed `MambaInnovation` struct) so the protocol round-trips the upstream kernel surface.
+- `SSMStateCache` (subclass of `ArraysCache` in `Libraries/MLXLMCommon/KVCache.swift`) currently has no tape-replay state. Today it stores `[MLXArray?]` slots through its `ArraysCache` parent — clean canvas for adding tape buffer storage. Phase 2 adds the tape buffer + `appendInnovation` / `commitFull` / `rollback(acceptedPrefix:)` / `cancel` implementations.
+- The protocol's `appendInnovation(_ delta: MLXArray)` signature is **too narrow** for the GDN recurrence — upstream's [`tape_replay_kernel`](https://github.com/bstnxbt/dflash-mlx/blob/main/dflash_mlx/kernels.py) takes three tape arrays per step (`tape, k, g`) plus the current `state`, not a single delta. Phase 2 generalises `appendInnovation` to take `[MLXArray]` (or a typed `GDNInnovation` struct) so the protocol round-trips the upstream kernel surface. Phase 1's narrower form ships first to land the dispatch contract; phase 2 widens it as part of the conformance work.
 
 **Open work for phase 3 (iterator wiring):**
 
-- `NGramSpeculativeTokenIterator.init` at [NgramSpeculativeDecoding.swift:391](../Libraries/MLXLMCommon/NgramSpeculativeDecoding.swift) still uses `canTrimPromptCache` and throws on hybrid caches. Same gate at [Evaluate.swift:1451](../Libraries/MLXLMCommon/Evaluate.swift) and [Evaluate.swift:2108](../Libraries/MLXLMCommon/Evaluate.swift) for auto-routing, [DFlashSpeculativeDecoding.swift:149](../Libraries/MLXLMCommon/DFlashSpeculativeDecoding.swift), and [MirrorSpeculativeDecoding.swift:130](../Libraries/MLXLMCommon/MirrorSpeculativeDecoding.swift). Phase 3 swaps each to `canRollbackPromptCache`.
+- `NGramSpeculativeTokenIterator.speculateRound` (`Libraries/MLXLMCommon/NgramSpeculativeDecoding.swift`) gates on `canTrimPromptCache(self.mainCache)` and throws on hybrid caches. Same gate exists in `Evaluate.swift` for auto-routing (in `generate(input:cache:parameters:context:draftModel:...)` and the parallel SpeculativeTokenIterator init) and in the DFlash / Mirror SD scaffolds (in their phase-1 PRs #141 / #142). Phase 3 swaps each to `canRollbackPromptCache`.
 - The `speculateRound` body needs `beginCacheRecord(mainCache)` → forward → `commitCacheRecord` / `rollbackPromptCache(...)` / `cancelCacheRecord` based on accept count.
+
+Specific line numbers are not pinned — they drift across rebases. The symbol names `canTrimPromptCache`, `canRollbackPromptCache`, `speculateRound`, `beginCacheRecord` etc. are the contract.
 
 **Multi-repo PR chain (corrected from initial spec):**
 
@@ -155,7 +157,7 @@ For PrefixKVCache: hybrid models become cacheable. Multi-turn TTFT on Qwen 3.5 9
 
 3. **Mamba variants we haven't handled.** Nemotron-H's "cascade" variant and Jamba's partial-Mamba have slightly different state shapes than Qwen 3.5's GatedDeltaNet. Each needs a kernel verification pass. Probably 2-3 kernel variants total across the supported model zoo. **Nemotron Cascade 2 30B-A3B (4-bit + 8-bit MLX-community builds) is cached locally** — phase 2 ships GDN-only kernel coverage but smoke-tests Cascade 2 to validate the second-Mamba-variant path.
 
-4. **Built against the spec 006 PR 1 surface.** Phase 2 of this spec lands **after** spec 006 PR 1 (KVCache type consolidation — see [issue #73](https://github.com/ekryski/mlx-swift-lm/issues/73)), so `MambaCache` is unchanged but the cross-cutting `TapeReplayCache` extension targets the cleaner cache hierarchy. `MambaCache` itself is outside spec 006's storage/eviction axes (it's SSM state, not K/V), so it's a clean addition.
+4. **Built against the post-spec-006 KV-cache hierarchy.** Spec 006 (KVCache type consolidation, issue #73) merged in PRs #163–#166. `MambaCache` was renamed to `SSMStateCache` and is now a subclass of `ArraysCache`, with `[MLXArray?]` slot storage (see `Libraries/MLXLMCommon/KVCache.swift:1335`). The `TapeReplayCache` conformance is a clean addition on top — `SSMStateCache` reports `KVStorageKind.ssm` and stays outside the K/V storage/eviction axes spec 006 reorganised.
 
 5. **Masked-timestep correctness** (NEW from upstream `3217e15`). Both `gated_delta_with_tape` and `tape_replay` kernels must save `old_state` before each step, gate decay/accumulate/quantize on a uniform `do_step` predicate, and restore via `metal::select` on masked positions. Without this, masked positions silently corrupt state. Mitigation: implement the `do_step` + `metal::select` pattern from day 1; add a `testMambaTapeReplayMaskedTimesteps` test that locks the contract against a masked-token reference run.
 
@@ -165,17 +167,17 @@ For PrefixKVCache: hybrid models become cacheable. Multi-turn TTFT on Qwen 3.5 9
 
 | File | What |
 |---|---|
-| `Libraries/MLXLMCommon/TapeReplayCache.swift` | (delivered phase 1) Generalise `appendInnovation(_ delta: MLXArray)` → `appendInnovation(_ innovations: [MLXArray])` so per-step state can carry the (k, g, qkv) trio that GDN's recurrent kernel needs. |
-| `Libraries/MLXLMCommon/KVCache.swift` ([:1323-1368](../Libraries/MLXLMCommon/KVCache.swift)) | `MambaCache: TapeReplayCache` extension — tape buffer (`[[MLXArray]]`), pre-record snapshot, `beginRecord` / `appendInnovation` / `commitFull` / `rollback(acceptedPrefix:)` / `cancel`. |
-| `mlx-swift/Source/Cmlx/mlx-generated/metal/gated_delta_replay.metal` (new, ~400-500 lines) | **In sibling `mlx-swift` repo.** Precompiled metal kernels: `gated_delta_with_tape` (forward + tape capture) and `tape_replay` (rollback by re-folding accepted prefix). Ship 4 templated variants each (vec × non-vec, masked × non-masked). Built into `mlx.metallib` via `make metal`. |
+| `Libraries/MLXLMCommon/TapeReplayCache.swift` | (Phase 1 in PR #143) Phase 2 generalises `appendInnovation(_ delta: MLXArray)` → `appendInnovation(_ innovations: [MLXArray])` so per-step state can carry the (k, g, qkv) trio that GDN's recurrent kernel needs. |
+| `Libraries/MLXLMCommon/KVCache.swift` (around `SSMStateCache` at line 1335) | `SSMStateCache: TapeReplayCache` extension — tape buffer (`[[MLXArray]]`), pre-record snapshot, `beginRecord` / `appendInnovation` / `commitFull` / `rollback(acceptedPrefix:)` / `cancel`. |
+| `mlx-swift/Source/Cmlx/mlx-generated/metal/gated_delta_replay.metal` (new, ~400–500 lines) | **In sibling `mlx-swift` repo.** Precompiled metal kernels: `gated_delta_with_tape` (forward + tape capture) and `tape_replay` (rollback by re-folding accepted prefix). Ship 4 templated variants each (vec × non-vec, masked × non-masked). Built into `mlx.metallib` via `make metal`. |
 | `Libraries/MLXLMCommon/TapeReplayKernels.swift` (new, ~80 lines) | Swift wrappers around the precompiled metallib symbols — no JIT. |
-| `Libraries/MLXLMCommon/Evaluate.swift` | Predicate flip at lines 1451 + 2108 (`canTrimPromptCache` → `canRollbackPromptCache`). |
-| `Libraries/MLXLMCommon/NgramSpeculativeDecoding.swift` | Predicate flip at line 391 + iterator wiring (`beginCacheRecord` / `commitCacheRecord` / `rollbackPromptCache` / `cancelCacheRecord`) around `speculateRound`. |
-| `Libraries/MLXLMCommon/DFlashSpeculativeDecoding.swift` | Predicate flip at line 149. |
-| `Libraries/MLXLMCommon/MirrorSpeculativeDecoding.swift` | Predicate flip at line 130. |
-| Mamba layer call site (likely [GatedDelta.swift](../Libraries/MLXLLM/Models/GatedDelta.swift) `update(...)`) | When cache is recording, call `cache.appendInnovation([k_t, g_t, qkv_t])`. Gate via `if mambaCache.isRecording { ... }` early-exit. |
-| `Tests/MLXLMTests/TapeReplayMambaTests.swift` (new) | Per-step / partial-accept / cancel / per-token-equivalence / bf16-stability / masked-timesteps coverage on Qwen 3.5 GDN + Nemotron Cascade 2 + iterator smoke tests. |
-| `Tests/Benchmarks/InferenceBenchmark.swift` | Drop the "Qwen 3.5 omitted due to MambaCache" guard. Add Nemotron Cascade 2 ngram-spot row. |
+| `Libraries/MLXLMCommon/Evaluate.swift` | Predicate flip from `canTrimPromptCache` → `canRollbackPromptCache` at the n-gram + speculative-iterator init guards (currently around lines 1429 + 2065 in alpha; symbol-level edit). |
+| `Libraries/MLXLMCommon/NgramSpeculativeDecoding.swift` | Predicate flip at the iterator init (currently line 633) + body wiring (`beginCacheRecord` / `commitCacheRecord` / `rollbackPromptCache` / `cancelCacheRecord`) around `speculateRound`. |
+| `Libraries/MLXLMCommon/DFlashSpeculativeDecoding.swift` | Predicate flip — file lands with phase-1 PR #141; touch when that's merged. |
+| `Libraries/MLXLMCommon/MirrorSpeculativeDecoding.swift` | Predicate flip — file lands with phase-1 PR #142; touch when that's merged. |
+| GDN layer call site (likely `Libraries/MLXLLM/Models/Qwen3Next.swift` / `Qwen35.swift` `Qwen3NextGatedDeltaNet.update(...)` and `Libraries/MLXLLM/Models/NemotronH.swift` for the Cascade 2 variant) | When cache is recording, call `cache.appendInnovation([k_t, g_t, qkv_t])`. Gate via `if ssmCache.isRecording { ... }` early-exit. |
+| `Tests/MLXLMTests/TapeReplaySSMStateCacheTests.swift` (new) | Per-step / partial-accept / cancel / per-token-equivalence / bf16-stability / masked-timesteps coverage on Qwen 3.5 GDN + Nemotron Cascade 2 + iterator smoke tests. |
+| `Tests/Benchmarks/InferenceBenchmark.swift` | Drop the "Qwen 3.5 omitted due to SSMStateCache" guard. Add Nemotron Cascade 2 ngram-spot row. |
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary

Both specs were drafted against the pre-spec-006 cache class set (`KVCacheSimple` / `RotatingKVCache` / `QuantizedKVCache` / `TurboQuantKVCache` / `MambaCache`). Spec 006 merged in PRs #163–#166 and the renames landed alongside the WS-A–D consolidation sprint. This PR walks both spec docs forward to the current alpha surface so future readers (and the Phase 2 / 1B PRs that follow) aren't tripping over stale class names and brittle line-number references.

No code changes — pure docs.

## Changes

### `specs/020-tape-replay-rollback-generalised.md`

- All references to `MambaCache` → `SSMStateCache` (10 sites). The class is now a subclass of `ArraysCache` at `KVCache.swift:1335` and reports `KVStorageKind.ssm`.
- "Phase 1 status" retitled to point at [PR #143](https://github.com/ekryski/mlx-swift-lm/pull/143) (rebased onto alpha, ready for review) instead of the pre-rebase commit SHA.
- Open-work bullets drop pinned line numbers (which drift across rebases) and use symbol names (`canTrimPromptCache`, `canRollbackPromptCache`, `speculateRound`, `beginCacheRecord`).
- Files-touched table reflects current alpha file structure: `DFlashSpeculativeDecoding.swift` and `MirrorSpeculativeDecoding.swift` noted as "lands with phase-1 PR #141 / #142" since neither is in alpha today. GDN call site pointed at `Qwen3Next.swift` / `Qwen35.swift` / `NemotronH.swift` (the actual hybrid models in tree) instead of the now-obsolete `GatedDelta.swift` reference.
- Risk #4 ("built against spec 006 PR 1 surface") rephrased as "post-spec-006 KV-cache hierarchy" since spec 006 has fully landed.
- New test file name: `TapeReplaySSMStateCacheTests.swift`.

### `specs/017-prefix-kv-cache.md`

- `LayerCacheState` sum-type description rewritten — covers the post-spec-006 hierarchy (`StandardKVCache` unbounded or windowed, `AffineQuantizedKVCache`, `TurboQuantizedKVCache`, `SSMStateCache`) and dispatches via the typed `KVStorageKind` axis (`.raw` / `.affineQuantized` / `.turboCompressed` / `.ssm` / `.composite`) that the runtime already exposes.
- Phasing rewritten: phase 1 is `StandardKVCache` only; **phase 1B** is the per-class `serialise()` / `hydrate(from:)` on `StandardKVCache` / `AffineQuantizedKVCache` / `TurboQuantizedKVCache`; phase 3 is `SSMStateCache` (depends on spec 020 phase 2).
- "Phase 1 status" retitled to point at [PR #144](https://github.com/ekryski/mlx-swift-lm/pull/144).
- Open-work bullet for phase 1B notes the per-class metaState round-trip needs (`maxSize`, `keep`, `groupSize`, `bits`, `keyBits`, `valueBits`, `compressedWriteOffset`, `rotatingIdx`) so reviewers can spot-check the constructor-shaped inverse.
- Open question 3 ("rotating cache wrap") rephrased as "windowed cache wrap" — `eviction == .window(size:keep:)` is the v4 surface.
- `dflash-mlx` upstream-reference bullet for `policies.py` now correctly maps Python `RotatingKVCache` → "windowed `StandardKVCache` whose `offset` exceeds `maxSize`".

## Pairs with

- [PR #143](https://github.com/ekryski/mlx-swift-lm/pull/143) — spec 020 phase 1 (rebased onto alpha; comment + docstring renames already applied).
- [PR #144](https://github.com/ekryski/mlx-swift-lm/pull/144) — spec 017 phase 1 (rebased onto alpha; one comment rename applied).

## Test plan

- [x] `grep -rnE "MambaCache|KVCacheSimple|RotatingKVCache|QuantizedKVCache\b|TurboQuantKVCache" specs/017-prefix-kv-cache.md specs/020-tape-replay-rollback-generalised.md` returns only intentional historical / upstream-Python references.
- [x] Both spec docs render cleanly on the GitHub PR-preview view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)