### PR TITLE
feat(kv-cache): unblock direct windowed-turbo construction; flag #185 for model-factory dispatch

### DIFF
--- a/Libraries/MLXLMCommon/KVCacheTypes.swift
+++ b/Libraries/MLXLMCommon/KVCacheTypes.swift
@@ -246,13 +246,6 @@ public func makeKVCache(
     scheme: KVCache.CompressionAlgorithm = .none,
     eviction: KVEviction = .unbounded
 ) -> any KVCache {
-    if case .turbo = scheme {
-        precondition(
-            eviction == .unbounded,
-            "TurboQuantizedKVCache does not support windowed eviction. Use `.affine(bits:)` for sliding-window-quantized caches."
-        )
-    }
-
     switch scheme {
     case .none:
         return StandardKVCache(eviction: eviction)
@@ -264,10 +257,23 @@ public func makeKVCache(
         return AffineQuantizedKVCache(
             groupSize: schemeGroupSize(scheme), bits: bits)
     case let .turbo(keyBits, valueBits, _, _):
-        // Boundary-skip is applied by the *model factory* (which sees the
-        // full attention-layer list), not by this single-cache helper.
+        // TurboQuantizedKVCache supports windowed eviction natively via its
+        // `rotatingMaxSize` + `rotatingIdx` write-position machinery — the
+        // raw-prefill → compressed-decode pipeline rotates the compressed
+        // store at `maxSize` once it transitions, and the SDPA path honors
+        // windowed semantics for the mask. Pass `maxSize` through when
+        // `.window` eviction is requested; `.keep` (the attention-sink
+        // prefix on `StandardKVCache`) is not currently surfaced on the
+        // TurboQuant codec — windowed turbo treats the buffer as a flat
+        // rotating window. Boundary-skip is applied by the *model factory*
+        // (which sees the full attention-layer list), not by this
+        // single-cache helper.
+        let maxSize: Int? = {
+            if case let .window(size, _) = eviction { return size }
+            return nil
+        }()
         return TurboQuantizedKVCache(
-            keyBits: keyBits, valueBits: valueBits)
+            keyBits: keyBits, valueBits: valueBits, maxSize: maxSize)
     }
 }
 
@@ -281,6 +287,14 @@ public func makeKVCache(
 /// - `.turbo(...)` → caller's responsibility (turbo construction needs
 ///   per-model `headDim` for kernel JIT pre-warm + boundary-skip logic;
 ///   models that support turbo construct `TurboQuantizedKVCache` directly).
+///   When `.turbo` is requested with `maxSize` set, this factory falls
+///   through to a `StandardKVCache(maxSize:keep:)` rather than dispatching
+///   a windowed turbo cache. The standalone factory `makeKVCache(scheme:
+///   .turbo, eviction: .window(size:))` *does* construct a windowed turbo —
+///   verified working on Mistral 3 / Ministral 3 / Gemma 3 — but model
+///   dispatch through here stays on the safe path until the Gemma 4-
+///   specific interaction (KV-shared layers + mixed sliding/full-attention
+///   cache construction) is investigated and fixed. See issue #185.
 /// - `.none` / `nil` → `StandardKVCache(maxSize: maxSize, keep: keep)` if
 ///   `maxSize` set; else `StandardKVCache()` (unbounded).
 public func makeAttentionCache(

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -778,6 +778,68 @@ func testMakeKVCacheFactoryAllSchemes() async throws {
     } else {
         Issue.record("Expected .turboCompressed storageKind")
     }
+    // Unbounded turbo should not have a windowed maxSize.
+    #expect(turbo.maxSize == nil)
+
+    // .turbo(...) + .window → TurboQuantizedKVCache with rotating buffer.
+    // The codec's rotatingMaxSize / rotatingIdx machinery wraps writes at
+    // `maxSize` once the raw → compressed transition completes; the public
+    // surface is `maxSize` returning the window size.
+    let turboWindow = makeKVCache(
+        scheme: .turbo(keyBits: 4, valueBits: 2),
+        eviction: .window(size: 256, keep: 0))
+    #expect(type(of: turboWindow) == TurboQuantizedKVCache.self)
+    #expect(turboWindow.maxSize == 256)
+    if case .turboCompressed(let kb, let vb) = turboWindow.storageKind {
+        #expect(kb == 4)
+        #expect(vb == 2)
+    } else {
+        Issue.record("Expected .turboCompressed storageKind on windowed turbo")
+    }
+
+    // Symmetric turbo + window — same dispatch, same maxSize plumbed through.
+    let turboSymWindow = makeKVCache(
+        scheme: .turbo(keyBits: 4, valueBits: 4),
+        eviction: .window(size: 4096, keep: 0))
+    #expect(type(of: turboSymWindow) == TurboQuantizedKVCache.self)
+    #expect(turboSymWindow.maxSize == 4096)
+}
+
+@Test("makeAttentionCache turbo+maxSize stays on StandardKVCache (issue #185)")
+func testMakeAttentionCacheTurboWindowedSafePath() async throws {
+    // Turbo + maxSize → falls through to StandardKVCache for now. The
+    // standalone makeKVCache(scheme:eviction:) factory does construct a
+    // windowed TurboQuantizedKVCache (see testMakeKVCacheFactoryAllSchemes),
+    // and that works on Mistral 3 / Ministral 3 / Gemma 3 — but Gemma 4's
+    // specific cache construction (KV-shared layers + mixed sliding /
+    // full-attention layers) produces incoherent output under the rotating
+    // compressed buffer. Until that's fixed (issue #185), model dispatch
+    // through makeAttentionCache stays on StandardKVCache for windowed turbo.
+    let turboParams = GenerateParameters(
+        compressionAlgorithm: .turbo(keyBits: 4, valueBits: 2))
+    let turboWindow = makeAttentionCache(
+        parameters: turboParams, maxSize: 1024)
+    #expect(type(of: turboWindow) == StandardKVCache.self)
+
+    // Turbo without maxSize → unbounded StandardKVCache (caller's
+    // responsibility for the unbounded turbo variant).
+    let turboNoWindow = makeAttentionCache(
+        parameters: turboParams, maxSize: nil)
+    #expect(type(of: turboNoWindow) == StandardKVCache.self)
+
+    // No compression + maxSize → StandardKVCache windowed (unchanged).
+    let noneWindow = makeAttentionCache(
+        parameters: GenerateParameters(), maxSize: 4096, keep: 4)
+    #expect(type(of: noneWindow) == StandardKVCache.self)
+    #expect(noneWindow.maxSize == 4096)
+
+    // Affine + maxSize → AffineQuantizedKVCache (window ignored, matching the
+    // pre-spec-006 legacy `maybeQuantizeKVCache` swap behaviour).
+    let affineParams = GenerateParameters(
+        compressionAlgorithm: .affine(bits: 4, groupSize: 64))
+    let affineWindow = makeAttentionCache(
+        parameters: affineParams, maxSize: 4096)
+    #expect(type(of: affineWindow) == AffineQuantizedKVCache.self)
 }
 
 @Test("KVCache.CompressionAlgorithm parser round-trips every supported string format")

--- a/documentation/kv-cache.md
+++ b/documentation/kv-cache.md
@@ -11,7 +11,7 @@ parser. This page covers the public API and how to choose between them.
 |---|---|---|---|
 | **No compression** (`StandardKVCache`, default) | Baseline. Speed-critical short / mid context. | 1× (raw fp16/bf16) | Supports unbounded growth or sliding-window eviction (`maxKVSize`). |
 | **Affine quantization** (`AffineQuantizedKVCache`) | Memory-constrained; attention quality matters. | ~3.5× at 4-bit | 4 / 6 / 8-bit affine group-quant. Self-transitions raw → quantized at `startOffset` so prefill stays fast. |
-| **TurboQuant compression** (`TurboQuantizedKVCache`) | Best memory ratio at minimal quality loss. | ~6–8× at `turbo4v2` | Block-wise MSE codec with **asymmetric K/V bits** (e.g. 4-bit K, 2-bit V). Separate decode paths: compressed-attention "B" (default) and raw-fp16 working-buffer "A". |
+| **TurboQuant compression** (`TurboQuantizedKVCache`) | Best memory ratio at minimal quality loss. Sliding-window support is implemented in the codec but model-factory dispatch is held back until [#185](https://github.com/ekryski/mlx-swift-lm/issues/185) (Gemma 4 specific) is fixed; direct construction via `makeKVCache(scheme:eviction:)` works on Mistral 3 / Ministral 3 / Gemma 3. | ~6–8× at `turbo4v2` | Block-wise MSE codec with **asymmetric K/V bits** (e.g. 4-bit K, 2-bit V). Separate decode paths: compressed-attention "B" (default) and raw-fp16 working-buffer "A". |
 | **Hybrid (`SSMStateCache`)** | Mamba / GatedDeltaNet (Qwen 3.5 / Nemotron-H / Jamba) | n/a | Stores conv + recurrent state instead of K/V. Composes with attention layers via `CacheList`. |
 | **Batched (`BatchedKVCache` / `BatchedHybridCache`)** | Multi-stream decode (speculative, B>1 serving) | linear in B | Slot-based admission for fixed-size batches. |
 

--- a/skills/mlx-swift-lm/references/kv-cache.md
+++ b/skills/mlx-swift-lm/references/kv-cache.md
@@ -10,8 +10,8 @@ names + the `maybeQuantizeKVCache(...)` helper, see
 | Class | Storage | Eviction | Use case |
 |---|---|---|---|
 | `StandardKVCache` | raw fp16 / bf16 | `.unbounded` or `.window(size:keep:)` | Default. Legacy `KVCacheSimple` (unbounded) and `RotatingKVCache` (windowed) collapsed into this single class. |
-| `AffineQuantizedKVCache` | 4 / 6 / 8-bit affine group-quant | unbounded only | Memory-efficient. Self-transitions from raw → quantized at `startOffset` so prefill stays fast. |
-| `TurboQuantizedKVCache` | TurboQuant MSE codec, asymmetric K/V bits | unbounded only | Best memory ratio. `keyBits`=0 enables raw-key mode. **Not compatible with windowed eviction** — pre-condition trap. |
+| `AffineQuantizedKVCache` | 4 / 6 / 8-bit affine group-quant | unbounded only | Memory-efficient. Self-transitions from raw → quantized at `startOffset` so prefill stays fast. Windowed-eviction requests fall back to raw `StandardKVCache(maxSize:)` per legacy `maybeQuantizeKVCache` swap behaviour. |
+| `TurboQuantizedKVCache` | TurboQuant MSE codec, asymmetric K/V bits | unbounded **or** `.window(size:)` via `makeKVCache` (direct construction); `unbounded` only via `makeAttentionCache` (model-factory path, until [#185](https://github.com/ekryski/mlx-swift-lm/issues/185) is fixed) | Best memory ratio. `keyBits`=0 enables raw-key mode. Sliding-window via `rotatingMaxSize` / `rotatingIdx` machinery — verified working on Mistral 3 / Ministral 3 / Gemma 3. Gemma 4 produces incoherent output under windowed turbo (KV-shared + mixed sliding/full-attention layers); the model-factory path falls through to `StandardKVCache(maxSize:)` until that's investigated. `.keep` (attention-sink prefix) is not surfaced through the codec — windowed turbo treats the buffer as a flat rotating window. |
 | `ArraysCache` | generic indexed `[MLXArray?]` slots | n/a | Building block for non-K/V caches. |
 | `SSMStateCache` | conv state + recurrent state (subclass of `ArraysCache`) | n/a (SSM state is cumulative) | Mamba / GatedDeltaNet / hybrid linear-attention layers. Replaces legacy `MambaCache`. |
 | `BatchedKVCache` | raw fp16 / bf16 across N streams | unbounded | Speculative decoding + multi-request servers. |
@@ -143,11 +143,14 @@ public func makeKVCache(
 ) -> any KVCache
 ```
 
-`.turbo(...)` + `.window(...)` triggers a precondition trap — turbo's
-two-phase prefill→decode design has no clean definition of "evict a token
-from the compressed store". For sliding-window quantization use
-`.affine(bits:)`, which supports unbounded mode and self-transitions to
-quantized after `startOffset`.
+`.turbo(...)` + `.window(size:)` is supported — the codec's
+`rotatingMaxSize` / `rotatingIdx` machinery wraps writes at `maxSize`
+once the raw → compressed transition completes, and the SDPA path
+honours windowed semantics for the mask. The `.keep` (attention-sink
+prefix) parameter on `.window(...)` is not currently surfaced through
+the TurboQuant codec; windowed turbo treats the buffer as a flat
+rotating window. Use `.affine(bits:)` instead if you need the
+attention-sink prefix.
 
 ### `turboBoundarySkipSet(attentionLayerIndices:algorithm:)`
 
@@ -418,8 +421,10 @@ if let qCache = cache as? AffineQuantizedKVCache {
 
 ## Constraints and footguns
 
-- **`.turbo(...)` + windowed eviction is not supported** — pre-condition
-  trap. Use `.affine(...)` for windowed quantized caches.
+- **`.turbo(...)` + `.window(size:keep:)` ignores `keep`.** The codec's
+  rotating buffer treats the window as flat — the attention-sink prefix
+  parameter is not currently surfaced. Use `.affine(bits:)` on a
+  separate `StandardKVCache` if you need the sink prefix.
 - **`AffineQuantizedKVCache` ignores windowed eviction** even when passed
   through `makeAttentionCache(maxSize:)` — matches legacy
   `maybeQuantizeKVCache` behaviour. If you need both, manage context


### PR DESCRIPTION
## Summary

The `TurboQuantizedKVCache` rotating-window code path (`rotatingMaxSize` / `rotatingIdx` machinery, lines 750–1364 in `TurboQuantKVCache.swift`) has been implemented for a while but never exposed through the public factories — `makeKVCache(scheme:eviction:)` trapped on `.turbo + .window` with a precondition, and `makeAttentionCache(parameters:maxSize:keep:)` silently fell through to a raw `StandardKVCache` regardless of `compressionAlgorithm`.

This PR unblocks the standalone factory + adds direct-construction test coverage. **The model-factory dispatch is intentionally held back** behind a Gemma 4-specific bug tracked in [#185](https://github.com/ekryski/mlx-swift-lm/issues/185).

## Investigation summary

Smoke runs via `./scripts/benchmark.sh --model <model> --kv turbo4v2 --method simple`, comparing the proposed `makeAttentionCache` factory dispatch (windowed turbo for sliding-window-attention models) against alpha:

| Model | Result |
|---|---|
| Mistral 3 (Ministral 3 3B) | ✅ coherent: _"Hello! I'm an AI assistant—no name, just here to help…"_ |
| Gemma 3 (Gemma 3 1B) | ✅ coherent: _"Hello there! I'm Gemma, and I'm here to help you with various tasks!"_ |
| Qwen 3.5 (Qwen 3.5 0.8B, no sliding-window) | ✅ coherent (control): _"I am Qwen3.5, a highly capable language model…"_ |
| **Gemma 4 (Gemma 4 E2B)** | ❌ incoherent: _"Except's. **SERVApa\\middleware narrowed\\immediately?**"_ |

The general windowed-turbo code path is not broken — Gemma 4 has a specific cache-construction interaction (KV-shared layers + mixed sliding/full-attention layer types per `Gemma4.newCache(parameters:)`) that doesn't compose with the rotating compressed buffer. Filed as [#185](https://github.com/ekryski/mlx-swift-lm/issues/185) with the full repro, suspected causes, and suggested investigation steps.

## Changes

- **`KVCacheTypes.swift` `makeKVCache(scheme:eviction:)`**: drop the `.turbo + .window` precondition trap. The `.turbo` arm now reads `eviction` and constructs `TurboQuantizedKVCache(... maxSize:)` when windowed. Direct callers (tests, custom cache strategies) get working windowed turbo immediately.
- **`KVCacheTypes.swift` `makeAttentionCache(parameters:maxSize:keep:)`**: unchanged in behaviour — still falls through to `StandardKVCache(maxSize:keep:)` for windowed turbo. Docstring updated to point at [#185](https://github.com/ekryski/mlx-swift-lm/issues/185) and explain why model dispatch stays on the safe path.
- **`KVCacheTests.swift` `testMakeKVCacheFactoryAllSchemes`**: extended to cover `.turbo + .window(size:)` → `TurboQuantizedKVCache(maxSize:)`, including symmetric and asymmetric-bits variants.
- **`KVCacheTests.swift` `testMakeAttentionCacheTurboWindowedSafePath`** (new): asserts the fall-through behaviour is preserved (so the safe path doesn't silently re-enable itself), with an inline note pointing at [#185](https://github.com/ekryski/mlx-swift-lm/issues/185).
- **`documentation/kv-cache.md` + `skills/mlx-swift-lm/references/kv-cache.md`** algorithm-matrix rows for `TurboQuantizedKVCache`: now state that windowed support is available via direct `makeKVCache(scheme:eviction:)` (working on Mistral 3 / Ministral 3 / Gemma 3) but model-factory dispatch is held back pending [#185](https://github.com/ekryski/mlx-swift-lm/issues/185). Constraints / footguns sections updated to drop the "precondition trap" claim.

## Verification

- `swift build -c release` clean.
- `swift test -c release --filter KVCache` — **58/58** pass, including the new dispatch-correctness tests.
- Smoke (`./scripts/benchmark.sh --model gemma4-e2b --quant 4bit --kv turbo4v2 --method simple`): coherent output unchanged from alpha (`makeAttentionCache` StandardKVCache fallback path preserved).
- Smoke (`--model ministral3-3b --quant 4bit --kv turbo4v2`, would now construct windowed turbo if the factory dispatch were enabled): coherent output verified directly via the `makeKVCache(scheme:eviction:)` standalone factory.

## Why split this from the model-factory unblock

Originally I planned to unblock both factories in one PR. The smoke run on Gemma 4 produced incoherent output — turned out to be a Gemma 4-specific interaction, not a general windowed-turbo problem. Rather than ship a factory unblock that silently breaks Gemma 4, the safer move is:

1. **This PR**: surface the working code path through the standalone factory + direct construction. Tests + docs accurate.
2. **[#185](https://github.com/ekryski/mlx-swift-lm/issues/185)**: investigate Gemma 4's KV-shared + mixed-layer-type cache construction and fix the interaction.
3. **Follow-up PR after #185**: enable the model-factory dispatch in `makeAttentionCache` so all sliding-window models get the memory savings.

## Test plan

- [ ] `swift build -c release` clean
- [ ] `swift test -c release --filter KVCache` passes 58/58
- [ ] Direct construction works: `let c = makeKVCache(scheme: .turbo(keyBits: 4, valueBits: 2), eviction: .window(size: 1024)); assert(c is TurboQuantizedKVCache); assert(c.maxSize == 1024)`
- [ ] Model-factory dispatch unchanged: `./scripts/benchmark.sh --model gemma4-e2b --quant 4bit --kv turbo4v2` produces coherent output
- [ ] [#185](https://github.com/ekryski/mlx-swift-lm/issues/185) tracks the follow-up work

🤖 Generated with [Claude Code](https://claude.com/claude-code)