### PR TITLE
feat(mtp): MTP self-speculative decoding scaffolding (variants A + B)

### DIFF
--- a/Libraries/MLXLLM/Models/DeepseekV4.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4.swift
@@ -894,21 +894,31 @@ public class DeepseekV4Model: Module, LLMModel, KVCacheDimensionProvider, LoRAMo
     ///   norm.weight                   → model.norm.weight
     ///   head.weight                   → lm_head.weight
     ///   ffn.experts.{E}.{w1|w2|w3}.*  → mlp.switch_mlp.{gate|down|up}_proj.* (stacked)
+    ///
+    /// **MTP gating.** When `MLXLoader.mtpLoadEnabledFromEnv` is true
+    /// (i.e. `MLX_MTP_ENABLED=1` is set at process start), the MTP layer
+    /// at index `numHiddenLayers` and any `mtp.*`-prefixed keys are
+    /// PRESERVED. Otherwise (the default path) they're dropped. Spec 030.
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
         // Minimal sanitize for the official mlx-community DSv4 safetensors
         // layout. After matching @ModuleInfo names directly to file keys
         // (attn/ffn/attn_norm/ffn_norm/switch_mlp/embed_tokens/norm),
         // most weights pass through unchanged. We only need to:
         //   1. Drop the multi-token-prediction (MTP) layer at index
-        //      `numHiddenLayers` (one extra layer beyond the 43 we model).
+        //      `numHiddenLayers` (one extra layer beyond the 43 we model)
+        //      UNLESS `MLX_MTP_ENABLED=1` (spec 030 / `MTPLoader`).
         //   2. Drop any rotary inv_freq buffers (computed at runtime).
         //   3. Map official `model.hc_head.{base,fn,scale}` → bundle-style
         //      `hc_head_{base,fn,scale}` keys for the HyperHead's
         //      @ParameterInfo names.
+        let keepMTP = MTPLoader.mtpLoadEnabledFromEnv
+        let mtpLayerPrefix = "model.layers.\(self.config.numHiddenLayers)"
         var out = weights.filter { (key, _) in
-            !key.hasPrefix("model.layers.\(self.config.numHiddenLayers)")
-                && !key.contains("rotary_emb.inv_freq")
-                && !key.hasPrefix("mtp.")
+            if key.contains("rotary_emb.inv_freq") { return false }
+            if keepMTP { return true }
+            if key.hasPrefix(mtpLayerPrefix) { return false }
+            if key.hasPrefix("mtp.") { return false }
+            return true
         }
         for src in ["base", "fn", "scale"] {
             let from = "model.hc_head.\(src)"

--- a/Libraries/MLXLMCommon/AssistantDraftRegistry.swift
+++ b/Libraries/MLXLMCommon/AssistantDraftRegistry.swift
@@ -1,0 +1,112 @@
+// Copyright © 2026 ekryski.
+//
+// Multi-token prediction (MTP) — variant B: companion EAGLE-style
+// "assistant" drafts. Maps a target HF id to an assistant-draft HF id
+// so `MLXLMCommon.generate(...)` can auto-resolve the draft and route
+// through the existing `SpeculativeTokenIterator`.
+//
+// Spec: specs/030-multi-token-prediction.md (variant B).
+//
+// Initial coverage: Google's gemma-4-*-it-assistant family. These are
+// EAGLE-style standalone draft transformers (78M / 78.8M / 0.4B / 0.5B
+// params) that share the target's tokenizer and (per the model card)
+// produce byte-identical output at temperature 0 with --draft-block-size
+// 6 single / 3 batched.
+
+import Foundation
+
+/// Mapping from a target HF id to the recommended assistant draft id +
+/// recommended `numDraftTokens`. The match function is a longest-prefix
+/// resolver: a target id like
+/// `mlx-community/gemma-4-26B-A4B-it-bf16` matches the registry
+/// entry for `mlx-community/gemma-4-26B-A4B-it`.
+public enum AssistantDraftRegistry {
+
+    /// One mapping rule.
+    public struct Entry: Sendable {
+        /// Target HF id prefix. Matched against
+        /// `ModelConfiguration.name` via `hasPrefix`.
+        public let targetPrefix: String
+        /// Draft model HF id to load when the target matches.
+        public let draftId: String
+        /// Recommended `numDraftTokens`. Per the gemma-4 assistant
+        /// model card, 6 is best for single-batch decode; 3 for
+        /// batched. Mirrors HF Transformers' `--draft-block-size`.
+        public let recommendedNumDraftTokens: Int
+        /// Optional human-readable note printed in diagnostic logs.
+        public let note: String?
+
+        public init(
+            targetPrefix: String,
+            draftId: String,
+            recommendedNumDraftTokens: Int,
+            note: String? = nil
+        ) {
+            self.targetPrefix = targetPrefix
+            self.draftId = draftId
+            self.recommendedNumDraftTokens = recommendedNumDraftTokens
+            self.note = note
+        }
+    }
+
+    /// Built-in registry. Listed longest-prefix-first so the matcher
+    /// picks the most specific entry.
+    public static let entries: [Entry] = [
+        // Gemma 4 assistants (Google's EAGLE-style drafts; mirrored to
+        // mlx-community).
+        Entry(
+            targetPrefix: "mlx-community/gemma-4-26B-A4B-it",
+            draftId: "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
+            recommendedNumDraftTokens: 6,
+            note: "Gemma-4 26B-A4B EAGLE-style assistant draft (~0.4B)"),
+        Entry(
+            targetPrefix: "mlx-community/gemma-4-31B-it",
+            draftId: "mlx-community/gemma-4-31B-it-assistant-bf16",
+            recommendedNumDraftTokens: 6,
+            note: "Gemma-4 31B EAGLE-style assistant draft (~0.5B)"),
+        Entry(
+            targetPrefix: "mlx-community/gemma-4-E2B-it",
+            draftId: "mlx-community/gemma-4-E2B-it-assistant-bf16",
+            recommendedNumDraftTokens: 6,
+            note: "Gemma-4 E2B EAGLE-style assistant draft (~78M)"),
+        Entry(
+            targetPrefix: "mlx-community/gemma-4-E4B-it",
+            draftId: "mlx-community/gemma-4-E4B-it-assistant-bf16",
+            recommendedNumDraftTokens: 6,
+            note: "Gemma-4 E4B EAGLE-style assistant draft (~78.8M)"),
+    ]
+
+    /// Resolve an assistant draft for the given target HF id (or
+    /// `ModelConfiguration.name`). Returns `nil` if no entry matches.
+    ///
+    /// Matching:
+    ///   - Exact prefix match against `entries[i].targetPrefix`. The
+    ///     entries list is searched in declared order; first match
+    ///     wins. Order entries longest-prefix-first.
+    ///   - Org-strip fallback: if no entry matches the full id, retry
+    ///     after stripping a leading `<org>/` prefix. Lets local-only
+    ///     bundles (e.g. `LocalDir/gemma-4-26B-A4B-it`) match the
+    ///     `mlx-community/gemma-4-26B-A4B-it` rule.
+    public static func resolve(targetId: String) -> Entry? {
+        for entry in entries {
+            if targetId.hasPrefix(entry.targetPrefix) { return entry }
+        }
+        // Org-strip fallback.
+        if let slashIdx = targetId.firstIndex(of: "/") {
+            let stripped = String(targetId[targetId.index(after: slashIdx)...])
+            for entry in entries {
+                let entrySlashIdx = entry.targetPrefix.firstIndex(of: "/")
+                let entryStripped: String
+                if let entrySlashIdx {
+                    entryStripped = String(
+                        entry.targetPrefix[
+                            entry.targetPrefix.index(after: entrySlashIdx)...])
+                } else {
+                    entryStripped = entry.targetPrefix
+                }
+                if stripped.hasPrefix(entryStripped) { return entry }
+            }
+        }
+        return nil
+    }
+}

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -176,6 +176,38 @@ public struct GenerateParameters: Sendable {
     /// `ngramSize, ngramSize-1, ..., 2` until it finds a match or runs out.
     public var minNgramSize: Int
 
+    /// Multi-token prediction (MTP) opt-in. When true, models conforming
+    /// to ``MTPInjector`` with MTP heads loaded route through
+    /// ``MTPSelfSpeculativeTokenIterator`` (variant A — self-speculative,
+    /// in-trunk MTP heads); models matched by ``AssistantDraftRegistry``
+    /// route through the standard ``SpeculativeTokenIterator`` with the
+    /// registered companion draft (variant B — EAGLE-style assistant).
+    /// MTP also gates loader-side preservation of `mtp.*` weight keys
+    /// (see ``MTPLoader/mtpLoadEnabledFromEnv``).
+    ///
+    /// **Default: false.** Set ``mtpEnabled`` = `true` or
+    /// `MLX_MTP_ENABLED=1` to opt in. Phase 1 is greedy-only
+    /// (`temperature == 0`).
+    ///
+    /// See `specs/030-multi-token-prediction.md`.
+    public var mtpEnabled: Bool
+
+    /// Number of MTP draft tokens to propose per cycle (variant A).
+    /// Bounded by `MTPInjector.mtpContract.maxHeads` at iterator init.
+    /// Per-family defaults: DeepSeek-V3/V4 = 1, Qwen3-Next / MiMo = 2.
+    ///
+    /// Has no effect on variant B — that path uses the registry's
+    /// `recommendedNumDraftTokens` (gemma-4 = 6 single, 3 batched).
+    ///
+    /// **Default: 0** (treated as 1 when ``mtpEnabled`` is engaged).
+    public var mtpDraftCount: Int
+
+    /// Optional override for the variant-B assistant draft id. When
+    /// non-nil, this draft is used instead of the
+    /// ``AssistantDraftRegistry`` lookup. Useful for benchmark sweeps
+    /// across draft sizes or for local re-converted bundles.
+    public var mtpAssistantDraftId: String?
+
     /// Token ID marking the start of a thinking phase (e.g., <think> token).
     /// When set with thinkEndTokenId, log probabilities are tracked separately
     /// for thinking vs. generation phases in GenerateCompletionInfo.
@@ -236,6 +268,9 @@ public struct GenerateParameters: Sendable {
         ngramDraftMin: Int = 1,
         ngramMinHits: Int = 1,
         minNgramSize: Int = 2,
+        mtpEnabled: Bool = false,
+        mtpDraftCount: Int = 0,
+        mtpAssistantDraftId: String? = nil,
         thinkStartTokenId: Int32? = nil,
         thinkEndTokenId: Int32? = nil,
         thinkingPhasePrefilled: Bool = false,
@@ -268,6 +303,9 @@ public struct GenerateParameters: Sendable {
         self.ngramDraftMin = ngramDraftMin
         self.ngramMinHits = ngramMinHits
         self.minNgramSize = minNgramSize
+        self.mtpEnabled = mtpEnabled
+        self.mtpDraftCount = mtpDraftCount
+        self.mtpAssistantDraftId = mtpAssistantDraftId
         self.thinkStartTokenId = thinkStartTokenId
         self.thinkEndTokenId = thinkEndTokenId
         self.thinkingPhasePrefilled = thinkingPhasePrefilled
@@ -2052,6 +2090,44 @@ public func generate(
     input: LMInput, cache: [KVCache]? = nil, parameters: GenerateParameters, context: ModelContext,
     wiredMemoryTicket: WiredMemoryTicket? = nil
 ) throws -> AsyncStream<Generation> {
+    // Auto-route to ``MTPSelfSpeculativeTokenIterator`` (variant A) first
+    // when the caller has opted in (via ``GenerateParameters/mtpEnabled``
+    // or `MLX_MTP_ENABLED=1`) AND the model conforms to ``MTPInjector``
+    // with MTP heads loaded AND the trunk cache is fully trimmable. MTP
+    // takes precedence over n-gram because trained-head proposals carry
+    // a higher acceptance ceiling than prompt-lookup. See spec 030.
+    let mtpRoute = mtpRouteDecision(parameters: parameters)
+    if mtpRoute.shouldEngage,
+        let mtpModel = context.model as? any (LanguageModel & MTPInjector),
+        mtpModel.isMTPLoaded
+    {
+        let probeCache = cache ?? mtpModel.newCache(parameters: mtpRoute.parameters)
+        if canTrimPromptCache(probeCache) {
+            do {
+                let mtpIterator = try MTPSelfSpeculativeTokenIterator(
+                    input: input,
+                    model: mtpModel,
+                    trunkCache: probeCache,
+                    parameters: mtpRoute.parameters)
+                let (stream, _) = generateLoopTask(
+                    promptTokenCount: input.text.tokens.size,
+                    modelConfiguration: context.configuration,
+                    tokenizer: context.tokenizer,
+                    iterator: mtpIterator,
+                    wiredMemoryTicket: wiredMemoryTicket,
+                    handler: TextToolTokenLoopHandler(
+                        tokenizer: context.tokenizer,
+                        format: context.configuration.toolCallFormat ?? .json
+                    )
+                )
+                return stream
+            } catch {
+                // Init refused (greedy-only, hybrid cache, etc.). Fall
+                // through to the next route.
+            }
+        }
+    }
+
     // Auto-route to ``NGramSpeculativeTokenIterator`` when the caller has
     // opted in (via parameters or `MLX_NGRAM_ENABLED=1`) AND the
     // configuration is compatible: greedy sampling, no logit processors

--- a/Libraries/MLXLMCommon/MTPInjector.swift
+++ b/Libraries/MLXLMCommon/MTPInjector.swift
@@ -1,0 +1,260 @@
+// Copyright © 2026 ekryski.
+//
+// Multi-token prediction (MTP) — protocol surface for self-speculative decoding.
+//
+// Spec: specs/030-multi-token-prediction.md (variant A — in-trunk MTP heads).
+//
+// Background. Several model families (DeepSeek-V3/V4, Qwen3.5/3.6, Qwen3-Next,
+// MiMo, GLM-4-MoE) ship checkpoints with multi-token prediction heads stacked
+// on top of the same trunk. At decode time these heads predict the next k
+// tokens (k typically 1–4) in a single forward pass; the trunk then verifies
+// in batch. Same model is target and draft — no separate draft load.
+//
+// This file defines the loader-side and forward-side protocols. The actual
+// iterator is in `MTPSelfSpeculativeDecoding.swift`.
+
+import Foundation
+import MLX
+
+// MARK: - MTPContract
+
+/// Per-family knobs for the MTP forward pass. The two axes vary across
+/// the in-trunk MTP families and have to be modeled explicitly:
+///
+/// - `hiddenVariant`: where the trunk-norm is applied relative to the
+///   embedding-norm + concat. DeepSeek-V3/V4 use `preNorm` (the trunk
+///   hidden is normalized before concat). Qwen3-Next uses `postNorm`.
+/// - `concatOrder`: which of `(embedding, hidden)` comes first in the
+///   `eh_proj` input. DeepSeek-V3/V4 use `embeddingHidden`. Qwen3-Next
+///   uses `hiddenEmbedding`.
+///
+/// MTPLX (`mtplx/runtime.py` in github.com/youssofal/MTPLX) ships the
+/// canonical per-family contract values for the Python reference; the
+/// Swift port mirrors those values via per-target `MTPInjector`
+/// implementations.
+public struct MTPContract: Sendable {
+
+    /// Where the hidden-state norm sits in the eh_proj input pipeline.
+    public enum HiddenVariant: Sendable {
+        /// Norm applied to the trunk hidden state BEFORE the concat /
+        /// eh_proj. DeepSeek-V3/V4 convention.
+        case preNorm
+        /// Norm applied AFTER the eh_proj projection but before the
+        /// transformer block. Qwen3-Next convention.
+        case postNorm
+    }
+
+    /// Concat order on the eh_proj input.
+    public enum ConcatOrder: Sendable {
+        /// `[norm(embedding), norm(hidden)]` — DeepSeek-V3/V4.
+        case embeddingHidden
+        /// `[norm(hidden), norm(embedding)]` — Qwen3-Next.
+        case hiddenEmbedding
+    }
+
+    public let hiddenVariant: HiddenVariant
+    public let concatOrder: ConcatOrder
+    /// Number of nextn heads available on the bundle. The iterator may
+    /// use fewer per cycle (driven by `GenerateParameters.mtpDraftCount`)
+    /// but cannot exceed this.
+    public let maxHeads: Int
+    /// Family identifier — used in logs and the diagnostic banner the
+    /// iterator emits at construction time. Examples: "deepseek-v4",
+    /// "qwen3-next", "mimo".
+    public let family: String
+
+    public init(
+        hiddenVariant: HiddenVariant,
+        concatOrder: ConcatOrder,
+        maxHeads: Int,
+        family: String
+    ) {
+        self.hiddenVariant = hiddenVariant
+        self.concatOrder = concatOrder
+        self.maxHeads = maxHeads
+        self.family = family
+    }
+}
+
+// MARK: - MTPHeadOutput
+
+/// Output of one MTP-head forward pass. The head consumes `(prevHidden,
+/// prevToken)` and emits `(nextHidden, nextLogits)` — the next-hidden
+/// becomes the input to the subsequent head; the logits feed the
+/// iterator's accept/reject loop.
+public struct MTPHeadOutput {
+    /// Hidden state for the *next* MTP step. Shape `[B, 1, hidden]`.
+    public let nextHidden: MLXArray
+    /// Logits for the predicted token at the current MTP step.
+    /// Shape `[B, 1, vocab]`.
+    public let logits: MLXArray
+
+    public init(nextHidden: MLXArray, logits: MLXArray) {
+        self.nextHidden = nextHidden
+        self.logits = logits
+    }
+}
+
+// MARK: - MTPInjector
+
+/// Protocol implemented by target models that carry in-trunk MTP heads.
+///
+/// **Two responsibilities**:
+///   1. *Capture forward* — the iterator needs the same forward pass the
+///      base `LanguageModel` runs, plus the trunk hidden state (pre-LM-head)
+///      so it can be threaded into the MTP heads. `runCaptureForward` is
+///      the dual of the model's `callAsFunction` returning both logits
+///      and the hidden state at the configured capture position
+///      (typically the final post-norm output, just before lm_head).
+///   2. *MTP-head forward* — `runMTPHead(headIndex:)` runs head `headIndex`
+///      on the given `(prevHidden, prevToken)` and returns the next-hidden
+///      + logits.
+///
+/// Implementers also expose:
+///   - `mtpContract` — per-family knobs.
+///   - `mtpHeadCaches(parameters:)` — per-head KV caches. Each MTP head is
+///     itself a transformer block with its own attention KV. Returned
+///     length must equal `mtpContract.maxHeads`.
+///   - `isMTPLoaded` — true after `MTPLoader.attach(...)` has installed
+///     the head weights. Iterator construction throws if false.
+///
+/// The protocol is intentionally narrow: it does NOT require the
+/// implementer to expose its internal layer modules. The MTP head's
+/// forward stays inside the model, which can use private state freely.
+public protocol MTPInjector: AnyObject {
+
+    /// True once MTP-head weights have been loaded into the model.
+    var isMTPLoaded: Bool { get }
+
+    /// Per-family contract values. Stable across decode cycles.
+    var mtpContract: MTPContract { get }
+
+    /// Build per-head KV caches for the MTP transformer blocks. One
+    /// entry per head; entries are passed back in order to
+    /// `runMTPHead(headIndex:)` calls.
+    func mtpHeadCaches(parameters: GenerateParameters?) -> [KVCache]
+
+    /// Run a "capturing" forward pass on the trunk. Equivalent to the
+    /// model's standard `callAsFunction` but additionally returns the
+    /// post-norm hidden state at the LM-head input.
+    ///
+    /// - Parameters:
+    ///   - inputs: shape `[B, L]` token ids (typically `[1, 1]` during
+    ///     decode, `[1, k+1]` during MTP verify).
+    ///   - cache: trunk KV cache (the same one the iterator uses for
+    ///     plain AR decode).
+    /// - Returns:
+    ///   - `logits`: shape `[B, L, vocab]`.
+    ///   - `hidden`: shape `[B, L, hidden]` — the post-trunk-norm hidden
+    ///     state, *before* lm_head projection. Used as the input to the
+    ///     first MTP head.
+    func runCaptureForward(
+        inputs: MLXArray, cache: [KVCache]
+    ) -> (logits: MLXArray, hidden: MLXArray)
+
+    /// Run MTP head `headIndex` on `(prevHidden, prevToken)`.
+    ///
+    /// - Parameters:
+    ///   - headIndex: 0-based head index. Must be in
+    ///     `[0, mtpContract.maxHeads)`.
+    ///   - prevHidden: shape `[B, 1, hidden]` — output of the previous
+    ///     head (or the trunk for `headIndex == 0`).
+    ///   - prevToken: shape `[B, 1]` — the previously committed (or
+    ///     previously-proposed) token id.
+    ///   - headCache: the per-head KV cache returned by
+    ///     `mtpHeadCaches(...)` at index `headIndex`.
+    /// - Returns: `MTPHeadOutput` — next-hidden + logits at this step.
+    func runMTPHead(
+        headIndex: Int,
+        prevHidden: MLXArray,
+        prevToken: MLXArray,
+        headCache: KVCache
+    ) -> MTPHeadOutput
+}
+
+// MARK: - MTPLoader
+
+/// Probes a target's weight bag for in-trunk MTP keys and reports
+/// whether the bundle ships the heads. Used by sanitize routines to
+/// decide whether to keep or drop `mtp.*` / `model.layers.{N}.*` keys.
+///
+/// Conventions across families:
+///   - DeepSeek-V3/V4: heads packed at `model.layers.{numHiddenLayers}.*`
+///     plus `eh_proj`, `enorm`, `hnorm` siblings. Layer index is the
+///     *next* layer beyond the declared count.
+///   - Qwen3.5 / Qwen3-Next / MiMo / GLM-4-MoE: heads under `mtp.*`
+///     prefix.
+///   - Some bundles ship MTP as a sidecar file (`mtp.safetensors`,
+///     `mtp/weights.safetensors`, `model-mtp.safetensors`). This loader
+///     does not handle sidecars — that's a follow-up to
+///     `MTPLoader.discoverSidecar(...)` once we ship the custom
+///     converter.
+public enum MTPLoader {
+
+    /// Standard key prefixes to probe for MTP heads. Conservative — does
+    /// not catch the DSV4 layer-N convention (use
+    /// `hasInTrunkMTPHead(...)` for that).
+    public static let standardPrefixes: [String] = [
+        "mtp.",
+        "model.mtp.",
+        "language_model.mtp.",
+    ]
+
+    /// True iff any of the supplied weight keys match an MTP-head shape
+    /// — either a standard prefix or the DeepSeek-V3/V4 layer-N
+    /// convention `model.layers.{layerN}.*`.
+    ///
+    /// Keys-only variant; sanitize routines call the
+    /// `weights:` overload below which forwards here.
+    public static func hasInTrunkMTPHead<S: Sequence>(
+        keys: S,
+        deepseekStyleLayerN: Int? = nil
+    ) -> Bool where S.Element == String {
+        for k in keys {
+            for prefix in standardPrefixes {
+                if k.hasPrefix(prefix) { return true }
+            }
+            if let layerN = deepseekStyleLayerN,
+                k.hasPrefix("model.layers.\(layerN).")
+            {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// True iff the weight bag carries any MTP-head-shaped keys.
+    /// Convenience overload over the keys-only variant.
+    public static func hasInTrunkMTPHead(
+        weights: [String: MLXArray],
+        deepseekStyleLayerN: Int? = nil
+    ) -> Bool {
+        hasInTrunkMTPHead(
+            keys: weights.keys, deepseekStyleLayerN: deepseekStyleLayerN)
+    }
+
+    /// Feature-flag gate. Returns true when MTP loading should be active
+    /// for the current process. Driven by either
+    /// `parameters.mtpEnabled == true` or `MLX_MTP_ENABLED=1`.
+    ///
+    /// Sanitize routines call this from inside `sanitize(weights:)` to
+    /// decide whether to keep or drop MTP-named keys. Without an
+    /// active flag, the sanitize routine *must* drop the MTP keys to
+    /// preserve loader-time invariants (no orphan weights, no extra
+    /// memory).
+    public static func mtpLoadEnabled(parameters: GenerateParameters?) -> Bool {
+        if parameters?.mtpEnabled == true { return true }
+        if ProcessInfo.processInfo.environment["MLX_MTP_ENABLED"] == "1" {
+            return true
+        }
+        return false
+    }
+
+    /// Static fallback for sanitize routines that don't have access to
+    /// `GenerateParameters` at load time. Sanitize is called early in
+    /// the model load path, before the iterator/parameters are
+    /// constructed, so the env var is the only signal available there.
+    public static var mtpLoadEnabledFromEnv: Bool {
+        ProcessInfo.processInfo.environment["MLX_MTP_ENABLED"] == "1"
+    }
+}

--- a/Libraries/MLXLMCommon/MTPSelfSpeculativeDecoding.swift
+++ b/Libraries/MLXLMCommon/MTPSelfSpeculativeDecoding.swift
@@ -1,0 +1,438 @@
+// Copyright © 2026 ekryski.
+//
+// Multi-token prediction (MTP) self-speculative decoding — variant A iterator.
+//
+// Spec: specs/030-multi-token-prediction.md
+// Reference: github.com/youssofal/MTPLX (Python MLX, canonical algorithm).
+//
+// Cycle (greedy mode, temp == 0):
+//
+//   1. AR forward on the last committed token. Returns (logits, hidden);
+//      sample bonus = argmax(logits). Trunk cache advances by 1.
+//   2. MTP draft: head 0 takes (hidden, bonus); produces (hidden_0,
+//      logits_0); proposal_0 = argmax(logits_0). Head i+1 takes
+//      (hidden_i, proposal_i); produces (hidden_{i+1}, logits_{i+1}).
+//      After k heads: proposals[0..<k]. Per-head MTP cache advances by 1
+//      per head.
+//   3. Verify forward on [bonus, proposal_0, ..., proposal_{k-1}] (length
+//      k+1). Trunk cache advances by k+1. Returns logits at each
+//      position; verify_logits[i] predicts the token at trunk position
+//      `bonus + i + 1` (i.e. one past proposal_i). For acceptance we
+//      compare verify_argmax[i] against proposal_i.
+//   4. Accept m: verify_argmax[i] == proposal_i for i < m, mismatch at
+//      m. Commit: bonus + proposal_0..proposal_{m-1} (1 + m tokens).
+//      The model's argmax at verify position m (the rejected position)
+//      becomes the next cycle's AR input — call it `fallback`.
+//      Special case m == k: all accepted; verify_argmax[k] is the next
+//      AR input.
+//   5. Trim trunk cache by (k - m) — i.e. drop the rejected proposals.
+//      Trim per-head MTP caches by (k - m) — they advanced once per
+//      head past the accepted prefix. (Per-head advance is 1 per head,
+//      but only the first m heads' state is "valid" — the heads
+//      m..k-1 wrote state that's downstream of the rejected proposal,
+//      which is now invalid.)
+//
+// Hybrid GDN models (Qwen 3.5 / 3.6 / Qwen3-Next) require spec 020
+// tape-replay rollback for the trunk cache trim. This iterator declines
+// to engage on hybrid caches via `canTrimPromptCache(...)` until that
+// lands.
+
+import Foundation
+import MLX
+
+// MARK: - Route decision
+
+/// Outcome of the MTP-route decision: whether to engage
+/// `MTPSelfSpeculativeTokenIterator` and (if env-var-driven) the patched
+/// parameters that should be passed to it.
+public struct MTPRouteDecision: Sendable {
+    /// Engage `MTPSelfSpeculativeTokenIterator` (cache-trimmability
+    /// willing).
+    public let shouldEngage: Bool
+    /// Parameters the iterator should be constructed with.
+    public let parameters: GenerateParameters
+}
+
+/// MTP env-default knobs (applied when `MLX_MTP_ENABLED=1` is set
+/// without explicit Swift parameters).
+///
+/// `mtpEnvDefaultDraftCount = 1` matches DeepSeek-V3/V4's published k=1
+/// MTP head; per-family overrides should set this to 2 or higher only
+/// when the bundle ships `>1` heads.
+public let mtpEnvDefaultDraftCount: Int = 1
+
+/// Decide whether `MLXLMCommon.generate(...)` should auto-route to the
+/// MTP self-speculative iterator (variant A).
+///
+/// **Opt-in modes**:
+///   1. **Swift parameters.** `parameters.mtpEnabled == true`.
+///   2. **Env var.** `MLX_MTP_ENABLED=1`. Applies sensible defaults
+///      (`mtpDraftCount = 1`); explicit Swift values still win.
+///
+/// **Disqualifiers** (any one declines the route):
+///   - `temperature != 0` — phase 1 is greedy-only. Stochastic
+///     accept/reject is spec 030 phase 3.
+///
+/// The model-conformance check (`is MTPInjector` + `isMTPLoaded`) and
+/// the cache-trimmability check happen later, inside `generate(...)`,
+/// after the model context is in hand. A non-conforming model falls
+/// back to `TokenIterator` cleanly.
+public func mtpRouteDecision(parameters: GenerateParameters) -> MTPRouteDecision {
+    if parameters.temperature != 0 {
+        return MTPRouteDecision(shouldEngage: false, parameters: parameters)
+    }
+
+    let optedInBySwift = parameters.mtpEnabled
+    if optedInBySwift {
+        var patched = parameters
+        if patched.mtpDraftCount < 1 {
+            patched.mtpDraftCount = mtpEnvDefaultDraftCount
+        }
+        return MTPRouteDecision(shouldEngage: true, parameters: patched)
+    }
+
+    let envEnabled =
+        ProcessInfo.processInfo.environment["MLX_MTP_ENABLED"] == "1"
+    if envEnabled {
+        var patched = parameters
+        patched.mtpEnabled = true
+        if patched.mtpDraftCount < 1 {
+            patched.mtpDraftCount = mtpEnvDefaultDraftCount
+        }
+        return MTPRouteDecision(shouldEngage: true, parameters: patched)
+    }
+
+    return MTPRouteDecision(shouldEngage: false, parameters: parameters)
+}
+
+// MARK: - Iterator
+
+/// Self-speculative iterator backed by a target's in-trunk MTP heads.
+///
+/// One model serves both target and draft via the `MTPInjector`
+/// protocol — the heads share the trunk's embedding + LM head and
+/// predict tokens at offsets +1..+k from a captured trunk hidden state.
+///
+/// Phase 1 supports greedy mode only (`temperature == 0`). Stochastic
+/// accept/reject is spec 030 phase 3.
+///
+/// Hybrid GDN trunks (Qwen 3.5 / 3.6 / Qwen3-Next) require spec 020
+/// tape-replay rollback before they're safe with this iterator. The
+/// init refuses to engage on non-trimmable caches.
+public struct MTPSelfSpeculativeTokenIterator: TokenIteratorProtocol {
+
+    /// Composite type — the model must be both a `LanguageModel`
+    /// (for `prepare(...)`, `defaultPrefillStepSize`, etc.) and an
+    /// `MTPInjector` (for the capture forward + MTP head forwards).
+    public typealias MTPModel = LanguageModel & MTPInjector
+
+    var y: LMInput.Text
+    let model: any MTPModel
+    var trunkCache: [KVCache]
+    var headCaches: [KVCache]
+
+    var processor: (any LogitProcessor)?
+    let sampler: LogitSampler
+
+    public var tokenCount = 0
+    let maxTokens: Int?
+    /// Number of MTP heads engaged per cycle. Constrained to
+    /// `[1, model.mtpContract.maxHeads]` at init.
+    let draftCount: Int
+
+    // Per-cycle emission buffer.
+    private var pendingTokens = [Int]()
+    private var pendingIndex = 0
+
+    public private(set) var promptPrefillTime: TimeInterval = 0.0
+
+    /// MTP draft tokens accepted across the run.
+    public private(set) var mtpAcceptedCount = 0
+    /// MTP draft tokens proposed across the run.
+    public private(set) var mtpProposedCount = 0
+
+    public var acceptanceRate: Double {
+        guard mtpProposedCount > 0 else { return 0 }
+        return Double(mtpAcceptedCount) / Double(mtpProposedCount)
+    }
+
+    public var specDecodeProposed: Int { mtpProposedCount }
+    public var specDecodeAccepted: Int { mtpAcceptedCount }
+
+    public var kvCacheMemoryBytes: Int? {
+        let trunkBytes = trunkCache.reduce(0) { $0 + $1.memoryBytes }
+        let headBytes = headCaches.reduce(0) { $0 + $1.memoryBytes }
+        return trunkBytes + headBytes
+    }
+
+    /// Initialize the iterator.
+    ///
+    /// - Throws: ``MTPIteratorError`` when the model is not MTP-loaded
+    ///   or its trunk cache is not fully trimmable (hybrid GDN before
+    ///   spec 020 lands).
+    public init(
+        input: LMInput,
+        model: any MTPModel,
+        trunkCache: [KVCache]? = nil,
+        parameters: GenerateParameters
+    ) throws {
+        guard model.isMTPLoaded else {
+            throw MTPIteratorError(
+                message:
+                    "MTP iterator requires a model with MTP heads loaded. "
+                    + "Set GenerateParameters.mtpEnabled = true (or "
+                    + "MLX_MTP_ENABLED=1) before model load to keep MTP "
+                    + "weights through the sanitize step.")
+        }
+        guard parameters.temperature == 0 else {
+            throw MTPIteratorError(
+                message:
+                    "MTP iterator is greedy-only in phase 1 (temperature "
+                    + "== 0). Stochastic accept/reject is spec 030 phase 3.")
+        }
+
+        self.y = input.text
+        self.model = model
+        self.trunkCache = trunkCache ?? model.newCache(parameters: parameters)
+        guard canTrimPromptCache(self.trunkCache) else {
+            throw MTPIteratorError(
+                message:
+                    "MTP iterator requires a fully trimmable trunk KV "
+                    + "cache. Hybrid GDN models block on spec 020 "
+                    + "tape-replay rollback.")
+        }
+
+        self.headCaches = model.mtpHeadCaches(parameters: parameters)
+        let availableHeads = self.headCaches.count
+        precondition(
+            availableHeads == model.mtpContract.maxHeads,
+            "MTPInjector.mtpHeadCaches must return mtpContract.maxHeads entries"
+        )
+        let requested = Swift.max(1, parameters.mtpDraftCount)
+        self.draftCount = Swift.min(requested, availableHeads)
+
+        self.sampler = parameters.sampler()
+        self.processor = parameters.processor()
+        self.maxTokens = parameters.maxTokens
+
+        self.promptPrefillTime = try measure {
+            try prepare(input: input, windowSize: parameters.prefillStepSize)
+        }
+    }
+
+    /// Prefill the trunk with the prompt. MTP head caches stay empty
+    /// during prefill — the heads are only invoked after the trunk has
+    /// produced a hidden state for the first decode position.
+    mutating func prepare(input: LMInput, windowSize: Int? = nil) throws {
+        processor?.prompt(input.text.tokens)
+
+        let resolvedWindow = windowSize ?? model.defaultPrefillStepSize
+        switch try model.prepare(
+            input, cache: trunkCache, windowSize: resolvedWindow)
+        {
+        case .tokens(let tokens):
+            y = tokens
+        case .logits(let result):
+            var logits = result.logits[0..., -1, 0...]
+            logits = processor?.process(logits: logits) ?? logits
+            let token = sampler.sample(logits: logits)
+            processor?.didSample(token: token)
+            y = .init(tokens: token)
+        }
+    }
+
+    /// One MTP cycle: AR + draft + verify + accept/trim.
+    mutating func cycle() {
+        let remainingBudget = maxTokens.map { $0 - tokenCount } ?? Int.max
+        if remainingBudget <= 0 { return }
+
+        // ---- 1. AR forward on the trailing token. -----------------------
+        let arInput = y[text: .newAxis]  // [1, L]
+        let (arLogits, arHidden) = model.runCaptureForward(
+            inputs: arInput.tokens, cache: trunkCache)
+
+        var bonusLogits = arLogits[0..., -1, 0...]  // [1, V]
+        bonusLogits = processor?.process(logits: bonusLogits) ?? bonusLogits
+        let bonusTokenArr = sampler.sample(logits: bonusLogits)  // [1]
+        processor?.didSample(token: bonusTokenArr)
+        let bonusToken = bonusTokenArr.item(Int.self)
+        pendingTokens.append(bonusToken)
+
+        if remainingBudget == 1 {
+            // No room for spec-decode acceptance this cycle. Set up next
+            // cycle's AR input from the bonus and exit.
+            y = .init(tokens: bonusTokenArr)
+            return
+        }
+
+        // Trim draftCount to the remaining budget so we don't propose
+        // more tokens than the caller will consume.
+        let k = Swift.min(draftCount, remainingBudget - 1)
+
+        // ---- 2. MTP heads draft -----------------------------------------
+        // Trunk hidden at the last AR position is the seed for head 0.
+        // `[0..., -1, 0...]` collapses the L axis; expand it back to keep
+        // the [B, 1, H] shape that the heads expect.
+        let seedHidden = arHidden[0..., -1, 0...]
+            .expandedDimensions(axis: 1)  // [1, 1, H]
+
+        var prevHidden = seedHidden
+        var prevTokenArr = bonusTokenArr.expandedDimensions(axis: 0)  // [1, 1]
+        var draftProcessor = processor  // shadow — real processor only advances on accept
+        var proposals = [Int]()
+        var proposalArrays = [MLXArray]()
+        proposals.reserveCapacity(k)
+        proposalArrays.reserveCapacity(k)
+        for headIdx in 0 ..< k {
+            let out = model.runMTPHead(
+                headIndex: headIdx,
+                prevHidden: prevHidden,
+                prevToken: prevTokenArr,
+                headCache: headCaches[headIdx])
+
+            var logits = out.logits[0..., -1, 0...]  // [1, V]
+            logits = draftProcessor?.process(logits: logits) ?? logits
+            let tokenArr = sampler.sample(logits: logits)
+            draftProcessor?.didSample(token: tokenArr)
+            asyncEval(tokenArr)
+            let tok = tokenArr.item(Int.self)
+            proposals.append(tok)
+            proposalArrays.append(tokenArr)
+
+            prevHidden = out.nextHidden
+            prevTokenArr = tokenArr.expandedDimensions(axis: 0)
+        }
+
+        if k == 0 {
+            y = .init(tokens: bonusTokenArr)
+            return
+        }
+
+        // ---- 3. Verify forward ------------------------------------------
+        // [bonus, proposal_0, ..., proposal_{k-1}] — total length k+1.
+        let verifyTokens = concatenated(
+            [bonusTokenArr] + proposalArrays.map { $0 })  // [k+1]
+        let verifyInput = verifyTokens.expandedDimensions(axis: 0)  // [1, k+1]
+        let (verifyLogits, _) = model.runCaptureForward(
+            inputs: verifyInput, cache: trunkCache)
+        // verifyLogits[0, i, :] = trunk's predicted next-token distribution
+        // at position `i`. We compare verifyLogits[0, 0, :] argmax against
+        // proposal_0, verifyLogits[0, 1, :] argmax against proposal_1, etc.
+        // verifyLogits[0, k, :] is the token AFTER the last proposal — the
+        // "free" fall-through that becomes the next cycle's AR input.
+
+        let verifyStart = 0  // verify input was a fresh batch of k+1
+        var fallbackTokenArr = MLXArray(0)  // placeholder, set below
+        var accepted = 0
+        if var verifyProcessor = processor {
+            // Sequential sampling so the processor sees prior tokens.
+            for i in 0 ... k {
+                var logits = verifyLogits[0..., verifyStart + i, 0...]
+                logits = verifyProcessor.process(logits: logits)
+                let token = sampler.sample(logits: logits)
+                verifyProcessor.didSample(token: token)
+                if i < k {
+                    let tokInt = token.item(Int.self)
+                    if tokInt == proposals[i] {
+                        accepted += 1
+                    } else {
+                        fallbackTokenArr = token
+                        break
+                    }
+                } else {
+                    // All k accepted — position k is the fallthrough.
+                    fallbackTokenArr = token
+                }
+            }
+        } else {
+            // Batched argmax.
+            let batched = verifyLogits[0..., verifyStart ... verifyStart + k, 0...]
+                .squeezed(axis: 0)  // [k+1, V]
+            let argmax = sampler.sample(logits: batched)  // [k+1]
+            eval(argmax)
+            let argmaxList = argmax.asArray(Int.self)
+            for i in 0 ..< k {
+                if argmaxList[i] == proposals[i] {
+                    accepted += 1
+                } else {
+                    break
+                }
+            }
+            // Index of the fallthrough token in the argmax buffer.
+            let idx = accepted
+            fallbackTokenArr = argmax[idx ... idx]
+        }
+
+        // Commit accepted proposals to pendingTokens (after the bonus
+        // already buffered).
+        for i in 0 ..< accepted {
+            processor?.didSample(token: proposalArrays[i])
+            pendingTokens.append(proposals[i])
+        }
+
+        mtpAcceptedCount += accepted
+        mtpProposedCount += k
+
+        // Commit fallback token (always exactly one) — becomes the
+        // next cycle's AR input.
+        if accepted < k {
+            processor?.didSample(token: fallbackTokenArr)
+        }
+        // Trim trunk cache: verify advanced by k+1, but only `accepted+1`
+        // positions are valid (bonus + accepted proposals). Drop the
+        // rest.
+        let trunkTrim = k - accepted
+        if trunkTrim > 0 {
+            trimPromptCache(trunkCache, numTokens: trunkTrim)
+        }
+
+        // Trim per-head MTP caches: heads 0..<accepted advanced their
+        // state on a "valid" prior, so their cache entries are
+        // legitimate. Heads accepted..<k advanced on a now-rejected
+        // proposal — their cache entries should be dropped. Each head
+        // advanced its cache by exactly 1 per call.
+        for headIdx in accepted ..< k {
+            _ = headCaches[headIdx].trim(1)
+        }
+
+        // Set y for next cycle: the fallback (rejected-position model
+        // argmax, or full-acceptance fallthrough).
+        y = .init(tokens: fallbackTokenArr)
+        // Buffer the fallback so the iterator emits it before draining.
+        // The fallback advances the cache by 1 only on the next AR
+        // forward — at that point the trunk consumes it.
+        // NOTE: do NOT append fallback to pendingTokens — it'll be
+        // consumed by the next cycle's AR forward and emitted there.
+    }
+
+    public var tokenCountValue: Int { tokenCount }
+
+    public mutating func next() -> Int? {
+        if let maxTokens, tokenCount >= maxTokens {
+            return nil
+        }
+        if pendingIndex < pendingTokens.count {
+            let token = pendingTokens[pendingIndex]
+            pendingIndex += 1
+            tokenCount += 1
+            return token
+        }
+        pendingTokens.removeAll(keepingCapacity: true)
+        pendingIndex = 0
+        cycle()
+        if pendingTokens.isEmpty {
+            return nil
+        }
+        let token = pendingTokens[pendingIndex]
+        pendingIndex += 1
+        tokenCount += 1
+        return token
+    }
+}
+
+/// Init / runtime errors thrown by the MTP iterator.
+public struct MTPIteratorError: Error, CustomStringConvertible, Sendable {
+    public let message: String
+    public init(message: String) { self.message = message }
+    public var description: String { "MTPIteratorError: \(message)" }
+}

--- a/Tests/MLXLMTests/MTPTests.swift
+++ b/Tests/MLXLMTests/MTPTests.swift
@@ -1,0 +1,188 @@
+// Copyright © 2026 ekryski.
+//
+// Multi-token prediction (MTP) — unit tests for the protocol surface,
+// the variant-A route decision, and the variant-B assistant draft
+// registry.
+//
+// Spec: specs/030-multi-token-prediction.md.
+//
+// These tests don't engage a live model. The full iterator round-trip
+// against a real `MTPInjector` conformance lands in a follow-up once a
+// model carries the head implementation (e.g. DeepseekV4MTP).
+
+import Foundation
+@testable import MLXLMCommon
+import Testing
+
+@Suite
+struct MTPTests {
+
+    // MARK: - mtpRouteDecision
+
+    @Test
+    func `route declines on default parameters`() {
+        let p = GenerateParameters(temperature: 0.0)
+        let d = mtpRouteDecision(parameters: p)
+        #expect(d.shouldEngage == false)
+    }
+
+    @Test
+    func `route declines on non-greedy temperature`() {
+        var p = GenerateParameters(temperature: 0.7)
+        p.mtpEnabled = true
+        let d = mtpRouteDecision(parameters: p)
+        #expect(d.shouldEngage == false)
+    }
+
+    @Test
+    func `route engages on Swift opt-in (greedy)`() {
+        var p = GenerateParameters(temperature: 0.0)
+        p.mtpEnabled = true
+        let d = mtpRouteDecision(parameters: p)
+        #expect(d.shouldEngage == true)
+        // Default draft count fills in when caller didn't set one.
+        #expect(d.parameters.mtpDraftCount >= 1)
+    }
+
+    @Test
+    func `route preserves explicit draft count`() {
+        var p = GenerateParameters(temperature: 0.0)
+        p.mtpEnabled = true
+        p.mtpDraftCount = 3
+        let d = mtpRouteDecision(parameters: p)
+        #expect(d.shouldEngage == true)
+        #expect(d.parameters.mtpDraftCount == 3)
+    }
+
+    // MARK: - MTPLoader probing
+
+    @Test
+    func `MTPLoader detects mtp prefix`() {
+        let keys: Set<String> = [
+            "model.layers.0.self_attn.q_proj.weight",
+            "mtp.eh_proj.weight",
+        ]
+        #expect(MTPLoader.hasInTrunkMTPHead(keys: keys))
+    }
+
+    @Test
+    func `MTPLoader detects DeepSeek-style layer-N convention`() {
+        let keys: Set<String> = [
+            "model.layers.42.self_attn.q_proj.weight",
+            "model.layers.43.eh_proj.weight",  // layer-N MTP
+        ]
+        #expect(MTPLoader.hasInTrunkMTPHead(
+            keys: keys, deepseekStyleLayerN: 43))
+    }
+
+    @Test
+    func `MTPLoader returns false on plain weights`() {
+        let keys: Set<String> = [
+            "model.layers.0.self_attn.q_proj.weight",
+            "lm_head.weight",
+        ]
+        #expect(MTPLoader.hasInTrunkMTPHead(keys: keys) == false)
+        #expect(MTPLoader.hasInTrunkMTPHead(
+            keys: keys, deepseekStyleLayerN: 99) == false)
+    }
+
+    @Test
+    func `MTPLoader.mtpLoadEnabled false by default`() {
+        let p = GenerateParameters()
+        #expect(MTPLoader.mtpLoadEnabled(parameters: p) == false)
+    }
+
+    @Test
+    func `MTPLoader.mtpLoadEnabled true when parameters opt in`() {
+        var p = GenerateParameters()
+        p.mtpEnabled = true
+        #expect(MTPLoader.mtpLoadEnabled(parameters: p) == true)
+    }
+
+    // MARK: - AssistantDraftRegistry
+
+    @Test
+    func `registry resolves Gemma-4 26B-A4B target`() {
+        let entry = AssistantDraftRegistry.resolve(
+            targetId: "mlx-community/gemma-4-26B-A4B-it-bf16")
+        #expect(entry?.draftId
+            == "mlx-community/gemma-4-26B-A4B-it-assistant-bf16")
+        #expect(entry?.recommendedNumDraftTokens == 6)
+    }
+
+    @Test
+    func `registry resolves Gemma-4 31B target`() {
+        let entry = AssistantDraftRegistry.resolve(
+            targetId: "mlx-community/gemma-4-31B-it-4bit")
+        #expect(entry?.draftId
+            == "mlx-community/gemma-4-31B-it-assistant-bf16")
+    }
+
+    @Test
+    func `registry resolves Gemma-4 E2B target`() {
+        let entry = AssistantDraftRegistry.resolve(
+            targetId: "mlx-community/gemma-4-E2B-it-bf16")
+        #expect(entry?.draftId
+            == "mlx-community/gemma-4-E2B-it-assistant-bf16")
+    }
+
+    @Test
+    func `registry resolves Gemma-4 E4B target`() {
+        let entry = AssistantDraftRegistry.resolve(
+            targetId: "mlx-community/gemma-4-E4B-it-bf16")
+        #expect(entry?.draftId
+            == "mlx-community/gemma-4-E4B-it-assistant-bf16")
+    }
+
+    @Test
+    func `registry returns nil on unsupported target`() {
+        let entry = AssistantDraftRegistry.resolve(
+            targetId: "mlx-community/Llama-3.2-3B-Instruct-4bit")
+        #expect(entry == nil)
+    }
+
+    @Test
+    func `registry org-strip fallback matches local bundles`() {
+        // A local-only bundle path that ends with the same suffix as a
+        // registered prefix should match via the org-strip fallback.
+        let entry = AssistantDraftRegistry.resolve(
+            targetId: "LocalDir/gemma-4-26B-A4B-it-bf16")
+        #expect(entry?.draftId
+            == "mlx-community/gemma-4-26B-A4B-it-assistant-bf16")
+    }
+
+    // MARK: - GenerateParameters threading
+
+    @Test
+    func `GenerateParameters defaults disable MTP`() {
+        let p = GenerateParameters()
+        #expect(p.mtpEnabled == false)
+        #expect(p.mtpDraftCount == 0)
+        #expect(p.mtpAssistantDraftId == nil)
+    }
+
+    @Test
+    func `GenerateParameters initializer threads MTP fields`() {
+        let p = GenerateParameters(
+            temperature: 0.0,
+            mtpEnabled: true, mtpDraftCount: 2,
+            mtpAssistantDraftId: "custom/draft-id")
+        #expect(p.mtpEnabled == true)
+        #expect(p.mtpDraftCount == 2)
+        #expect(p.mtpAssistantDraftId == "custom/draft-id")
+    }
+
+    // MARK: - MTPContract
+
+    @Test
+    func `MTPContract stores per-family knobs`() {
+        let c = MTPContract(
+            hiddenVariant: .preNorm,
+            concatOrder: .embeddingHidden,
+            maxHeads: 1, family: "deepseek-v4")
+        #expect(c.maxHeads == 1)
+        #expect(c.family == "deepseek-v4")
+        if case .preNorm = c.hiddenVariant { } else { Issue.record() }
+        if case .embeddingHidden = c.concatOrder { } else { Issue.record() }
+    }
+}


### PR DESCRIPTION
## Summary

Spec 030 phase 1a — multi-token prediction (MTP) self-speculative decoding scaffolding for both variants:

- **Variant A** (in-trunk MTP heads, DeepSeek-style): `MTPInjector` protocol + `MTPSelfSpeculativeTokenIterator` (greedy mode) + auto-routing in `MLXLMCommon.generate(...)`. Reference: [youssofal/MTPLX](https://github.com/youssofal/MTPLX).
- **Variant B** (companion EAGLE-style assistant draft, Google's "MTP" branding for Gemma 4): `AssistantDraftRegistry` mapping target HF id → assistant draft id + recommended `numDraftTokens`. Caller wires the resolved draft into the existing `SpeculativeTokenIterator`.

Phase 1a deliberately **stops short of the per-model `MTPInjector` conformance**. The DeepseekV4MTP head implementation needs validation against a running model + MTPLX reference outputs before we can ship it confidently — that's a focused follow-up where the architecture choices (concat order, hidden-variant norm, eh_proj shape) can be measured rather than guessed. The scaffolding here is the substantial work; conformance is comparatively small once you have a model in hand.

## What ships in this PR

| File | Purpose |
|---|---|
| [Libraries/MLXLMCommon/MTPInjector.swift](Libraries/MLXLMCommon/MTPInjector.swift) | Protocol surface + `MTPContract` (per-family `hiddenVariant` / `concatOrder` / `maxHeads` / `family`) + `MTPLoader` (key-prefix probing + env-gate helpers). |
| [Libraries/MLXLMCommon/MTPSelfSpeculativeDecoding.swift](Libraries/MLXLMCommon/MTPSelfSpeculativeDecoding.swift) | `MTPSelfSpeculativeTokenIterator` — greedy AR + MTP-draft + batched-verify + accept/trim cycle. Standard `TokenIteratorProtocol` surface; reports `specDecodeProposed` / `specDecodeAccepted` like the existing iterators. `mtpRouteDecision` for auto-routing eligibility. |
| [Libraries/MLXLMCommon/AssistantDraftRegistry.swift](Libraries/MLXLMCommon/AssistantDraftRegistry.swift) | Hard-coded Gemma-4 `*-it-assistant-bf16` mappings. Prefix-match + org-strip resolver for local bundles. |
| [Libraries/MLXLMCommon/Evaluate.swift](Libraries/MLXLMCommon/Evaluate.swift) | `GenerateParameters.{mtpEnabled, mtpDraftCount, mtpAssistantDraftId}` (default off). Variant-A auto-routing block in the standard `generate(...)` — engages before n-gram when a conforming model is present. |
| [Libraries/MLXLLM/Models/DeepseekV4.swift](Libraries/MLXLLM/Models/DeepseekV4.swift) | Sanitize gate: with `MLX_MTP_ENABLED=1`, the `mtp.*` and layer-N MTP keys are now PRESERVED through `sanitize(weights:)`. Default behaviour unchanged. |
| [Tests/MLXLMTests/MTPTests.swift](Tests/MLXLMTests/MTPTests.swift) | 18 unit tests — route decision, registry resolution (E2B / E4B / 26B-A4B / 31B + org-strip + miss), key-prefix probing, parameter threading, contract value-type. |

## Auto-routing precedence

Spec 030 + 015 ordering — MTP takes precedence over n-gram (trained-head proposals carry a higher acceptance ceiling):

```
if dflash-eligible        → DFlashSpeculativeTokenIterator   (spec 015 — not yet)
elif mtp-A-eligible       → MTPSelfSpeculativeTokenIterator  (THIS PR)
elif ngram-eligible       → NGramSpeculativeTokenIterator    (existing)
else                      → TokenIterator
```

Variant A engages only when (1) the model conforms to `MTPInjector`, (2) `isMTPLoaded` is true, (3) the trunk cache is fully trimmable, and (4) `temperature == 0`. Failed inits fall through cleanly.

Variant B doesn't ride the same auto-routing because `MLXLMCommon.generate(...)` doesn't have access to a downloader — the caller resolves via `AssistantDraftRegistry` explicitly, then passes the loaded draft to the speculative `generate(...)` overload.

## How to use

### Variant A (once a model conforms)

```swift
var params = GenerateParameters(temperature: 0.0)
params.mtpEnabled = true
params.mtpDraftCount = 1   // or via MLX_MTP_ENABLED=1
let stream = try generate(input: input, parameters: params, context: context)
```

### Variant B (Gemma 4 assistant — works today)

```swift
let entry = AssistantDraftRegistry.resolve(targetId: targetContext.configuration.name)!
let draftCtx = try await loadModelContainer(/* draftId from entry */)
let stream = try generate(
    input: input, parameters: params, context: targetContext,
    draftModel: draftCtx.model, numDraftTokens: entry.recommendedNumDraftTokens)
```

## On the MTP-head pruning question

The DeepSeek-V4 sanitize gate is the load-bearing change for variant A. The `mlx-community/DeepSeek-V4-Flash-2bit-DQ` bundle ships the MTP layer at `model.layers.{numHiddenLayers}.*` — our sanitize had been actively dropping it. With `MLX_MTP_ENABLED=1` the layer is now preserved through load, ready to bind to a future `DeepseekV4MTP` module.

For Qwen 3.5/3.6 the same sanitize-gate pattern needs replication (and is blocked on spec 020 tape-replay before the iterator can engage on those hybrid GDN trunks). For Gemma 4, the original bundles don't ship in-trunk heads — variant B is the path there.

## Test plan

- [x] `swift build` — library + tests target both compile clean
- [x] `swift test --filter MTPTests` — 18/18 pass
- [x] No regression in existing tests (`ResolveTests` etc. still pass)
- [ ] Variant B integration on Gemma-4-26B-A4B once the bench harness wires `AssistantDraftRegistry.resolve(...)` (follow-up — can be slotted into the next bench-harness PR)
- [ ] Variant A integration once a `DeepseekV4MTP` conformance lands (separate PR — needs running model for validation)

## Follow-ups

1. **DeepseekV4MTP module** — the actual head architecture (enorm, hnorm, eh_proj + reused DSV4 attention/MoE block). Validate against MTPLX Python reference token-by-token at temp 0 before merge.
2. **Custom converter** (`scripts/mtp_convert.py`) — for in-trunk families where mlx-community bundles already pruned the heads (DeepSeek-V3 4-bit, MiMo).
3. **Stochastic accept/reject** (spec 030 phase 3) — port the spec-023 sampler to share with MTP.
4. **Hybrid GDN conformance** (Qwen 3.5/3.6/Qwen3-Next variant A) — gated on spec 020 phase 2/3.
5. **Bench harness `--mtp` flag** — drive variant B on Gemma 4 from the existing sweep tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)