### PR TITLE
chore(doctor): require gatedDeltaStepRecord + stateReplay symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,10 +217,23 @@ status:
 # minute-long build and prints a remediation hint. Not run as part of `make` —
 # it's a diagnostic you reach for when something looks off.
 
-# Symbols we depend on from mlx-swift's MLXFast — load-bearing for the Turbo B
-# path. If any are missing the project won't build. Add to this list when
-# new MLXFast functions become required by Libraries/.
-DOCTOR_REQUIRED_SYMBOLS := turboBulkDequantRotated turboFlashPass1 turboFlashPass2
+# Symbols we depend on from mlx-swift's MLXFast — load-bearing for the
+# project's native-kernel paths. If any are missing the project won't build.
+# Add to this list when new MLXFast functions become required by Libraries/.
+#
+# Current set:
+#   - turboBulkDequantRotated / turboFlashPass1 / turboFlashPass2
+#       TurboQuant Path B (compressed-domain KV decode).
+#   - gatedDeltaStepRecord / stateReplay
+#       Spec 020 state-replay rollback (`SSMStateCache` + n-gram on Qwen
+#       3.5 / 3.6 hybrid models). Wrappers around the native Metal kernels
+#       at `mlx-swift/Source/Cmlx/mlx-generated/metal/gated_delta_replay.metal`.
+DOCTOR_REQUIRED_SYMBOLS := \
+	turboBulkDequantRotated \
+	turboFlashPass1 \
+	turboFlashPass2 \
+	gatedDeltaStepRecord \
+	stateReplay
 
 .PHONY: doctor
 doctor:


### PR DESCRIPTION
`make doctor` verifies the resolved `mlx-swift` exposes the MLXFast symbols `Libraries/` depends on. After spec 020 (state-replay rollback) shipped, the project now depends on two new native-kernel wrappers that should be checked alongside the existing turbo* set:

| Symbol | What |
|---|---|
| `gatedDeltaStepRecord` | Forward GDN kernel with per-step `delta` tape capture (used by `SSMStateCache` during the verify forward). |
| `stateReplay` | Re-fold the accepted prefix of a delta log onto a pre-record state snapshot (used by `SSMStateCache.rollback(acceptedPrefix:)`). |

If a developer resolves an `mlx-swift` without these symbols (stale release tag, wrong branch, etc.), `make doctor` now fails with a clear `MISSING` line instead of producing a confusing link-time error deeper in the build.

Also reformats `DOCTOR_REQUIRED_SYMBOLS` as a multi-line list with inline grouping comments so adding more symbols stays clean.

## Verification

```
$ make doctor
mlx-swift-lm doctor
===================

Resolved mlx-swift: /Users/eric/Development/personal/ai/mlx-swift-lm/../mlx-swift
  HEAD: b06bbdb (alpha)

Required symbols in MLXFast.swift:
  turboBulkDequantRotated: OK
  turboFlashPass1: OK
  turboFlashPass2: OK
  gatedDeltaStepRecord: OK
  stateReplay: OK

Submodule pin consistency (mlx-swift's gitlink vs. submodule HEAD):
  Source/Cmlx/mlx: OK (701cd4a4)
  Source/Cmlx/mlx-c: OK (f8ad22f5)

All checks passed.
```