### PR TITLE
fix(warnings): clean up mlx-swift-lm-side build warnings

### DIFF
--- a/Libraries/MLXLLM/Models/GatedDelta.swift
+++ b/Libraries/MLXLLM/Models/GatedDelta.swift
@@ -429,7 +429,8 @@ public func gatedDeltaUpdateRecord(
     let g = computeGatedDeltaG(aLog, a, dtBias)
 
     let B = q.dim(0)
-    let T = q.dim(1)
+    // T = q.dim(1) — kernel reads T from tensor shapes; not needed at the
+    // dispatcher level. Kept in the per-round recording explanation below.
     let Hk = q.dim(2)
     let Dk = q.dim(3)
     let Hv = v.dim(2)

--- a/Tests/Benchmarks/InferenceBenchmark.swift
+++ b/Tests/Benchmarks/InferenceBenchmark.swift
@@ -721,6 +721,17 @@ private enum BenchEnv {
 
     /// Install the crash-stack capture handler. Idempotent — safe to call
     /// multiple times. Replaces any previously-installed handler.
+    ///
+    /// Intentionally uses MLX's legacy global `setErrorHandler(...)` (now
+    /// deprecated upstream in favour of the scoped `withErrorHandler { body }`
+    /// form, which would be the right API for most use cases). The bench
+    /// needs the handler installed PROCESS-WIDE across an async
+    /// `@MainActor` test function whose body captures `self`, and Swift 6's
+    /// isolation rules forbid transferring that closure to the non-isolated
+    /// `withErrorHandler`. Until mlx-swift offers an isolation-friendly
+    /// global-handler entry point, this is the only path that keeps the
+    /// bench function shape stable — the resulting one-line deprecation
+    /// warning at the call below is accepted noise.
     static func installCrashStackCapture() {
         // Clear any stale log from a previous run so the file's presence
         // is itself a signal that a crash occurred this run.
@@ -850,8 +861,8 @@ struct InferenceBenchmarks {
         // handler that captures the Swift backtrace at the moment of a
         // C++→Swift error (before `fatalError` kills the process and
         // discards captured stdio). Backtrace is written to
-        // `/tmp/mlx-bench-crash.log` so it survives the process exit.
-        // Off by default — has no overhead when the env var is unset.
+        // `/tmp/mlx-bench-crash.log` so it survives the process exit. Off
+        // by default — has no overhead when the env var is unset.
         if BenchEnv.debugCrashCapture {
             BenchEnv.installCrashStackCapture()
         }

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -1032,10 +1032,15 @@ func testToQuantizedDispatchesOnEviction() async throws {
 
 /// `.none` and `.affine` algorithms — boundary-skip is turbo-specific.
 @Test func testTurboBoundarySkipSetNonTurboAlgorithms() {
+    // Fully-qualify `KVCacheCompressionAlgorithm.none` rather than `.none`
+    // because the parameter type is `KVCacheCompressionAlgorithm?` and the
+    // enum has its own `.none` case — Swift can't disambiguate
+    // `Optional<KVCacheCompressionAlgorithm>.none` (nil) from the case.
+    // We mean the enum case (no compression), not nil.
     #expect(
         turboBoundarySkipSet(
             attentionLayerIndices: Array(0 ..< 16),
-            algorithm: .none
+            algorithm: KVCacheCompressionAlgorithm.none
         ).isEmpty)
     #expect(
         turboBoundarySkipSet(


### PR DESCRIPTION
Cleans up the mlx-swift-lm-side build warnings on `alpha`. Three warnings; two fully fixable, one accepted with a clear inline rationale.

## Fixes

### 1. `Libraries/MLXLLM/Models/GatedDelta.swift:432` — unused `let T`

The variable was extracted from `q` for an explanatory comment about per-round recording, but never referenced in code (the kernel reads `T` from the tensor shape). Comment out, leave a note for readers.

### 2. `Tests/MLXLMTests/KVCacheTests.swift:1038` — `.none` ambiguity

`KVCacheCompressionAlgorithm` has a `.none` case, and the parameter type is `KVCacheCompressionAlgorithm?`. Swift can't disambiguate between the enum case and `Optional<...>.none` (nil). The test intent is clearly the enum case (verify that `.none` algorithm yields no boundary-skip set, since boundary-skip is turbo-specific), so fully qualify as `KVCacheCompressionAlgorithm.none`.

## Accepted (with rationale)

### 3. `Tests/Benchmarks/InferenceBenchmark.swift:739` — `setErrorHandler` deprecated

The bench installs an MLX error handler globally for the duration of a `@MainActor` test function. Migrating to the scoped replacement (`withErrorHandler(handler, body:)`) would be the right API, but Swift 6's isolation rules forbid transferring a closure that captures `@MainActor self` to the non-isolated `withErrorHandler`:

```
error: sending value of non-Sendable type '() async throws -> ()' risks causing data races [#SendingRisksDataRace]
```

Tried two restructures (extracted helper + inlined wrap) — both hit the same Sendable boundary error. The only paths to silence it are:

- Drop `@MainActor` from `benchmark()` — unclear what depends on the main-actor isolation; risks regressing GPU dispatch behaviour
- Have mlx-swift add an isolation-friendly global-handler entry point — upstream change
- Live with the warning

Going with option 3. Added a 10-line doc comment on `installCrashStackCapture()` explaining the situation so the warning becomes accepted noise rather than mystery.

## Verification

```
$ make clean && make 2>&1 | grep "Tests/Benchmarks\|Libraries/MLXLLM\|Tests/MLXLMTests" | grep "warning:" | wc -l
1     (only the documented setErrorHandler deprecation)
```

Before this PR: 3 mlx-swift-lm-side warnings. After: 1 (documented).

All 202 unit tests still pass.

## Out of scope

A larger set of warnings comes from the `mlx-swift` dependency itself (Sendable / variable-mutation / conditional-downcast in `Source/MLX/MLXArray.swift`, `Stream.swift`, `Source/MLXNN/Module.swift`), plus several `.metal` kernel C++17-extension warnings in `mlx-generated/`. Those belong in `ekryski/mlx-swift` + `ekryski/mlx` PRs respectively; not this PR's concern.