### PR TITLE
fix(build-metallib): match mlx CMake's -Wno-c++17/20-extensions flags

### DIFF
--- a/scripts/build-metallib.sh
+++ b/scripts/build-metallib.sh
@@ -64,9 +64,19 @@ build_metallib_for_config() {
         air_name=$(echo "$rel_path" | sed 's|/|_|g; s|\.metal$|.air|')
         local air_file="$AIR_DIR/$air_name"
 
+        # `-Wno-c++17-extensions` / `-Wno-c++20-extensions` match the flags
+        # both `mlx/mlx/backend/metal/kernels/CMakeLists.txt:19-20` and
+        # `mlx-swift/xcode/xcconfig/Cmlx.xcconfig:14` pass to xcrun metal.
+        # Several upstream kernels (steel_attention.h, integral_constant.h)
+        # use `if constexpr` and other post-C++14 features that compile
+        # cleanly under -std=metal3.1 but trigger -Wc++17-extensions /
+        # -Wc++20-extensions diagnostics without these silencers. Upstream
+        # treats them as intentional noise — we match.
         xcrun metal \
             -std=metal3.1 \
             -O2 \
+            -Wno-c++17-extensions \
+            -Wno-c++20-extensions \
             -I "$METAL_SRC_DIR" \
             -I "$MLX_KERNEL_INC" \
             -c "$metal_file" \


### PR DESCRIPTION
Adds `-Wno-c++17-extensions` and `-Wno-c++20-extensions` to `xcrun metal` in `scripts/build-metallib.sh`, matching the flags both upstream paths already pass:

| Source | Where |
|---|---|
| `mlx/mlx/backend/metal/kernels/CMakeLists.txt` | Lines 19-20 |
| `mlx-swift/xcode/xcconfig/Cmlx.xcconfig` | Line 14 |

Our SPM build was the only path missing them.

## What this fixes

Several upstream kernels (`steel_attention.h`, `integral_constant.h`, `steel/utils/*`) use `if constexpr` and similar post-C++14 features that compile cleanly under `-std=metal3.1` but trigger four `-Wc++17-extensions` diagnostics without the silencers. Upstream treats them as accepted noise — this brings our build path into line.

## Before / after

```
$ make clean-metal && make 2>&1 | grep -E "warning:.*metal" | wc -l
# Before: 5
# After:  1
```

The remaining one (`unused variable 'bits'` in `rms_norm_qgemv.metal`) is a real source issue, fixed in [`ekryski/mlx#27`](https://github.com/ekryski/mlx/pull/27). Once that lands and the submodule mirrors update, this build path will be fully warning-free.

## Verification

- `make clean-metal && make` — clean build
- `swift test --skip-build -c release --skip Benchmarks` — 202 tests pass