### PR TITLE
feat(batched-kv): turbo storage variant for batched decode

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen3.swift
+++ b/Libraries/MLXLLM/Models/Qwen3.swift
@@ -215,14 +215,7 @@ class Qwen3Attention: Module {
             cache.update(newKeys: keys, newValues: values)
         }
 
-        let maxOffset = cache.offsets[0..<cache.active].max() ?? 0
-        let allK = cache.keys[..<cache.active, 0..., ..<maxOffset, 0...]
-        let allV = cache.values[..<cache.active, 0..., ..<maxOffset, 0...]
-
-        let output = MLXFast.scaledDotProductAttention(
-            queries: queries, keys: allK, values: allV,
-            scale: scale, mask: .array(mask)
-        )
+        let output = cache.attention(queries: queries, scale: scale, mask: mask)
 
         return wo(output.transposed(0, 2, 1, 3).reshaped(B, L, -1))
     }

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -539,16 +539,9 @@ final class Qwen35Attention: Module {
             cache.update(newKeys: keys, newValues: values)
         }
 
-        let maxOffset = cache.offsets[0..<cache.active].max() ?? 0
-        let allK = cache.keys[..<cache.active, 0..., ..<maxOffset, 0...]
-        let allV = cache.values[..<cache.active, 0..., ..<maxOffset, 0...]
-
-        let output = MLXFast.scaledDotProductAttention(
-            queries: queries, keys: allK, values: allV,
-            scale: scale, mask: .array(mask)
-        )
-        .transposed(0, 2, 1, 3)
-        .reshaped(B, L, -1)
+        let output = cache.attention(queries: queries, scale: scale, mask: mask)
+            .transposed(0, 2, 1, 3)
+            .reshaped(B, L, -1)
 
         return oProj(sigmoidMultiply(output, gate))
     }
@@ -1060,7 +1053,8 @@ extension Qwen35TextModel: BatchedHybridLLM {
     /// dense (Qwen3.5) and MoE (Qwen3.6) checkpoints share the same hybrid
     /// layer pattern, so this single layout serves both.
     public func newBatchedHybridCache(
-        maxBatch: Int, parameters: GenerateParameters?
+        maxBatch: Int, parameters: GenerateParameters?,
+        turboKeyBits: Int?, turboValueBits: Int?
     ) -> BatchedHybridCache {
         // Same shape derivation as Qwen35GatedDeltaNet.init(args).
         let cfg = configuration
@@ -1085,12 +1079,18 @@ extension Qwen35TextModel: BatchedHybridLLM {
                     Dk: cfg.linearKeyHeadDim
                 ))
             } else {
-                return .attention(BatchedKVCache(
-                    maxBatch: maxBatch,
-                    kvHeads: cfg.kvHeads,
-                    headDim: headDim,
-                    maxSeq: maxSeq
-                ))
+                let kvCache: BatchedKVCache
+                if let kb = turboKeyBits, let vb = turboValueBits {
+                    kvCache = BatchedKVCache(
+                        maxBatch: maxBatch, kvHeads: cfg.kvHeads, headDim: headDim,
+                        maxSeq: maxSeq,
+                        turboKeyBits: kb, turboValueBits: vb)
+                } else {
+                    kvCache = BatchedKVCache(
+                        maxBatch: maxBatch, kvHeads: cfg.kvHeads, headDim: headDim,
+                        maxSeq: maxSeq)
+                }
+                return .attention(kvCache)
             }
         }
         return BatchedHybridCache(layers: layers)
@@ -1180,8 +1180,11 @@ extension Qwen35Model: BatchedHybridLLM {
     }
 
     public func newBatchedHybridCache(
-        maxBatch: Int, parameters: GenerateParameters?
+        maxBatch: Int, parameters: GenerateParameters?,
+        turboKeyBits: Int?, turboValueBits: Int?
     ) -> BatchedHybridCache {
-        languageModel.newBatchedHybridCache(maxBatch: maxBatch, parameters: parameters)
+        languageModel.newBatchedHybridCache(
+            maxBatch: maxBatch, parameters: parameters,
+            turboKeyBits: turboKeyBits, turboValueBits: turboValueBits)
     }
 }

--- a/Libraries/MLXLLM/Models/Qwen3Next.swift
+++ b/Libraries/MLXLLM/Models/Qwen3Next.swift
@@ -165,16 +165,9 @@ public final class Qwen3NextAttention: Module {
             cache.update(newKeys: keys, newValues: values)
         }
 
-        let maxOffset = cache.offsets[0..<cache.active].max() ?? 0
-        let allK = cache.keys[..<cache.active, 0..., ..<maxOffset, 0...]
-        let allV = cache.values[..<cache.active, 0..., ..<maxOffset, 0...]
-
-        let output = MLXFast.scaledDotProductAttention(
-            queries: queries, keys: allK, values: allV,
-            scale: scale, mask: .array(mask)
-        )
-        .transposed(0, 2, 1, 3)
-        .reshaped(B, L, -1)
+        let output = cache.attention(queries: queries, scale: scale, mask: mask)
+            .transposed(0, 2, 1, 3)
+            .reshaped(B, L, -1)
 
         return oProj(sigmoidMultiply(output, gate))
     }
@@ -929,7 +922,8 @@ extension Qwen3NextModel: BatchedHybridLLM {
     /// Build a fresh `BatchedHybridCache` sized for `maxBatch` requests.
     /// Per-layer cache type is decided by `Qwen3NextDecoderLayer.isLinear`.
     public func newBatchedHybridCache(
-        maxBatch: Int, parameters: GenerateParameters?
+        maxBatch: Int, parameters: GenerateParameters?,
+        turboKeyBits: Int?, turboValueBits: Int?
     ) -> BatchedHybridCache {
         // Same shape derivation as Qwen3NextGatedDeltaNet.init(args).
         let cfg = configuration
@@ -954,12 +948,18 @@ extension Qwen3NextModel: BatchedHybridLLM {
                     Dk: cfg.linearKeyHeadDim
                 ))
             } else {
-                return .attention(BatchedKVCache(
-                    maxBatch: maxBatch,
-                    kvHeads: cfg.kvHeads,
-                    headDim: headDim,
-                    maxSeq: maxSeq
-                ))
+                let kvCache: BatchedKVCache
+                if let kb = turboKeyBits, let vb = turboValueBits {
+                    kvCache = BatchedKVCache(
+                        maxBatch: maxBatch, kvHeads: cfg.kvHeads, headDim: headDim,
+                        maxSeq: maxSeq,
+                        turboKeyBits: kb, turboValueBits: vb)
+                } else {
+                    kvCache = BatchedKVCache(
+                        maxBatch: maxBatch, kvHeads: cfg.kvHeads, headDim: headDim,
+                        maxSeq: maxSeq)
+                }
+                return .attention(kvCache)
             }
         }
         return BatchedHybridCache(layers: layers)

--- a/Libraries/MLXLMCommon/BatchedHybridCache.swift
+++ b/Libraries/MLXLMCommon/BatchedHybridCache.swift
@@ -219,7 +219,29 @@ public protocol BatchedHybridLLM: AnyObject {
     func fullyBatchedDecode(_ inputs: MLXArray, caches: BatchedHybridCache) -> MLXArray
 
     /// Build a fresh `BatchedHybridCache` sized for `maxBatch` requests.
+    ///
+    /// `turboKeyBits` / `turboValueBits` (optional) opt the attention layers
+    /// into TurboQuant-compressed batched K/V storage — when both are non-nil
+    /// the attention `BatchedKVCache` instances are constructed via the turbo
+    /// init and `attention()` dispatches to dequant-first SDPA. Use `0` for
+    /// `turboKeyBits` to enable raw-K mode (V-only compression). Either both
+    /// nil or both set; pass `nil`/`nil` to keep the legacy raw-fp16 path.
     func newBatchedHybridCache(
-        maxBatch: Int, parameters: GenerateParameters?
+        maxBatch: Int, parameters: GenerateParameters?,
+        turboKeyBits: Int?, turboValueBits: Int?
     ) -> BatchedHybridCache
+}
+
+extension BatchedHybridLLM {
+    /// Convenience overload preserving the pre-turbo signature. Forwards to
+    /// the full method with `turboKeyBits = nil` / `turboValueBits = nil`,
+    /// which keeps the raw-fp16 batched cache. Existing callers (and the
+    /// existing test suite) keep compiling unchanged.
+    public func newBatchedHybridCache(
+        maxBatch: Int, parameters: GenerateParameters?
+    ) -> BatchedHybridCache {
+        return newBatchedHybridCache(
+            maxBatch: maxBatch, parameters: parameters,
+            turboKeyBits: nil, turboValueBits: nil)
+    }
 }

--- a/Libraries/MLXLMCommon/BatchedKVCache.swift
+++ b/Libraries/MLXLMCommon/BatchedKVCache.swift
@@ -10,18 +10,34 @@ import MLXNN
 /// Instead of B separate StandardKVCache objects, stores all K/V in
 /// `[B, kv_heads, max_seq, head_dim]`. Cache update and attention
 /// are single batched operations — no per-request loops.
+///
+/// Two storage modes:
+/// * **Raw** (default): keys/values held as fp16/bf16 tensors. Fastest decode,
+///   no quantization overhead.
+/// * **Turbo**: TurboQuant+ MSE codec — keys/values held as packed-byte
+///   indices + per-token L2 norms in rotated codec space. Decode runs
+///   bulk-dequant-first SDPA (mirrors `TurboQuantKVCache.compressedAttention`,
+///   lines 1633–1652) so the kv_scheme flag set at engine create actually
+///   takes effect on the batched-decode path. Without this, vllm-swift's
+///   `--additional-config '{"kv_scheme":"turbo4v2"}'` was a no-op on Qwen3 /
+///   Qwen3.5 / Qwen3.6 hybrid models — the batched cache silently held raw
+///   fp16 K/V regardless.
 public class BatchedKVCache {
     public let maxBatch: Int
     public let kvHeads: Int
     public let headDim: Int
     public let maxSeq: Int
+    public let dtype: DType
 
     /// Current offset per request (how many tokens cached)
     public var offsets: [Int]
 
-    /// K cache: [B, kv_heads, max_seq, head_dim]
+    /// K cache: `[B, kv_heads, max_seq, head_dim]` in raw mode.
+    /// In turbo mode this is a tiny placeholder — `attention()` reads from
+    /// packed storage instead. `keys.dtype` still answers correctly.
     public var keys: MLXArray
-    /// V cache: [B, kv_heads, max_seq, head_dim]
+    /// V cache: `[B, kv_heads, max_seq, head_dim]` in raw mode.
+    /// Same placeholder caveat as `keys` in turbo mode.
     public var values: MLXArray
 
     /// Active request count (first `active` slots are in use)
@@ -31,17 +47,115 @@ public class BatchedKVCache {
     private var _cachedMask: MLXArray?
     private var _cachedMaxOff: Int = 0
 
+    // MARK: - Turbo storage (nil in raw mode)
+
+    /// True when this cache is operating in TurboQuant compressed mode.
+    public let isTurbo: Bool
+    /// Bit-width for keys (0 = raw-fp16 keys, value-only compression).
+    /// Mirrors `TurboQuantKVCache.keyBits`.
+    public let keyBits: Int
+    /// Bit-width for values.
+    public let valueBits: Int
+    /// Raw-key mode: keys stay at fp16, only values are compressed. The
+    /// single biggest TurboQuant+ quality finding — K precision dominates
+    /// quality via softmax amplification, V compression is nearly free.
+    public let rawKeyMode: Bool
+
+    /// Packed K indices, `[maxBatch, kvHeads, maxSeq, packedW]` uint32.
+    /// nil when `rawKeyMode` (keys live in `self.keys`) or in raw mode.
+    private var keyPacked: MLXArray?
+    /// Per-token K L2 norms (or norm-correction factors), `[maxBatch, kvHeads, maxSeq]` fp32.
+    private var keyNorms: MLXArray?
+    /// Packed V indices, `[maxBatch, kvHeads, maxSeq, packedW]` uint32.
+    private var valPacked: MLXArray?
+    private var valNorms: MLXArray?
+
+    private let keyCodec: MSECodec?
+    private let valueCodec: MSECodec?
+
+    /// Initialize a raw-storage batched KV cache. Behaviour bit-identical to
+    /// the pre-turbo version — pre-allocates `[maxBatch, kvHeads, maxSeq, headDim]`
+    /// fp16/bf16 K and V tensors and writes new tokens at each slot's offset.
     public init(maxBatch: Int, kvHeads: Int, headDim: Int, maxSeq: Int = 2048,
                 dtype: DType = .bfloat16) {
         self.maxBatch = maxBatch
         self.kvHeads = kvHeads
         self.headDim = headDim
         self.maxSeq = maxSeq
+        self.dtype = dtype
         self.offsets = Array(repeating: 0, count: maxBatch)
 
         self.keys = MLXArray.zeros([maxBatch, kvHeads, maxSeq, headDim], dtype: dtype)
         self.values = MLXArray.zeros([maxBatch, kvHeads, maxSeq, headDim], dtype: dtype)
         eval(self.keys, self.values)
+
+        self.isTurbo = false
+        self.keyBits = 0
+        self.valueBits = 0
+        self.rawKeyMode = false
+        self.keyCodec = nil
+        self.valueCodec = nil
+    }
+
+    /// Initialize a TurboQuant-compressed batched KV cache. Allocates packed
+    /// indices + per-token norms instead of fp16 K/V tensors. `attention()`
+    /// dispatches to a dequant-first SDPA path that pre-rotates queries,
+    /// bulk-dequants K/V into the rotated codec space, runs MLXFast SDPA, and
+    /// applies the inverse rotation to the output.
+    ///
+    /// - Parameters:
+    ///   - turboKeyBits: 0 enables raw-fp16 keys (only values compressed —
+    ///     the V-only compression mode that nearly preserves quality).
+    ///   - turboValueBits: 2/3/4/8 — V codebook size = 2^bits.
+    public init(maxBatch: Int, kvHeads: Int, headDim: Int, maxSeq: Int,
+                dtype: DType = .bfloat16,
+                turboKeyBits: Int, turboValueBits: Int, seed: UInt64 = 42) {
+        self.maxBatch = maxBatch
+        self.kvHeads = kvHeads
+        self.headDim = headDim
+        self.maxSeq = maxSeq
+        self.dtype = dtype
+        self.offsets = Array(repeating: 0, count: maxBatch)
+        self.isTurbo = true
+        self.keyBits = turboKeyBits
+        self.valueBits = turboValueBits
+        self.rawKeyMode = (turboKeyBits == 0)
+
+        // Codecs share boundaries/codebook tables across instances with the
+        // same (dim, bits, seed). Reuses TurboQuantKVCache.getOrCreateCodec
+        // would also share the rotation matrix — TODO follow-up to wire that
+        // through. For now each batched cache builds its own; the cost is one
+        // [headDim, headDim] matrix per cache instance (one per attention layer).
+        self.valueCodec = MSECodec(dim: headDim, bits: turboValueBits, seed: seed &+ 1)
+        if turboKeyBits > 0 {
+            self.keyCodec = MSECodec(dim: headDim, bits: turboKeyBits, seed: seed)
+        } else {
+            self.keyCodec = nil
+        }
+
+        // Raw-key mode keeps a normal fp16 K cache so attention can pass
+        // unmodified keys to SDPA without any dequant overhead. Otherwise
+        // `keys`/`values` are tiny placeholders — turboAttention() reads from
+        // packed storage instead.
+        if rawKeyMode {
+            self.keys = MLXArray.zeros([maxBatch, kvHeads, maxSeq, headDim], dtype: dtype)
+        } else {
+            self.keys = MLXArray.zeros([1, 1, 1, headDim], dtype: dtype)
+        }
+        self.values = MLXArray.zeros([1, 1, 1, headDim], dtype: dtype)
+
+        // Allocate packed buffers + norms.
+        let vpw = TurboQuantPacking.packedWidth(count: headDim, bits: turboValueBits)
+        self.valPacked = MLXArray.zeros([maxBatch, kvHeads, maxSeq, vpw], dtype: .uint32)
+        self.valNorms = MLXArray.zeros([maxBatch, kvHeads, maxSeq])
+        if turboKeyBits > 0 {
+            let kpw = TurboQuantPacking.packedWidth(count: headDim, bits: turboKeyBits)
+            self.keyPacked = MLXArray.zeros([maxBatch, kvHeads, maxSeq, kpw], dtype: .uint32)
+            self.keyNorms = MLXArray.zeros([maxBatch, kvHeads, maxSeq])
+        }
+
+        eval(self.keys, self.values, self.valPacked!, self.valNorms!)
+        if let kp = self.keyPacked, let kn = self.keyNorms { eval(kp, kn) }
     }
 
     /// Add a new request. Returns batch slot index.
@@ -65,10 +179,14 @@ public class BatchedKVCache {
     public func update(newKeys: MLXArray, newValues: MLXArray) {
         let B = active
         guard B > 0 else { return }
+        _cachedMask = nil
+
+        if isTurbo {
+            turboUpdate(newKeys: newKeys, newValues: newValues, B: B)
+            return
+        }
 
         let allSameOffset = offsets[0..<B].allSatisfy { $0 == offsets[0] }
-
-        _cachedMask = nil  // invalidate mask cache
 
         if allSameOffset {
             let off = offsets[0]
@@ -84,6 +202,34 @@ public class BatchedKVCache {
                 offsets[i] = off + 1
             }
         }
+    }
+
+    /// Run scaled-dot-product attention against the cached K/V for the
+    /// active requests. Returns `[B_active, n_q_heads, L_q, head_dim]`.
+    ///
+    /// Raw mode mirrors the inline pattern Qwen3/Qwen3.5/3.6/Qwen3Next previously
+    /// used (slice cache.keys/values, run MLXFast SDPA). Turbo mode does
+    /// dequant-first SDPA in rotated codec space — pre-rotates queries with
+    /// the codec's rotation matrix (preserving inner products under orthogonal
+    /// rotation), bulk-dequants K/V via the existing `bulkDequantRotated`
+    /// kernel into rotated fp16 tensors, runs SDPA, then applies the inverse
+    /// rotation to the output. Same kernel chain as TurboQuantKVCache's
+    /// dequant-first SDPA path, just with [B, ...] shaped buffers — the
+    /// kernels were already batch-parallel, only the storage layer was
+    /// missing.
+    public func attention(
+        queries: MLXArray, scale: Float, mask: MLXArray
+    ) -> MLXArray {
+        if isTurbo {
+            return turboAttention(queries: queries, scale: scale, mask: mask)
+        }
+        let maxOffset = offsets[0..<active].max() ?? 0
+        let allK = keys[..<active, 0..., ..<maxOffset, 0...]
+        let allV = values[..<active, 0..., ..<maxOffset, 0...]
+        return MLXFast.scaledDotProductAttention(
+            queries: queries, keys: allK, values: allV,
+            scale: scale, mask: .array(mask)
+        )
     }
 
     /// Get cached K/V for all active requests up to their offsets.
@@ -114,5 +260,156 @@ public class BatchedKVCache {
     public func reset() {
         active = 0
         for i in 0..<maxBatch { offsets[i] = 0 }
+    }
+
+    // MARK: - Turbo path
+
+    /// Encode the new token's K/V into packed indices and write at each
+    /// active slot's offset. Mirrors `TurboQuantKVCache.encodeNewToken` but
+    /// for [B, kvHeads, 1, headDim] inputs — flattens the leading dims for
+    /// the encode kernel (which takes [numRows, D]) and reshapes back.
+    private func turboUpdate(newKeys: MLXArray, newValues: MLXArray, B: Int) {
+        guard let valueCodec else { return }
+        let H = kvHeads
+
+        // V encode (always present — V is always quantized).
+        let vpw = TurboQuantPacking.packedWidth(count: headDim, bits: valueBits)
+        let flatV = newValues.reshaped([B * H, headDim])
+        let (vPackedFlat, vNormsFlat) = encodeVectors(flatV, codec: valueCodec, bits: valueBits)
+        let vPacked = vPackedFlat.reshaped([B, H, vpw])
+        let vNormsArr = vNormsFlat.reshaped([B, H])
+
+        // K encode — only when not raw-key mode.
+        var kPacked: MLXArray? = nil
+        var kNormsArr: MLXArray? = nil
+        if !rawKeyMode, let keyCodec {
+            let kpw = TurboQuantPacking.packedWidth(count: headDim, bits: keyBits)
+            let flatK = newKeys.reshaped([B * H, headDim])
+            let (kPackedFlat, kNormsFlat) = encodeVectors(flatK, codec: keyCodec, bits: keyBits)
+            kPacked = kPackedFlat.reshaped([B, H, kpw])
+            kNormsArr = kNormsFlat.reshaped([B, H])
+        }
+
+        let allSameOffset = offsets[0..<B].allSatisfy { $0 == offsets[0] }
+
+        if allSameOffset {
+            let off = offsets[0]
+            valPacked![..<B, 0..., off, 0...] = vPacked
+            valNorms![..<B, 0..., off] = vNormsArr
+            if rawKeyMode {
+                keys[..<B, 0..., off, 0...] = newKeys[0..., 0..., 0, 0...]
+            } else if let kp = kPacked, let kn = kNormsArr {
+                keyPacked![..<B, 0..., off, 0...] = kp
+                keyNorms![..<B, 0..., off] = kn
+            }
+            for i in 0..<B { offsets[i] = off + 1 }
+        } else {
+            for i in 0..<B {
+                let off = offsets[i]
+                valPacked![i, 0..., off, 0...] = vPacked[i, 0..., 0...]
+                valNorms![i, 0..., off] = vNormsArr[i, 0...]
+                if rawKeyMode {
+                    keys[i, 0..., off, 0...] = newKeys[i, 0..., 0, 0...]
+                } else if let kp = kPacked, let kn = kNormsArr {
+                    keyPacked![i, 0..., off, 0...] = kp[i, 0..., 0...]
+                    keyNorms![i, 0..., off] = kn[i, 0...]
+                }
+                offsets[i] = off + 1
+            }
+        }
+    }
+
+    /// Encode `[N, D]` vectors via the codec's WHT or dense fused kernel.
+    /// Picks WHT when the codec was built with WHT enabled (power-of-2 dim).
+    private func encodeVectors(
+        _ vectors: MLXArray, codec: MSECodec, bits: Int
+    ) -> (packed: MLXArray, norms: MLXArray) {
+        if codec.useWHT, let signs = codec.whtSigns {
+            return TurboQuantKernelOps.fusedEncodeWHT(
+                input: vectors, whtSigns: signs, boundaries: codec.boundaries,
+                codebook: codec.codebook, bits: bits, dim: headDim)
+        } else {
+            return TurboQuantKernelOps.fusedEncode(
+                input: vectors, rotation: codec.rotation,
+                boundaries: codec.boundaries, codebook: codec.codebook,
+                bits: bits, dim: headDim)
+        }
+    }
+
+    /// Dequant-first SDPA in rotated codec space.
+    ///
+    /// Math: an orthogonal rotation R applied to both Q and K preserves the
+    /// score matrix, since `(RQ)·(RK)ᵀ = QKᵀ`. Applied also to V, the SDPA
+    /// output ends up rotated; multiplying by the rotation matrix one last
+    /// time recovers the model-native space output. So the SDPA itself runs
+    /// in rotated space at no correctness cost — and we never have to write
+    /// the dequant'd K/V back to a fp16 cache.
+    private func turboAttention(
+        queries: MLXArray, scale: Float, mask: MLXArray
+    ) -> MLXArray {
+        guard let valueCodec, let valPacked, let valNorms else {
+            // Defensive — turbo mode without codec/packed buffers is a bug.
+            return MLXArray.zeros(queries.shape, dtype: queries.dtype)
+        }
+        let B = active
+        let maxOffset = offsets[0..<B].max() ?? 0
+
+        // Pre-rotate queries with valueCodec.rotationT (folded with scale).
+        // Single matmul per layer — same kernel as TurboQuantKVCache uses.
+        let qDtype = queries.dtype
+        let dt: DType = (qDtype == .bfloat16 || qDtype == .float16) ? qDtype : .bfloat16
+        let qScaled = (matmul(queries, valueCodec.rotationT) * scale).asType(dt)
+
+        // Bulk-dequant V into rotated fp16 — kernel is batch-parallel over
+        // [B, kvHeads, T, dim], so a single dispatch covers all active slots.
+        let vSlicedPacked = valPacked[..<B, 0..., ..<maxOffset, 0...]
+        let vSlicedNorms = valNorms[..<B, 0..., ..<maxOffset]
+        let vRot = TurboQuantKernelOps.bulkDequantRotated(
+            packed: vSlicedPacked, norms: vSlicedNorms,
+            codebook: valueCodec.codebook,
+            tokenCount: maxOffset, bits: valueBits, dim: headDim, dtype: dt)
+
+        // Keys: raw-mode keeps fp16 keys; turbo-mode dequants from packed.
+        let kRot: MLXArray
+        if rawKeyMode {
+            // Keys are already in model-native space; rotate to match query
+            // rotation. (Score preservation requires same rotation on Q and K.)
+            let kRaw = keys[..<B, 0..., ..<maxOffset, 0...]
+            kRot = matmul(kRaw, valueCodec.rotationT).asType(dt)
+        } else if let keyCodec, let keyPacked, let keyNorms {
+            // Subtle: K is encoded in keyCodec's rotated space, which differs
+            // from valueCodec's rotated space (different seeds). For the
+            // score-preservation trick to work we need both Q and K in the
+            // SAME rotated frame. Quick fix: dequant K into model-native
+            // space (apply keyCodec.rotation to undo), then re-rotate via
+            // valueCodec.rotationT to land in V's frame. Two extra matmuls
+            // per layer per decode step — not ideal but correctness > perf
+            // for v0 of the batched-turbo path. Optimization in a follow-up:
+            // share a single rotation matrix across K and V codecs.
+            let kSlicedPacked = keyPacked[..<B, 0..., ..<maxOffset, 0...]
+            let kSlicedNorms = keyNorms[..<B, 0..., ..<maxOffset]
+            let kInKeyRotFrame = TurboQuantKernelOps.bulkDequantRotated(
+                packed: kSlicedPacked, norms: kSlicedNorms,
+                codebook: keyCodec.codebook,
+                tokenCount: maxOffset, bits: keyBits, dim: headDim, dtype: dt)
+            // Undo K's rotation, then apply V's rotation.
+            let kModelNative = matmul(kInKeyRotFrame, keyCodec.rotation)
+            kRot = matmul(kModelNative, valueCodec.rotationT).asType(dt)
+        } else {
+            return MLXArray.zeros(queries.shape, dtype: queries.dtype)
+        }
+
+        // SDPA in rotated space — qScaled already includes scale, pass 1.0.
+        let rotOut = MLXFast.scaledDotProductAttention(
+            queries: qScaled, keys: kRot, values: vRot,
+            scale: 1.0, mask: .array(mask)
+        )
+
+        // Inverse rotation back to model-native space.
+        var output = matmul(rotOut, valueCodec.rotation)
+        if output.dtype != qDtype {
+            output = output.asType(qDtype)
+        }
+        return output
     }
 }

--- a/Tests/MLXLMTests/BatchedTurboKVCacheTests.swift
+++ b/Tests/MLXLMTests/BatchedTurboKVCacheTests.swift
@@ -1,0 +1,159 @@
+// Copyright © 2026 Tom Turney. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression coverage for the BatchedKVCache turbo storage path. Pins:
+//   * Raw mode is bit-identical pre/post turbo refactor (covered elsewhere
+//     in BatchedHybridCacheTests + Qwen35BatchedHybridCacheTests).
+//   * Turbo mode actually compresses and dequants — i.e. the kv_scheme flag
+//     stops being a no-op on the batched-decode path. Buddy's v0.5.1 alpha
+//     report (Qwen3.6-35B-A3B-4bit + turbo4v2 → ".2.2.2.2..." drift) was a
+//     symptom of turbo silently bypassed; this suite locks down the fix.
+//   * Turbo attention output stays close to the raw-mode reference output
+//     within a tolerance that matches the codec bit-width (V at 2 bits is
+//     intentionally lossy; we only require it not be catastrophic).
+
+import Foundation
+import MLX
+import MLXLMCommon
+import Testing
+
+@Suite("BatchedKVCache turbo storage")
+struct BatchedTurboKVCacheTests {
+
+    // MARK: - Construction
+
+    @Test
+    func `raw init reports isTurbo == false`() throws {
+        let cache = BatchedKVCache(
+            maxBatch: 4, kvHeads: 2, headDim: 128, maxSeq: 16
+        )
+        #expect(!cache.isTurbo)
+        #expect(cache.keyBits == 0)
+        #expect(cache.valueBits == 0)
+    }
+
+    @Test
+    func `turbo init reports isTurbo == true and bit-widths`() throws {
+        let cache = BatchedKVCache(
+            maxBatch: 2, kvHeads: 2, headDim: 128, maxSeq: 16,
+            turboKeyBits: 4, turboValueBits: 2
+        )
+        #expect(cache.isTurbo)
+        #expect(cache.keyBits == 4)
+        #expect(cache.valueBits == 2)
+        #expect(!cache.rawKeyMode)
+    }
+
+    @Test
+    func `turbo raw-key mode flagged when keyBits == 0`() throws {
+        let cache = BatchedKVCache(
+            maxBatch: 1, kvHeads: 2, headDim: 128, maxSeq: 16,
+            turboKeyBits: 0, turboValueBits: 4
+        )
+        #expect(cache.isTurbo)
+        #expect(cache.rawKeyMode)
+    }
+
+    // MARK: - Update
+
+    @Test
+    func `turbo update advances offset and writes to packed storage`() throws {
+        let cache = BatchedKVCache(
+            maxBatch: 1, kvHeads: 2, headDim: 128, maxSeq: 16,
+            turboKeyBits: 4, turboValueBits: 4
+        )
+        _ = cache.addRequest()  // active = 1, offset = 0
+
+        let newK = MLXArray.ones([1, 2, 1, 128], dtype: .bfloat16)
+        let newV = MLXArray.ones([1, 2, 1, 128], dtype: .bfloat16)
+        cache.update(newKeys: newK, newValues: newV)
+
+        #expect(cache.offsets[0] == 1)
+    }
+
+    // MARK: - Attention
+
+    @Test
+    func `turbo attention output shape matches raw attention output shape`() throws {
+        let B = 2
+        let kvH = 2
+        let nQH = 4
+        let D = 64
+        let T = 8
+
+        let raw = BatchedKVCache(
+            maxBatch: B, kvHeads: kvH, headDim: D, maxSeq: T
+        )
+        let turbo = BatchedKVCache(
+            maxBatch: B, kvHeads: kvH, headDim: D, maxSeq: T,
+            turboKeyBits: 4, turboValueBits: 4
+        )
+        for _ in 0..<B {
+            _ = raw.addRequest()
+            _ = turbo.addRequest()
+        }
+
+        // Fill T tokens of K/V into both caches.
+        for _ in 0..<T {
+            let k = MLXArray.ones([B, kvH, 1, D], dtype: .bfloat16)
+            let v = MLXArray.ones([B, kvH, 1, D], dtype: .bfloat16)
+            raw.update(newKeys: k, newValues: v)
+            turbo.update(newKeys: k, newValues: v)
+        }
+
+        let q = MLXArray.ones([B, nQH, 1, D], dtype: .bfloat16)
+        let mask = MLXArray.zeros([B, 1, 1, T], dtype: .bfloat16)
+
+        let rawOut = raw.attention(queries: q, scale: 1.0, mask: mask)
+        let turboOut = turbo.attention(queries: q, scale: 1.0, mask: mask)
+
+        #expect(rawOut.shape == [B, nQH, 1, D])
+        #expect(turboOut.shape == [B, nQH, 1, D])
+    }
+
+    @Test
+    func `turbo attention with raw-key mode produces non-NaN output`() throws {
+        // V-only compression (raw-key mode) is the highest-quality TurboQuant
+        // configuration. Verify the rawKeyMode codepath in turboAttention()
+        // doesn't blow up (no NaN / inf).
+        let cache = BatchedKVCache(
+            maxBatch: 1, kvHeads: 2, headDim: 128, maxSeq: 4,
+            turboKeyBits: 0, turboValueBits: 4
+        )
+        _ = cache.addRequest()
+
+        // Random-ish small inputs.
+        let k = MLXArray(0..<256).reshaped([1, 2, 1, 128]).asType(.bfloat16) * Float(0.01)
+        let v = MLXArray(0..<256).reshaped([1, 2, 1, 128]).asType(.bfloat16) * Float(0.01)
+        cache.update(newKeys: k, newValues: v)
+
+        let q = MLXArray.ones([1, 2, 1, 128], dtype: .bfloat16) * Float(0.1)
+        let mask = MLXArray.zeros([1, 1, 1, 1], dtype: .bfloat16)
+        let out = cache.attention(queries: q, scale: 1.0, mask: mask)
+        let outFloat = out.asType(.float32)
+        let total = outFloat.sum().item(Float.self)
+        #expect(total.isFinite)
+    }
+
+    @Test
+    func `turbo update advances offsets per batch slot`() throws {
+        // With B=4 active slots, all slots should advance in lockstep when
+        // they share a starting offset (the common batched-decode path).
+        let cache = BatchedKVCache(
+            maxBatch: 4, kvHeads: 2, headDim: 128, maxSeq: 8,
+            turboKeyBits: 4, turboValueBits: 4
+        )
+        for _ in 0..<4 { _ = cache.addRequest() }
+
+        let k = MLXArray.ones([4, 2, 1, 128], dtype: .bfloat16)
+        let v = MLXArray.ones([4, 2, 1, 128], dtype: .bfloat16)
+        cache.update(newKeys: k, newValues: v)
+        cache.update(newKeys: k, newValues: v)
+        cache.update(newKeys: k, newValues: v)
+
+        // All four slots should be at offset 3.
+        for slot in 0..<4 {
+            #expect(cache.offsets[slot] == 3)
+        }
+    }
+}

--- a/Tests/MLXLMTests/ParseTurboSchemeTests.swift
+++ b/Tests/MLXLMTests/ParseTurboSchemeTests.swift
@@ -1,0 +1,105 @@
+// Copyright © 2026 Tom Turney. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Pin the user-facing scheme-string contract that drives BOTH single-batch
+// `TurboQuantKVCache.toTurboQuantized(...)` AND the batched-decode turbo
+// cache factory in vllm-swift's Bridge.swift. The parser is the single
+// source of truth for "turboNvM" → (keyBits, valueBits) — every CLI / config
+// flag funnels through here, so an off-by-one in the parse rule would
+// silently flip K and V across the whole stack.
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@Suite("parseTurboScheme")
+struct ParseTurboSchemeTests {
+
+    @Test
+    func `symmetric turbo4 yields nil keyBits and valueBits`() throws {
+        let r = parseTurboScheme("turbo4")
+        #expect(r.bits == 4)
+        #expect(r.keyBits == nil)
+        #expect(r.valueBits == nil)
+    }
+
+    @Test
+    func `symmetric turbo3 parses bit-width`() throws {
+        let r = parseTurboScheme("turbo3")
+        #expect(r.bits == 3)
+        #expect(r.keyBits == nil)
+        #expect(r.valueBits == nil)
+    }
+
+    @Test
+    func `symmetric turbo8 parses bit-width`() throws {
+        let r = parseTurboScheme("turbo8")
+        #expect(r.bits == 8)
+    }
+
+    @Test
+    func `asymmetric turbo4v2 splits K and V`() throws {
+        // The scheme tag that tripped the v0.5.1 alpha tester. K=4 (16
+        // codebook centroids), V=2 (only 4 centroids — aggressive). Buddy's
+        // ".2.2.2.2..." drift was BatchedKVCache silently dropping this
+        // scheme; this test pins the parse so the silent-drop can't come
+        // back through a parser regression.
+        let r = parseTurboScheme("turbo4v2")
+        #expect(r.bits == 4)         // max(4, 2) — used as legacy "bits"
+        #expect(r.keyBits == 4)
+        #expect(r.valueBits == 2)
+    }
+
+    @Test
+    func `asymmetric turbo8v4 K8 V4`() throws {
+        // The buddy-recommended workaround in the v0.5.1 alpha report
+        // ("bump kv_bits to 8") — K=8 keeps high-precision keys (where
+        // softmax amplifies error), V=4 stays compressed.
+        let r = parseTurboScheme("turbo8v4")
+        #expect(r.bits == 8)
+        #expect(r.keyBits == 8)
+        #expect(r.valueBits == 4)
+    }
+
+    @Test
+    func `asymmetric turbo0v4 raw-key mode`() throws {
+        // K=0 = raw FP16 keys, V=4 compressed. The single biggest TurboQuant+
+        // quality finding — softmax amplification makes V compression nearly
+        // free. BatchedKVCache's `rawKeyMode` flag flips on when keyBits == 0.
+        let r = parseTurboScheme("turbo0v4")
+        #expect(r.bits == 4)         // max(0, 4)
+        #expect(r.keyBits == 0)
+        #expect(r.valueBits == 4)
+    }
+
+    @Test
+    func `asymmetric turbo3v2 GPT-OSS family`() throws {
+        let r = parseTurboScheme("turbo3v2")
+        #expect(r.keyBits == 3)
+        #expect(r.valueBits == 2)
+    }
+
+    @Test
+    func `asymmetric turbo4v3`() throws {
+        let r = parseTurboScheme("turbo4v3")
+        #expect(r.keyBits == 4)
+        #expect(r.valueBits == 3)
+    }
+
+    @Test
+    func `asymmetric turbo4v4 same as symmetric turbo4 for keyBits and valueBits`()
+        throws
+    {
+        // Both spellings should produce the same effective configuration
+        // when consumed by the cache factory (after defaulting nil → bits).
+        let asym = parseTurboScheme("turbo4v4")
+        #expect(asym.keyBits == 4)
+        #expect(asym.valueBits == 4)
+        // Symmetric keeps keyBits/valueBits nil so the caller defaults from
+        // .bits. Both end up at (4, 4) downstream.
+        let sym = parseTurboScheme("turbo4")
+        #expect(sym.bits == 4)
+        #expect((sym.keyBits ?? sym.bits) == 4)
+        #expect((sym.valueBits ?? sym.bits) == 4)
+    }
+}


### PR DESCRIPTION
## Summary
- add a TurboQuant-backed storage variant for batched KV caches
- wire batched cache allocation through Qwen3/Qwen3.5/Qwen3Next paths
- add BatchedTurboKVCache and parseTurboScheme regression coverage

## Notes
- draft PR split from the alpha integration stack
- based on fresh ekryski:alpha