### PR TITLE
fix(MLXVLM): mark shared CIContext nonisolated unsafe

### DIFF
--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -13,7 +13,12 @@ public struct ProcessedFrames {
     public let totalDuration: CMTime
 }
 
-private let context = CIContext()
+// `nonisolated(unsafe)` because CIContext is reference-typed but Apple
+// doesn't conform it to Sendable. CIContext is documented as
+// thread-safe for the methods we use (createCGImage, render). Without
+// this annotation Swift 6.x strict-concurrency rejects the static let
+// as a hard error on CI runners (local macOS 26 Swift accepts it).
+nonisolated(unsafe) private let context = CIContext()
 
 /// Collection of methods for processing media (images, video, etc.).
 ///


### PR DESCRIPTION
## Summary
- annotate the shared MLXVLM CIContext static as nonisolated(unsafe)
- fixes Swift concurrency isolation diagnostics without changing runtime behavior

## Notes
- draft PR split from the alpha integration stack
- based on fresh ekryski:alpha