### PR TITLE
fix(models): harden bf16 and ConfigI loading paths

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma2.swift
+++ b/Libraries/MLXLLM/Models/Gemma2.swift
@@ -163,6 +163,12 @@ public class Gemma2ModelInner: Module {
         var h = embedTokens(inputs)
         h = h * hiddenScale
 
+        // Auto-upcast for bf16 unquantized weights — see Llama.swift for
+        // rationale (sparse NaN from MLX Swift bf16 Metal matmul).
+        let needsFP32Upcast = (h.dtype == .bfloat16)
+        let originalDtype = h.dtype
+        if needsFP32Upcast { h = h.asType(.float32) }
+
         // Gemma2 uses the older array-based mask pattern with manual application in attention
         let mask: MLXArray? = createAttentionMask(h: h, cache: cache)
 
@@ -170,7 +176,9 @@ public class Gemma2ModelInner: Module {
             h = layer(h, mask: mask, cache: cache?[i])
         }
 
-        return norm(h)
+        var normed = norm(h)
+        if needsFP32Upcast { normed = normed.asType(originalDtype) }
+        return normed
     }
 }
 

--- a/Libraries/MLXLLM/Models/Gemma4.swift
+++ b/Libraries/MLXLLM/Models/Gemma4.swift
@@ -1166,6 +1166,20 @@ public class Gemma4TextModel: Module, LLMModel, KVCacheDimensionProvider {
                 rewritten = rewritten.replacingOccurrences(
                     of: ".mlp.up_proj", with: ".mlp.gate_up_proj")
             }
+            // MoE experts (Gemma 4 26B A4B ConfigI variant): config.json keys
+            // overrides on the pre-fuse expert path
+            // `.experts.switch_glu.{gate,up,down}_proj`. The Swift modules
+            // are `.experts.{gate_up_proj, down_proj}` (gate+up fused; the
+            // `switch_glu` segment is stripped during sanitize(weights:)).
+            // Remap per-layer quant overrides to the post-fuse Swift path.
+            if rewritten.contains(".experts.switch_glu.") {
+                rewritten = rewritten.replacingOccurrences(
+                    of: ".experts.switch_glu.gate_proj", with: ".experts.gate_up_proj")
+                rewritten = rewritten.replacingOccurrences(
+                    of: ".experts.switch_glu.up_proj", with: ".experts.gate_up_proj")
+                rewritten = rewritten.replacingOccurrences(
+                    of: ".experts.switch_glu.down_proj", with: ".experts.down_proj")
+            }
             stripped[rewritten] = value
         }
         return BaseConfiguration.PerLayerQuantization(

--- a/Libraries/MLXLLM/Models/Llama.swift
+++ b/Libraries/MLXLLM/Models/Llama.swift
@@ -50,7 +50,6 @@ class LlamaAttention: Module {
         var keys = wk(x)
         var values = wv(x)
 
-        // Prepare the queries, keys and values for the attention computation
         queries = queries.reshaped(B, L, args.attentionHeads, -1).transposed(0, 2, 1, 3)
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
@@ -59,12 +58,8 @@ class LlamaAttention: Module {
         keys = applyRotaryPosition(rope, to: keys, cache: cache)
 
         let output = attentionWithCacheUpdate(
-            queries: queries,
-            keys: keys,
-            values: values,
-            cache: cache,
-            scale: scale,
-            mask: mask
+            queries: queries, keys: keys, values: values,
+            cache: cache, scale: scale, mask: mask
         )
         .transposed(0, 2, 1, 3)
         .reshaped(B, L, -1)
@@ -138,13 +133,36 @@ public class LlamaModelInner: Module {
     func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
         var h = embedTokens(inputs)
 
+        // Auto-upcast for bf16 unquantized weights:
+        //
+        // MLX Swift's Linear path on Apple Metal accumulates bf16 matmuls
+        // with limited intermediate precision, producing sparse NaN at
+        // matmul outputs for HF unquantized checkpoints (Llama-3.2-hf,
+        // Mistral-7B-v0.3-hf, etc.). The NaN appears first in `down_proj`
+        // of MLP layer 0 and cascades through every subsequent layer.
+        //
+        // Python `mlx-lm` runs the same models bf16 and gets correct output
+        // — implying the Swift backend's matmul kernel differs from the
+        // Python one (likely accumulation dtype). Until that's resolved at
+        // the MLX kernel level, upcast the hidden stream to fp32 whenever
+        // weights are bf16. ~30% slower decode, ~2× hidden-state memory,
+        // but the model produces correct output.
+        //
+        // MLX-quantized checkpoints (4-bit/6-bit with f16 scales) are
+        // unaffected — Linear's quant path uses correct fp32 accumulation.
+        let needsFP32Upcast = (h.dtype == .bfloat16)
+        let originalDtype = h.dtype
+        if needsFP32Upcast { h = h.asType(.float32) }
+
         let mask = createAttentionMask(h: h, cache: cache?.first)
 
         for (i, layer) in layers.enumerated() {
             h = layer(h, mask: mask, cache: cache?[i])
         }
 
-        return norm(h)
+        var normed = norm(h)
+        if needsFP32Upcast { normed = normed.asType(originalDtype) }
+        return normed
     }
 }
 

--- a/Libraries/MLXLLM/Models/Qwen3.swift
+++ b/Libraries/MLXLLM/Models/Qwen3.swift
@@ -301,13 +301,22 @@ public class Qwen3ModelInner: Module {
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
         var h = embedTokens(inputs)
 
+        // Auto-upcast for bf16 unquantized weights to dodge MLX Swift's
+        // Metal Linear bf16-accumulation bug (sparse NaN at down_proj).
+        // See Llama.swift LlamaModelInner for full rationale.
+        let needsFP32Upcast = (h.dtype == .bfloat16)
+        let originalDtype = h.dtype
+        if needsFP32Upcast { h = h.asType(.float32) }
+
         let mask = createAttentionMask(h: h, cache: cache?.first)
 
         for (i, layer) in layers.enumerated() {
             h = layer(h, mask: mask, cache: cache?[i])
         }
 
-        return norm(h)
+        var normed = norm(h)
+        if needsFP32Upcast { normed = normed.asType(originalDtype) }
+        return normed
     }
 
     /// Fully batched forward: shared per-layer BatchedKVCaches.

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -664,7 +664,14 @@ final class Qwen35DecoderLayer: Module {
     ) -> MLXArray {
         let r: MLXArray
         if isLinear {
-            r = linearAttn!(inputLayerNorm(x), mask: ssmMask, cache: cache as? SSMStateCache)
+            // GDN's fused Metal kernel is compiled for bf16/fp16 only.
+            // In selective-fp32 mode (bf16 unquantized weights) the caller
+            // hands us fp32 to dodge the bf16 matmul NaN bug — downcast
+            // for the sub-call, upcast the result so residual + MLP stay fp32.
+            let needsCast = (x.dtype == .float32)
+            let xIn = needsCast ? x.asType(.bfloat16) : x
+            let rRaw = linearAttn!(inputLayerNorm(xIn), mask: ssmMask, cache: cache as? SSMStateCache)
+            r = needsCast ? rRaw.asType(.float32) : rRaw
         } else {
             r = selfAttn!(inputLayerNorm(x), mask: attentionMask, cache: cache)
         }
@@ -684,7 +691,11 @@ final class Qwen35DecoderLayer: Module {
         let r: MLXArray
         switch (isLinear, layerCache) {
         case (true, .gdn(let mambaCache)):
-            r = linearAttn!.fullyBatchedForward(inputLayerNorm(x), cache: mambaCache)
+            // See callAsFunction: GDN kernel needs bf16; residual + MLP stay fp32 in selective mode.
+            let needsCast = (x.dtype == .float32)
+            let xIn = needsCast ? x.asType(.bfloat16) : x
+            let rRaw = linearAttn!.fullyBatchedForward(inputLayerNorm(xIn), cache: mambaCache)
+            r = needsCast ? rRaw.asType(.float32) : rRaw
         case (false, .attention(let kvCache)):
             r = selfAttn!.fullyBatchedForward(
                 inputLayerNorm(x), cache: kvCache, mask: attnMask)
@@ -744,6 +755,23 @@ public class Qwen35TextModelInner: Module {
     func callAsFunction(_ inputs: MLXArray, cache: [KVCache?]? = nil) -> MLXArray {
         var hiddenStates = embedTokens(inputs)
 
+        // Selective fp32 upcast for bf16 unquantized weights:
+        //
+        // MLX Swift's Metal Linear kernel produces sparse NaN when both
+        // input and weight are bf16 (see Llama.swift LlamaModelInner for
+        // detailed rationale). Llama / Qwen3 / Gemma2 fix this by
+        // upcasting the entire hidden stream to fp32.
+        //
+        // Qwen3.5/3.6 is hybrid (GDN/SSM + attention). The fused GDN
+        // Metal kernel `gated_delta_step_fused_*` is only compiled for
+        // bf16/fp16, not fp32 — uniform upcast would crash. Instead:
+        // upcast the hidden stream to fp32 BEFORE each attention/MLP
+        // layer (the matmul-heavy path that triggers the bug), and
+        // downcast to the original bf16 BEFORE each SSM/GDN layer
+        // (where the kernel needs bf16).
+        let originalDtype = hiddenStates.dtype
+        let needsSelectiveFP32 = (originalDtype == .bfloat16)
+
         var cacheArray = cache
         if cacheArray == nil {
             cacheArray = Array(repeating: nil as KVCache?, count: layers.count)
@@ -765,6 +793,16 @@ public class Qwen35TextModelInner: Module {
             let attnMask =
                 layer.isLinear
                 ? MLXFast.ScaledDotProductAttentionMaskMode.none : faMask
+
+            // Selective-fp32 entry: keep the residual stream in fp32 across
+            // ALL layers so attention, MLP, and residual adds dodge the bf16
+            // matmul NaN bug. GDN's fused Metal kernel still needs bf16
+            // input — Qwen35DecoderLayer downcasts internally for the GDN
+            // sub-call and upcasts the result, leaving residual + MLP in fp32.
+            if needsSelectiveFP32 {
+                hiddenStates = hiddenStates.asType(.float32)
+            }
+
             hiddenStates = layer(
                 hiddenStates, attentionMask: attnMask, ssmMask: mask, cache: cacheArray?[i])
             // Force dtype after every layer — quantized operations can promote
@@ -772,7 +810,12 @@ public class Qwen35TextModelInner: Module {
             // The unconditional asType adds a cast node that ensures downstream
             // GDN/attention kernels receive bf16. When dtype is already correct,
             // asType is a no-op (zero overhead).
-            hiddenStates = hiddenStates.asType(modelDtype)
+            // SKIP when selective-fp32 is active: we want attention outputs to
+            // stay fp32 so the next-layer cast decides direction. Quantized
+            // models (no selective-fp32) keep the original forced cast.
+            if !needsSelectiveFP32 {
+                hiddenStates = hiddenStates.asType(modelDtype)
+            }
 
             // During prefill, two paths:
             //
@@ -807,6 +850,11 @@ public class Qwen35TextModelInner: Module {
             }
         }
 
+        // When selective-fp32 is active, ensure normed is fp32 so the
+        // downstream lm_head (bf16 weights) doesn't trigger the same
+        // bf16-matmul NaN bug we just dodged in the attention layers.
+        // The outer model wrapper handles the dtype after lm_head.
+        if needsSelectiveFP32 { hiddenStates = hiddenStates.asType(.float32) }
         return norm(hiddenStates)
     }
 
@@ -961,7 +1009,27 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider {
         let hasUnsanitizedConv1d = weights.contains { key, value in
             key.contains("conv1d.weight") && value.dim(-1) != 1
         }
-        let shouldShiftNormWeights = hasMTPWeights || hasUnsanitizedConv1d
+        // Determine whether norm weights are stored as offsets-from-1
+        // (Python mlx_lm convert convention for some Qwen3.5 checkpoints)
+        // vs absolute values. Check the actual magnitude of a probe norm
+        // tensor: offset format has mean near 0, absolute has mean near 1.
+        // The previous heuristic shifted whenever MTP weights were present,
+        // which incorrectly applied to MTP-variant checkpoints that ship
+        // absolute-format norms (e.g. Qwen3.6-35B-A3B-4bit-mtp), pushing
+        // gamma values to ~2.0 and crashing decode into token-soup garbage.
+        let normsLookLikeOffsets: Bool = {
+            for (k, v) in weights {
+                guard k.hasSuffix(".input_layernorm.weight"),
+                      v.ndim == 1 else { continue }
+                let mean = v.mean(keepDims: false)
+                eval(mean)
+                let m = abs(mean.item(Float.self))
+                return m < 0.5  // offset format mean ≈ 0; absolute ≈ 1
+            }
+            return false
+        }()
+        let shouldShiftNormWeights = normsLookLikeOffsets || hasUnsanitizedConv1d
+        _ = hasMTPWeights  // keep for future use; no longer drives the shift
 
         var weights = weights.filter { !$0.key.contains("mtp.") }
 

--- a/Libraries/MLXLMCommon/Models/Gemma3.swift
+++ b/Libraries/MLXLMCommon/Models/Gemma3.swift
@@ -110,15 +110,34 @@ public enum Gemma3 {
             hiddenLayers = try container.decodeIfPresent(Int.self, forKey: .hiddenLayers) ?? 26
             intermediateSize =
                 try container.decodeIfPresent(Int.self, forKey: .intermediateSize) ?? 6912
-            // 4B+ variants set these explicitly; 1B uses the defaults below.
+            // Some checkpoints (notably mlx_lm-converted multimodal Gemma3
+            // VLM repos) omit attention head fields from config.json; fall
+            // back to the canonical per-variant defaults indexed by
+            // `hidden_size`.
+            //   1B:  hidden=1152, heads=4,  kv=1,  head_dim=256
+            //   4B:  hidden=2560, heads=8,  kv=4,  head_dim=256
+            //   12B: hidden=3584, heads=16, kv=8,  head_dim=256
+            //   27B: hidden=5376, heads=32, kv=16, head_dim=128
+            let defHeads: Int
+            let defKVHeads: Int
+            let defHeadDim: Int
+            if hiddenSize < 2048 {
+                defHeads = 4; defKVHeads = 1; defHeadDim = 256
+            } else if hiddenSize < 3072 {
+                defHeads = 8; defKVHeads = 4; defHeadDim = 256
+            } else if hiddenSize < 4096 {
+                defHeads = 16; defKVHeads = 8; defHeadDim = 256
+            } else {
+                defHeads = 32; defKVHeads = 16; defHeadDim = 128
+            }
             attentionHeads =
-                try container.decodeIfPresent(Int.self, forKey: .attentionHeads) ?? 4
-            headDim = try container.decodeIfPresent(Int.self, forKey: .headDim) ?? 256
+                try container.decodeIfPresent(Int.self, forKey: .attentionHeads) ?? defHeads
+            headDim = try container.decodeIfPresent(Int.self, forKey: .headDim) ?? defHeadDim
             rmsNormEps = try container.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1.0e-6
             // 1B = 262144, 4B+ = 262208 — always JSON-driven.
             vocabularySize =
                 try container.decodeIfPresent(Int.self, forKey: .vocabularySize) ?? 262144
-            kvHeads = try container.decodeIfPresent(Int.self, forKey: .kvHeads) ?? 1
+            kvHeads = try container.decodeIfPresent(Int.self, forKey: .kvHeads) ?? defKVHeads
             ropeTheta =
                 try container.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 1_000_000.0
             ropeLocalBaseFreq =

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -789,7 +789,14 @@ enum Qwen35Language {
         ) -> MLXArray {
             let r: MLXArray
             if isLinear {
-                r = linearAttn!(inputLayerNorm(x), mask: ssmMask, cache: cache as? SSMStateCache)
+                // GDN's fused Metal kernel is compiled for bf16/fp16 only.
+                // In selective-fp32 mode the caller hands us fp32 to dodge the
+                // bf16 matmul NaN bug — downcast for the sub-call, upcast the
+                // result so residual + MLP stay fp32.
+                let needsCast = (x.dtype == .float32)
+                let xIn = needsCast ? x.asType(.bfloat16) : x
+                let rRaw = linearAttn!(inputLayerNorm(xIn), mask: ssmMask, cache: cache as? SSMStateCache)
+                r = needsCast ? rRaw.asType(.float32) : rRaw
             } else {
                 r = selfAttn!(
                     inputLayerNorm(x), mask: attentionMask, cache: cache, positionIds: positionIds)
@@ -835,6 +842,16 @@ enum Qwen35Language {
                 hiddenStates = embedTokens(inputs)
             }
 
+            // Selective fp32 upcast for bf16 unquantized weights. Same
+            // rationale as MLXLLM/Models/Qwen35.swift — bf16 matmul produces
+            // sparse NaN; residual + MLP stay fp32; DecoderLayer downcasts
+            // only inside the GDN sub-call (kernel requires bf16/fp16).
+            let originalDtype = hiddenStates.dtype
+            let needsSelectiveFP32 = (originalDtype == .bfloat16)
+            if needsSelectiveFP32 {
+                hiddenStates = hiddenStates.asType(.float32)
+            }
+
             var cacheArray = cache
             if cacheArray == nil {
                 cacheArray = Array(repeating: nil as KVCache?, count: layers.count)
@@ -861,7 +878,9 @@ enum Qwen35Language {
                 )
             }
 
-            return norm(hiddenStates)
+            var normed = norm(hiddenStates)
+            if needsSelectiveFP32 { normed = normed.asType(originalDtype) }
+            return normed
         }
     }
 


### PR DESCRIPTION
## Summary
- add bf16 hidden-stream upcasts for Llama, Gemma2, and Qwen3 paths to avoid sparse NaNs on unquantized checkpoints
- add selective fp32 handling for Qwen3.5/GDN paths while preserving bf16 inputs for fused GDN kernels
- harden ConfigI-related loading paths: Gemma4 expert quant override remapping, Qwen3.5 norm-shift detection, and Gemma3 missing-head defaults

## Notes
- draft PR split from the alpha integration stack
- based on fresh ekryski:alpha
- contains the seven in-flight files as one commit