### PR TITLE
feat(gemma4): spec 041 phase 5 — affine donor compression via shared-reader quantised path

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4.swift
+++ b/Libraries/MLXLLM/Models/Gemma4.swift
@@ -423,12 +423,57 @@ class Gemma4Attention: Module {
         cache: KVCache? = nil,
         useSharedKV: Bool = false,
         sharedKVArrays: (MLXArray, MLXArray)? = nil,
+        // spec 041 phase 5: donor under affine quantisation hands its
+        // `getQuantizedState()` triple to the reader instead of dequanting
+        // to FP16 first. When non-nil, takes precedence over `sharedKVArrays`.
+        quantizedSharedKVArrays: (
+            (MLXArray, MLXArray, MLXArray?), (MLXArray, MLXArray, MLXArray?)
+        )? = nil,
+        quantizedSharedKVConfig: (
+            groupSize: Int, bits: Int, mode: QuantizationMode
+        )? = nil,
         donorOffset: Int? = nil,
         inputNormWeight: MLXArray? = nil
     ) -> MLXArray {
         let (B, L, _) = (x.dim(0), x.dim(1), x.dim(2))
 
         var queries = qProj(x).reshaped(B, L, nHeads, -1)
+
+        if useSharedKV,
+           let quantizedKV = quantizedSharedKVArrays,
+           let quantizedConfig = quantizedSharedKVConfig
+        {
+            // Affine-quantised donor → reader path (spec 041 phase 5).
+            // No dequant; route through the discrete-path quantized SDPA
+            // (which now folds sinks via the augmented-softmax — PR #210).
+            let offset = donorOffset ?? cache?.offset ?? 0
+            if let _fusedInvFreqs {
+                queries = MLXFast.rmsNormRoPE(
+                    queries, weight: qNorm.weight, invFreqs: _fusedInvFreqs,
+                    eps: rmsNormEps, offset: offset, nHeads: nHeads, seqLen: L)
+                queries = queries.transposed(0, 2, 1, 3)
+            } else {
+                queries = qNorm(queries)
+                queries = queries.transposed(0, 2, 1, 3)
+                queries = rope(queries, offset: offset)
+            }
+
+            let output = quantizedScaledDotProductAttention(
+                queries: queries,
+                quantizedKeys: quantizedKV.0,
+                quantizedValues: quantizedKV.1,
+                scale: scale,
+                mask: mask,
+                sinks: nil,
+                groupSize: quantizedConfig.groupSize,
+                bits: quantizedConfig.bits,
+                mode: quantizedConfig.mode
+            )
+            .transposed(0, 2, 1, 3)
+            .reshaped(B, L, -1)
+
+            return oProj(output)
+        }
 
         if useSharedKV, let sharedKV = sharedKVArrays {
             let (cachedKeys, cachedValues) = sharedKV
@@ -714,10 +759,23 @@ class Gemma4TransformerBlock: Module {
         perLayerInput: MLXArray? = nil,
         useSharedKV: Bool = false,
         sharedKVArrays: (MLXArray, MLXArray)? = nil,
+        quantizedSharedKVArrays: (
+            (MLXArray, MLXArray, MLXArray?), (MLXArray, MLXArray, MLXArray?)
+        )? = nil,
+        quantizedSharedKVConfig: (
+            groupSize: Int, bits: Int, mode: QuantizationMode
+        )? = nil,
         donorOffset: Int? = nil
     ) -> MLXArray {
         let inputNorm = inputLayerNorm(x)
-        let attnOut = selfAttention(inputNorm, mask: mask, cache: cache, useSharedKV: useSharedKV, sharedKVArrays: sharedKVArrays, donorOffset: donorOffset)
+        let attnOut = selfAttention(
+            inputNorm,
+            mask: mask, cache: cache,
+            useSharedKV: useSharedKV,
+            sharedKVArrays: sharedKVArrays,
+            quantizedSharedKVArrays: quantizedSharedKVArrays,
+            quantizedSharedKVConfig: quantizedSharedKVConfig,
+            donorOffset: donorOffset)
         // Fused RMSNorm + residual add via framework Metal kernel (rms_norm_residual.metal).
         // Single dispatch replaces separate rmsNorm + add (saves 90 dispatches/token).
         var h = MLXFast.rmsNormResidual(
@@ -934,6 +992,17 @@ public class Gemma4ModelInner: Module {
         // the donor's K/V arrays directly instead of re-slicing from cache.
         // This eliminates ~450 redundant graph ops (Slice, SDPA, etc).
         var intermediateKVs: [(MLXArray, MLXArray)?] = Array(repeating: nil, count: layers.count)
+        // Spec 041 phase 5: parallel storage for affine-quantised donor state.
+        // When a donor is `AffineQuantizedKVCache`, we capture the post-update
+        // `(packed, scales, biases)` triple and hand it straight to the
+        // reader's `quantizedScaledDotProductAttention` call — no dequant,
+        // no compression loss.
+        var intermediateQuantizedKVs: [
+            ((MLXArray, MLXArray, MLXArray?), (MLXArray, MLXArray, MLXArray?))?
+        ] = Array(repeating: nil, count: layers.count)
+        var intermediateQuantizedConfigs: [
+            (groupSize: Int, bits: Int, mode: QuantizationMode)?
+        ] = Array(repeating: nil, count: layers.count)
 
         for (i, layer) in layers.enumerated() {
             let maskMode: MLXFast.ScaledDotProductAttentionMaskMode
@@ -985,9 +1054,26 @@ public class Gemma4ModelInner: Module {
                     // Shared layers don't write to cache — skip during prefill
                     continue
                 }
-                h = layer(h, mask: maskMode, cache: nil, perLayerInput: pli,
-                          useSharedKV: true, sharedKVArrays: intermediateKVs[donorIdx],
-                          donorOffset: donorPreUpdateOffsets[donorIdx])
+                // Spec 041 phase 5: prefer the affine-quantised donor path
+                // when the donor is an `AffineQuantizedKVCache`. Avoids the
+                // legacy `StandardKVCache` fallback that lost compression on
+                // donor layers under `--kv affine*`.
+                if let qkv = intermediateQuantizedKVs[donorIdx],
+                   let qcfg = intermediateQuantizedConfigs[donorIdx]
+                {
+                    h = layer(
+                        h, mask: maskMode, cache: nil, perLayerInput: pli,
+                        useSharedKV: true,
+                        quantizedSharedKVArrays: qkv,
+                        quantizedSharedKVConfig: qcfg,
+                        donorOffset: donorPreUpdateOffsets[donorIdx])
+                } else {
+                    h = layer(
+                        h, mask: maskMode, cache: nil, perLayerInput: pli,
+                        useSharedKV: true,
+                        sharedKVArrays: intermediateKVs[donorIdx],
+                        donorOffset: donorPreUpdateOffsets[donorIdx])
+                }
             } else {
                 donorPreUpdateOffsets[i] = cache[i]?.offset ?? 0
                 h = layer(h, mask: maskMode, cache: cache[i], perLayerInput: pli)
@@ -997,6 +1083,15 @@ public class Gemma4ModelInner: Module {
                     intermediateKVs[i] = (k, v)
                 } else if let c = cache[i] as? TurboQuantizedKVCache, let k = c.lastReturnedKeys, let v = c.lastReturnedValues {
                     intermediateKVs[i] = (k, v)
+                } else if let c = cache[i] as? AffineQuantizedKVCache,
+                          let state = c.getQuantizedState()
+                {
+                    // Spec 041 phase 5: hand the reader the donor's quantised
+                    // state directly. Sliced to `..<offset` already by
+                    // `getQuantizedState()`.
+                    intermediateQuantizedKVs[i] = state
+                    intermediateQuantizedConfigs[i] = (
+                        groupSize: c.groupSize, bits: c.bits, mode: c.mode)
                 }
             }
         }
@@ -1178,15 +1273,19 @@ public class Gemma4TextModel: Module, LLMModel, KVCacheDimensionProvider {
 
         let affineStep = defaultPrefillStepSize
 
-        // Compute the donor set first so `makeAttentionCache` can pick the
-        // right cache class up-front. KV-shared donors (Gemma 4 E2B / E4B
-        // only) need a cache that exposes raw FP16 K/V via
-        // `lastReturnedKeys` / `lastReturnedValues` — shared reader layers
-        // pass those straight to `MLXFast.scaledDotProductAttention`. For
-        // `--kv affine*` that means falling back to `StandardKVCache`
-        // (since `AffineQuantizedKVCache` has no `lastReturnedKeys`
-        // accessor); for `--kv turbo*` `TurboQuantizedKVCache` already
-        // implements the accessor and stays compressed.
+        // Compute the donor set first. Gemma 4 LLM (this file) routes shared
+        // reader layers through `Gemma4TextAttention`'s quantised donor path
+        // (spec 041 phase 5) — readers consume the donor's
+        // `getQuantizedState()` triple directly when the cache is
+        // `AffineQuantizedKVCache`. So we pass `forceRawKV: false` on
+        // donor layers to KEEP them compressed under `--kv affine*`. The
+        // turbo path's `TurboQuantizedKVCache` exposes `lastReturnedKeys`
+        // / `lastReturnedValues` natively, so it also doesn't need the
+        // `StandardKVCache` fallback.
+        //
+        // Other KV-sharing callers (Gemma 3n, Gemma 4 VLM) whose readers
+        // can only consume FP16 still pass `forceRawKV: isDonor` so their
+        // donors fall back to `StandardKVCache` under affine.
         var donorIndices = Set<Int>()
         for (i, donor) in model.previousKVs.enumerated() {
             if donor != i && donor < config.layerTypes.count {
@@ -1204,13 +1303,13 @@ public class Gemma4TextModel: Module, LLMModel, KVCacheDimensionProvider {
                 maxSize = config.slidingWindow
                 isSliding = true
             }
-            let isDonor = donorIndices.contains(idx)
             caches.append(
                 makeAttentionCache(
                     parameters: parameters, maxSize: maxSize,
                     affineStep: affineStep,
-                    forceRawKV: isDonor,
+                    forceRawKV: false,  // spec 041 phase 5: reader path handles quantised donors.
                     architecturalSlidingWindow: isSliding))
+            _ = idx
         }
 
         // Mark KV-sharing donor caches — these must not be turbo-compressed

--- a/Libraries/MLXLMCommon/KVCacheTypes.swift
+++ b/Libraries/MLXLMCommon/KVCacheTypes.swift
@@ -315,8 +315,7 @@ public func makeAttentionCache(
     architecturalSlidingWindow: Bool = false
 ) -> KVCache {
     if case let .affine(bits, groupSize) = parameters?.compressionAlgorithm {
-        // Two cases force a `StandardKVCache` fallback even when the user
-        // requested affine quantisation:
+        // Two cases force a `StandardKVCache` fallback under affine:
         //
         // 1. **Architectural sliding window (`architecturalSlidingWindow ==
         //    true`).** Gemma 4 / Mistral3 / etc. define sliding-window layers
@@ -325,14 +324,18 @@ public func makeAttentionCache(
         //    rotating-buffer logic (grows unbounded), so without this
         //    fallback the model attends over the full prefill once context
         //    exceeds the window and produces gibberish.
-        // 2. **KV-sharing donors (`forceRawKV == true`).** Gemma 4 E2B / E4B
-        //    thread a donor layer's `lastReturnedKeys` / `lastReturnedValues`
-        //    into shared reader layers via `intermediateKVs[donorIdx]`.
-        //    `AffineQuantizedKVCache` doesn't expose those properties (the
-        //    cache stores `(packedIndices, scales, biases)` triples, not a
-        //    raw FP16 buffer the reader can hand straight to MLXFast SDPA).
-        //    Without this fallback, readers receive nil and SDPA emits
-        //    garbage logits even at sub-window contexts.
+        //
+        // 2. **KV-sharing donors when the caller can't consume quantized
+        //    donor state (`forceRawKV == true`).** Spec 041 Phase 5 added a
+        //    reader path in `Gemma4TextAttention.callAsFunction(useSharedKV:...)`
+        //    that consumes the donor's `getQuantizedState()` tuple directly
+        //    via `quantizedScaledDotProductAttention`. That callsite passes
+        //    `forceRawKV: false` so its donors stay compressed under affine.
+        //    Other KV-sharing callers (Gemma 3n, Gemma 4 VLM — both still
+        //    routing donors through FP16 SDPA in the reader) keep
+        //    `forceRawKV: true`, falling back to `StandardKVCache` here. The
+        //    flag is the caller's contract: "my reader can / cannot route
+        //    quantized donor state."
         //
         // `maxSize` alone is NOT a fallback trigger — the bench harness
         // and library callers set `maxSize == contextSize` on full-attention
@@ -341,17 +344,15 @@ public func makeAttentionCache(
         // architecture) those layers should keep their affine compression
         // even with a `maxSize` set.
         //
-        // Trade-off where the fallback engages: those specific layers stay
-        // FP16 instead of quantising. On Gemma 4 sliding-window layers the
-        // cache is bounded at `slidingWindow ≈ 1024` tokens so the absolute
-        // memory cost is small. On full-attention donor layers (E2B / E4B
-        // only, ~half the cluster) we lose the compression but coherence
-        // is preserved. Tracked in
-        // https://github.com/ekryski/mlx-swift-lm/issues/202; closing the
-        // gap properly is spec 041 Phase 5 — shared readers consume the
-        // donor's quantised `(wq, scales, biases)` tuple directly via the
-        // new flash quantised SDPA kernel, no dequant + no compression
-        // loss. Spec: `specs/041-flash-quantized-sdpa.md`.
+        // Trade-off where the sliding-window fallback still engages: those
+        // specific layers stay FP16 instead of quantising. On Gemma 4
+        // sliding-window layers the cache is bounded at
+        // `slidingWindow ≈ 1024` tokens so the absolute memory cost is
+        // small. Closing this gap fully needs a rotating-buffer-aware
+        // affine cache — tracked in
+        // https://github.com/ekryski/mlx-swift-lm/issues/202 and on spec
+        // 041 Phase 1 (the kernel-level fix carries window semantics in
+        // its mask).
         if forceRawKV || architecturalSlidingWindow {
             if let maxSize {
                 return StandardKVCache(maxSize: maxSize, keep: keep)

--- a/specs/040-mamba-state-replay.md
+++ b/specs/040-mamba-state-replay.md
@@ -1,6 +1,12 @@
 # 040 — Mamba / Mamba 2 state-replay rollback
 
-**Status:** Spec extracted 2026-05-12 from [spec 020](020-tape-replay-rollback-generalised.md)'s "Mamba / Mamba 2 follow-up (post-MVP)" section. **Not started.**
+**Status:** Spec extracted 2026-05-12 from [spec 020](020-tape-replay-rollback-generalised.md)'s "Mamba / Mamba 2 follow-up (post-MVP)" section. **Not started — scoped at ~1500 LOC across the 4-repo chain (Option 1) or ~200 LOC pure-Swift (Option 2 fallback); both require focused multi-day implementation + per-shape numerical validation against `ssmAttn` reference output.**
+
+The 2026-05-13 session attempting a one-shot implementation surfaced two blockers worth recording so the next attempt can plan around them:
+
+1. **Metal toolchain not present on every dev machine.** `make build-tests` falls through to `xcrun metal` which is not part of the default Xcode install (`xcodebuild -downloadComponent MetalToolchain` is required). Option 1's kernel work needs the metal CLI; Option 2 (Swift-only sequential loop + per-step state capture) does not, but its expected 5–10× verify-forward slowdown likely eats the n-gram speculative-decode margin on Mamba.
+2. **Option 2 design tension on `SSMStateCache` layout.** The class currently owns the GDN `deltaLog` (a `[[MLXArray]]?` of `(δ_t, k_t, g_t)` triples per layer). The Mamba flavour would either (a) parallel-store an `[MLXArray]?` of per-step recurrent-state snapshots — cheap to record, O(1) replay, ~25 KB per step per layer (so ~320 MB transient across 50 SSM layers on Nemotron-30B-A3B with a 256-token verify window, freed at `commitFull` / `rollback`); or (b) per-step `(dA_t, dB_t·x_t)` tuples matching the GDN shape — half the storage, O(k) replay. Both interact with the conv-state cache in `applyConv` (`cache[0]`), which would also need per-step capture to support mid-window rollback — that's the part that pushes Option 2 past the trivial-fallback estimate.
+
 **Branch:** TBD (`ek/040-mamba-state-replay-phase1` once implementation begins)
 **Depends on:** [spec 020](020-tape-replay-rollback-generalised.md) phases 1–3 (shipped 2026-05-11 via [PR #143](https://github.com/ekryski/mlx-swift-lm/pull/143) + cross-repo chain). Reuses the `StateReplayCache` protocol, the `SSMStateCache` storage class, the `beginRecord` / `commitFull` / `rollback` lifecycle, the n-gram iterator's record-then-rollback dispatch, and the 4-repo kernel-chain pattern from spec 020 verbatim — this spec is the **Mamba-recurrence kernel pair**, nothing else.
 

--- a/specs/041-flash-quantized-sdpa.md
+++ b/specs/041-flash-quantized-sdpa.md
@@ -114,6 +114,14 @@ Fold the per-head `sinks` logit into the online softmax (same math as upstream M
 
 ### Phase 5 — KV-sharing reader path (Gemma 4 E2B / E4B fallback recovery)
 
+**Status:** Phase 5 (Gemma 4 LLM) shipped 2026-05-13. Discrete-path
+`quantizedScaledDotProductAttention` is used as the stop-gap; the flash
+kernel from Phase 1 will replace it without changing the reader API.
+Gemma 3n and Gemma 4 VLM still pass `forceRawKV: true` and fall back to
+`StandardKVCache` on affine donors — extending the reader path to those
+files is straightforward (mechanical mirror of the Gemma 4 LLM diff)
+and tracked alongside Phase 1.
+
 Closes the `--kv affine*` fallback that `makeAttentionCache` currently routes through `StandardKVCache` whenever a layer is flagged `architecturalSlidingWindow` or `forceRawKV` (KV-sharing donor). Bug history + current fallback semantics tracked in [#202](https://github.com/ekryski/mlx-swift-lm/issues/202).
 
 The fallback exists because today's shared-layer attention path in `Gemma4.swift` (and similarly in `Gemma3nText.swift`) consumes `sharedKVArrays: (MLXArray, MLXArray)` — raw FP16 K/V — and routes them straight to `MLXFast.scaledDotProductAttention`. Donor caches built as `AffineQuantizedKVCache` store `(packedIndices, scales, biases)` triples, which the shared reader has no way to feed into the FP16 SDPA call. Three options were considered:


### PR DESCRIPTION
## Summary

Stacks on top of #210 (GPT-OSS sinks). Closes spec 041 Phase 5 (KV-sharing reader path) for Gemma 4 LLM — donors stay \`AffineQuantizedKVCache\` and the reader consumes their quantised \`(packed, scales, biases)\` tuple directly via \`quantizedScaledDotProductAttention\`. No dequant, no compression loss.

The discrete-path qSDPA is the stop-gap; spec 041 Phase 1's flash quantised SDPA kernel will swap the actual SDPA call in without changing the reader API. Phase 5 for Gemma 3n and Gemma 4 VLM remains as mechanical follow-up.

## Verification (M1 Max 64GB)

Gemma 4 E2B \`--kv affine4\` summarization @ ctx=8192:

| Metric | pass1 baseline (pre-fixes) | this PR |
|---|---:|---:|
| Decode tok/s | 44.0 (gibberish) | 87.3 (coherent) |
| Peak GPU | 9.62 GB | 5.47 GB |
| KV cache | 48 MB | 26 MB |
| Output | garbage | \"This is a fascinating collection of excerpts, clearly drawn from Nick Carraway's perspective in The Great Gatsby...\" |

Gemma 4 E4B \`--kv affine4\` + \`turbo4v2\` summarization @ ctx=4096: both coherent (\"The provided text includes excerpts from two different pieces of writing...\" and \"The provided text contains two main parts:\").

## Test plan

- [x] \`swift build\` clean
- [x] Gemma 4 E2B coherent at ctx=4096 simple + 8192 summarization
- [x] Gemma 4 E4B coherent at ctx=4096 summarization with both affine4 + turbo4v2
- [x] Spec 041 doc updated with phase 5 status
- [ ] CI

## Stacked dependency

This PR is based on the GPT-OSS sinks branch (#210). Merging requires #210 to land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)