### PR TITLE
perf(loadtime): split big-MoE quantize + per-layer asyncEval

### DIFF
--- a/Libraries/MLXLLM/Models/DeepseekV4.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4.swift
@@ -762,12 +762,22 @@ public class DeepseekV4ModelInner: Module {
         let hFlat2 = h.reshaped(h.dim(0), h.dim(1), -1)  // for createAttentionMask
         let mask = createAttentionMask(h: hFlat2, cache: firstCache)
 
+        // 43-layer forward through 256-expert MoE blocks overruns Metal's
+        // ~2s GPU command-buffer watchdog if dispatched as one big graph.
+        // Split per-layer with asyncEval so each layer commits its own
+        // command buffer. Mirrors Qwen35/NemotronH pattern.
+        let isPrefill = h.dim(1) > 1
         for (i, layer) in layers.enumerated() {
             h = layer(
                 h,
                 mask: mask,
                 cache: cache?[i],
                 inputIds: inputs)
+            if isPrefill, let c = cache?[i] {
+                var toEval: [MLXArray] = [h]
+                toEval.append(contentsOf: c.innerState())
+                asyncEval(toEval)
+            }
         }
 
         // HyperHead reduce: (B, L, hcMult, H) → (B, L, H)

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -54,6 +54,12 @@ public func loadWeights(
                 return nil
             }
         }
+        // Force eager eval of the per-module fresh-quantize ops emitted by
+        // `quantize(model:)`. For very large MoE models (DeepSeek-V4 256
+        // experts × 43 layers) the lazy graph fuses these into one big
+        // command buffer that overruns Metal's GPU watchdog (~2s) at first
+        // forward. Splitting here lets the rest of load proceed normally.
+        eval(model.parameters())
     }
 
     // apply the loaded weights


### PR DESCRIPTION
## Summary

Two changes that prevent Metal's GPU command-buffer watchdog (~2s) from killing model load + first-forward on very large MoE models — surfaced while bringing up DeepSeek-V4-Flash (43 layers × 256 experts, 90 GB on disk).

### \`Load.swift\` — \`eval(model.parameters())\` after \`quantize(model:)\`

\`quantize(model:)\` walks the module tree and emits a fresh-quantize op per \`Quantizable\` leaf. For DeepSeek-V4 (43 layers × 256 experts × {gate,up,down} SwitchLinear ≈ 33K modules) the lazy graph fuses these into a single Metal command buffer that overruns the watchdog at first forward.

Splitting with one \`eval(model.parameters())\` after the \`quantize()\` walk forces eager materialization of each module's quant op separately. Cheap on small models (one eval over a graph that was about to evaluate anyway). Decisive on big MoE.

### \`DeepseekV4.swift\` — per-layer \`asyncEval\` during prefill

Same watchdog symptom on the forward path. Per-layer \`asyncEval\` splits the 43-layer graph at layer boundaries so the GPU pipeline stays fed without any single command buffer exceeding the watchdog. Mirrors the pattern already in \`Qwen35TextModelInner\` and \`NemotronHBackbone\`.

## Test plan

- [x] No-op on small quantized models (Qwen3-0.6B-4bit, Llama-3.2-3B-4bit) — load time unchanged, decode tok/s unchanged
- [ ] DeepSeek-V4-Flash-2bit-DQ end-to-end coherency — deferred (model is 90 GB and triggers OS-level memory pressure on local test boxes; needs the bigger M-series rig)

## Notes

Both changes are defensive: they take a code path that was already used for Qwen35/NemotronH on the forward and extend it to the load + DeepseekV4 forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)