### PR TITLE
ci(auto-label): switch to pull_request_target so external-fork PRs get labelled

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -24,10 +24,29 @@ name: Auto-label PRs
 # Each PR gets at most ONE label from this workflow. If the title has no
 # matching prefix, no label is applied and the PR falls to "Other Changes"
 # in release notes — same as today.
+#
+# Why `pull_request_target` instead of `pull_request`: PRs from forks
+# owned by someone other than the base repo's owner receive a read-only
+# `GITHUB_TOKEN` under the `pull_request` event, regardless of what
+# `permissions:` declares — GitHub's security default. That made
+# `gh pr edit --add-label` silently fail on PRs from external
+# contributors' forks (only PRs from `ekryski/*` got labelled).
+# `pull_request_target` runs in the base repo's context with the base
+# repo's full-permission token, so labels apply uniformly to every PR
+# regardless of the source fork.
+#
+# Safety: `pull_request_target` is only dangerous when the workflow
+# checks out untrusted PR code (the typical exploit vector — fork code
+# runs with elevated permissions). This workflow does NOT check out PR
+# code; it only reads the PR title (a string already shown publicly)
+# and calls `gh pr edit` to add a label. No `actions/checkout`, no
+# execution of PR-author-controlled scripts. The `synchronize` event
+# is dropped — title doesn't change on push, so re-running on every
+# new commit is wasted work.
 
 on:
-  pull_request:
-    types: [opened, edited, reopened, synchronize]
+  pull_request_target:
+    types: [opened, edited, reopened]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Summary

Auto-label workflow was only labelling PRs from \`ekryski/*\` branches (yours), silently skipping PRs from external contributors' forks (TheTom et al.).

## Root cause

Under \`on: pull_request\`, PRs opened from a fork owned by someone other than the base repo's owner receive a **read-only \`GITHUB_TOKEN\`** — regardless of what \`permissions:\` declares. This is GitHub's security default and supersedes the workflow's own permission grants.

So \`gh pr edit --add-label\` silently failed on every external-fork PR. No error in the run log either; the workflow just couldn't write to the PR. (Your own PRs work because the same-owner case gets full token permissions.)

## Fix

Switch the trigger to \`pull_request_target\`, which runs in the **base repo's** context with the base repo's full-permission token. Labels now apply uniformly to every incoming PR regardless of source fork.

## Safety review

\`pull_request_target\` is only dangerous when a workflow checks out untrusted PR code (the standard exploit vector — fork-author code runs with elevated repo permissions). This workflow:

- does NOT use \`actions/checkout\` (no fork code is fetched)
- reads only \`github.event.pull_request.title\` (a public string)
- executes only \`gh pr edit --add-label\` with constant args (label name comes from a regex match against a fixed allowlist of conventional-commit prefixes — no PR-author-controlled values reach the shell)

There's no path for PR-author-controlled code to run with elevated permissions.

Also dropped the \`synchronize\` event from the trigger types — PR title doesn't change on push, so re-running on every new commit is wasted CI minutes.

## Test plan

- [ ] After merge, next external-fork PR (e.g. one of TheTom's drafts) should get auto-labelled
- [ ] Existing \`ekryski/*\` PRs continue to be labelled (no regression)
- [x] Workflow no longer fires on \`synchronize\` (just \`opened/edited/reopened\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)