### PR TITLE
Batched sparse attention decode + per-family support (8 attention + 2 hybrid)

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma3+Sparse.swift
+++ b/Libraries/MLXLLM/Models/Gemma3+Sparse.swift
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// BatchedSparseLLM conformance for Gemma3TextModel. Pairs with the shared
+// `Gemma3.{Attention, TransformerBlock, Backbone}.fullyBatchedSparseForward`
+// hooks in MLXLMCommon/Models/Gemma3+Sparse.swift.
+
+import Foundation
+import MLX
+import MLXLMCommon
+
+extension Gemma3TextModel: BatchedSparseLLM {
+
+    /// Single-step batched sparse decode. Per-layer
+    /// `BatchedRetrievalAttentionKVCache` list must match
+    /// `model.layers.count`. Sliding vs global layer mix is reflected in
+    /// each layer's own RoPE — the dense fallback path uses the inner
+    /// cache's `getCachedWithMask` which respects per-layer offsets.
+    public func fullyBatchedSparseDecode(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        let out = model.fullyBatchedSparseForward(inputs, raCaches: raCaches)
+        return lmHead(out)
+    }
+}

--- a/Libraries/MLXLLM/Models/Gemma4+Sparse.swift
+++ b/Libraries/MLXLLM/Models/Gemma4+Sparse.swift
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// Batched sparse decode hooks for Gemma 4. Gemma 4 specifics handled here:
+//   - Per-layer sliding / global attention mix via `layerTypes`. Each layer
+//     owns its own RoPE (sliding uses local rope theta; global uses the
+//     scaled rope theta + maxPositionEmbeddings).
+//   - Sliding layers and global layers have DIFFERENT head dimensions and
+//     KV-head counts (global uses `globalKvHeads` / `globalHeadDim`). The
+//     per-layer `BatchedRetrievalAttentionKVCache` list must match each
+//     layer's actual K shape — the caller is responsible.
+//   - v_norm: Gemma 4 applies a value RMSNorm with no learned weight; we
+//     replicate via `MLXFast.rmsNorm(values, weight: .mlxNone, eps: ...)`.
+//   - KV-shared layers (e2b: trailing `num_kv_shared_layers` layers reuse
+//     the donor layer's K/V) are NOT supported on the sparse decode path
+//     in this initial port — the caller must pre-condition with
+//     `numKvSharedLayers == 0`. The conformance precondition surfaces this
+//     so a future spec can wire shared-layer routing through the cache list.
+//   - attentionKEqV (some non-sliding layers re-use K as V — no v_proj):
+//     handled by reading `vProj` optionality at runtime.
+//   - Embeddings are pre-scaled by sqrt(hiddenSize).
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+extension Gemma4Attention {
+
+    /// Batched sparse forward for a single decode step on a Gemma 4 attention
+    /// layer (sliding OR global). RoPE is selected per layer at init, so the
+    /// same call site handles both attention kinds.
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+        let cache = raCache.inner
+
+        // Use the non-fused norm + RoPE path on the sparse decode site to keep
+        // the math straightforward; the fused-kernel optimisation lives on the
+        // existing dense path and is orthogonal to the sparse-attention swap.
+        var queries = qProj(x).reshaped(B, L, nHeads, -1)
+        var keys = kProj(x).reshaped(B, L, nKVHeads, -1)
+        var values: MLXArray
+        if attentionKEqV {
+            values = keys
+        } else {
+            values = vProj!(x).reshaped(B, L, nKVHeads, -1)
+        }
+        // v_norm has no learned weight — keep parity with the dense path.
+        values = MLXFast.rmsNorm(values, weight: MLXArray.mlxNone, eps: rmsNormEps)
+
+        queries = qNorm(queries).transposed(0, 2, 1, 3)
+        keys = kNorm(keys).transposed(0, 2, 1, 3)
+        values = values.transposed(0, 2, 1, 3)
+
+        let allSameOffset = cache.offsets[0 ..< cache.active]
+            .allSatisfy { $0 == cache.offsets[0] }
+        let preUpdateK: MLXArray
+        if allSameOffset {
+            let offset = cache.offsets[0]
+            queries = rope(queries, offset: offset)
+            keys = rope(keys, offset: offset)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        } else {
+            let qSlices = split(queries, parts: B, axis: 0)
+            let kSlices = split(keys, parts: B, axis: 0)
+            var rotQ = [MLXArray]()
+            var rotK = [MLXArray]()
+            rotQ.reserveCapacity(B)
+            rotK.reserveCapacity(B)
+            for i in 0 ..< B {
+                let off = cache.offsets[i]
+                rotQ.append(rope(qSlices[i], offset: off))
+                rotK.append(rope(kSlices[i], offset: off))
+            }
+            queries = concatenated(rotQ, axis: 0)
+            keys = concatenated(rotK, axis: 0)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        }
+
+        raCache.updateIndex(newKeys: preUpdateK)
+
+        let output: MLXArray
+        if L == 1 && raCache.isSparseEligible {
+            output = raCache.sparseAttend(queries: queries, scale: scale)
+        } else {
+            let (k, v, mask) = cache.getCachedWithMask()
+            output = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: k, values: v,
+                scale: scale, mask: .array(mask))
+        }
+        return oProj(output.transposed(0, 2, 1, 3).reshaped(B, L, -1))
+    }
+}
+
+extension Gemma4TransformerBlock {
+
+    /// Sparse forward over Gemma 4's pre/post norm + rmsNormResidual fusion.
+    /// MoE / PLE / per-layer scalar are preserved exactly as in the dense
+    /// `callAsFunction`. KV-shared layers are not supported on this path —
+    /// caller must skip them (see ModelInner precondition).
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache,
+        perLayerInput: MLXArray? = nil
+    ) -> MLXArray {
+        let inputNorm = inputLayerNorm(x)
+        let attnOut = selfAttention.fullyBatchedSparseForward(
+            inputNorm, raCache: raCache)
+        var h = MLXFast.rmsNormResidual(
+            attnOut, residual: x,
+            weight: postAttentionLayerNorm.weight,
+            eps: postAttentionLayerNorm.eps)
+
+        // FFN — shared MLP path only. The MoE expert-routing code lives in
+        // the dense `callAsFunction` and uses a fileprivate top-k helper
+        // (`gemma4TopK`) that is not available from this extension file.
+        // Sparse decode on MoE Gemma 4 checkpoints would need the same
+        // routing wired in; until then this extension preconditions on
+        // non-MoE configs (synthetic smoke uses dense FFN).
+        precondition(experts == nil && router == nil,
+            "Gemma4 batched sparse decode does not yet support MoE blocks")
+        let preFFNNorm = preFeedforwardLayerNorm(h)
+        let ffnOut = sharedMLP(preFFNNorm)
+        h = MLXFast.rmsNormResidual(
+            ffnOut, residual: h,
+            weight: postFeedforwardLayerNorm.weight,
+            eps: postFeedforwardLayerNorm.eps)
+
+        // Per-Layer Embeddings (PLE) gate + projection.
+        if let gate = perLayerInputGate,
+            let proj = perLayerProjection,
+            let norm = postPerLayerInputNorm,
+            let pli = perLayerInput
+        {
+            let residual = h
+            var g = compiledGeluMulSparse(gate(h), pli)
+            g = proj(g)
+            g = norm(g)
+            h = residual + g
+        }
+
+        return h * layerScalar
+    }
+}
+
+/// Local copy of the compiled fused gelu*mul used by Gemma 4's PLE gate.
+/// The shared dense-path one in Gemma4.swift is fileprivate, so we keep a
+/// dedicated compiled closure here to avoid touching the source file.
+private let compiledGeluMulSparse: @Sendable (MLXArray, MLXArray) -> MLXArray =
+    compile(shapeless: true) { gate, x in
+        geluApproximate(gate) * x
+    }
+
+extension Gemma4ModelInner {
+
+    /// Per-layer sparse forward. Caller is responsible for:
+    ///   - Building one `BatchedRetrievalAttentionKVCache` per layer whose
+    ///     `inner.keys` shape matches the layer's K (sliding vs global K-shape).
+    ///   - Configuring `numKvSharedLayers == 0` (KV-shared layers are not
+    ///     wired on this path yet — they would need shared-K routing through
+    ///     the cache list, which is a future spec).
+    public func fullyBatchedSparseForward(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        precondition(raCaches.count == layers.count,
+            "raCaches count (\(raCaches.count)) must match layers count (\(layers.count))")
+        precondition(config.numKvSharedLayers == 0,
+            "Gemma4 batched sparse decode does not yet support KV-shared layers")
+
+        var h = embedTokens(inputs)
+        // sqrt(hiddenSize) embedding scale.
+        h = h * sqrt(Float(config.hiddenSize))
+
+        // Per-Layer Embeddings (PLE) is computed exactly as the dense path,
+        // but only when the model declares it. The synthetic smoke config
+        // leaves `hiddenSizePerLayerInput == 0` which skips the entire block.
+        var perLayerInputs: MLXArray? = nil
+        if hiddenSizePerLayerInput > 0, let embedPL = embedTokensPerLayer {
+            var pli = embedPL(inputs) * embedTokensPerLayerScale
+            pli = pli.reshaped(
+                pli.dim(0), pli.dim(1), config.hiddenLayers, hiddenSizePerLayerInput)
+            if let proj = perLayerModelProjection {
+                var plProj = proj(h) * perLayerProjectionScale
+                plProj = plProj.reshaped(
+                    plProj.dim(0), plProj.dim(1), config.hiddenLayers, hiddenSizePerLayerInput)
+                if let norm = perLayerProjectionNorm {
+                    plProj = norm(plProj)
+                }
+                pli = (plProj + pli) * perLayerInputScale
+            }
+            perLayerInputs = pli
+        }
+
+        for (i, layer) in layers.enumerated() {
+            let pli = perLayerInputs.map { $0[0..., 0..., i, 0...] }
+            h = layer.fullyBatchedSparseForward(
+                h, raCache: raCaches[i], perLayerInput: pli)
+        }
+        return norm(h)
+    }
+}
+
+extension Gemma4TextModel: BatchedSparseLLM {
+
+    public func fullyBatchedSparseDecode(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        var out = model.fullyBatchedSparseForward(inputs, raCaches: raCaches)
+        if config.tieWordEmbeddings {
+            out = model.embedTokens.asLinear(out)
+        } else {
+            out = lmHead!(out)
+        }
+        // Final logit softcapping — only when configured (matches dense path).
+        if let softcap = config.finalLogitSoftcapping, softcap > 0 {
+            out = compiledLogitSoftcapSparse(MLXArray(softcap), out)
+        }
+        return out
+    }
+}
+
+/// Local copy of the compiled logit softcap kernel (fileprivate on the dense
+/// path; duplicated here to keep this extension additive).
+private let compiledLogitSoftcapSparse: @Sendable (MLXArray, MLXArray) -> MLXArray =
+    compile(shapeless: true) { softcap, x in
+        tanh(x / softcap) * softcap
+    }

--- a/Libraries/MLXLLM/Models/Gemma4+Sparse.swift
+++ b/Libraries/MLXLLM/Models/Gemma4+Sparse.swift
@@ -11,14 +11,20 @@
 //     layer's actual K shape — the caller is responsible.
 //   - v_norm: Gemma 4 applies a value RMSNorm with no learned weight; we
 //     replicate via `MLXFast.rmsNorm(values, weight: .mlxNone, eps: ...)`.
-//   - KV-shared layers (e2b: trailing `num_kv_shared_layers` layers reuse
-//     the donor layer's K/V) are NOT supported on the sparse decode path
-//     in this initial port — the caller must pre-condition with
-//     `numKvSharedLayers == 0`. The conformance precondition surfaces this
-//     so a future spec can wire shared-layer routing through the cache list.
 //   - attentionKEqV (some non-sliding layers re-use K as V — no v_proj):
 //     handled by reading `vProj` optionality at runtime.
 //   - Embeddings are pre-scaled by sqrt(hiddenSize).
+//   - KV-shared layers (e2b: trailing `num_kv_shared_layers` layers reuse
+//     the donor layer's K/V) are wired through the donor's
+//     `BatchedRetrievalAttentionKVCache` — the caller passes the SAME
+//     cache instance for each shared layer as the donor occupies in the
+//     `raCaches` list (see `ModelInner.fullyBatchedSparseForward`). The
+//     shared layer computes Q only and runs sparse attend against the
+//     donor's already-written K/V, RoPE'ing Q at the donor's pre-update
+//     offset (mirrors the dense path's `donorOffset`).
+//   - MoE FFN blocks (`experts` / `router` non-nil) pass through the
+//     existing dense expert-routing branch in `Gemma4TransformerBlock`
+//     — sparse only affects attention; expert routing is orthogonal.
 
 import Foundation
 import MLX
@@ -27,9 +33,8 @@ import MLXNN
 
 extension Gemma4Attention {
 
-    /// Batched sparse forward for a single decode step on a Gemma 4 attention
-    /// layer (sliding OR global). RoPE is selected per layer at init, so the
-    /// same call site handles both attention kinds.
+    /// Batched sparse forward for a donor (own-cache) layer.
+    /// Selects sliding OR global at init; same call site handles both.
     public func fullyBatchedSparseForward(
         _ x: MLXArray,
         raCache: BatchedRetrievalAttentionKVCache
@@ -96,41 +101,113 @@ extension Gemma4Attention {
         }
         return oProj(output.transposed(0, 2, 1, 3).reshaped(B, L, -1))
     }
+
+    /// KV-shared variant: compute Q only, run sparse attend against the
+    /// donor's cache (which already wrote its K/V this step). RoPE for Q
+    /// uses the donor's pre-update offset — mirrors the dense
+    /// `useSharedKV: true` branch in `Gemma4Attention.callAsFunction`.
+    ///
+    /// Caller contract: `raCache` is the same instance the donor layer
+    /// just wrote to; `donorPreUpdateOffset` is the offset captured BEFORE
+    /// the donor's `cache.update` ran (otherwise Q is RoPE'd at the wrong
+    /// position).
+    public func fullyBatchedSparseSharedForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache,
+        donorPreUpdateOffset: Int
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+
+        // Compute Q only; K/V already live in donor's cache.
+        var queries = qProj(x).reshaped(B, L, nHeads, -1)
+        queries = qNorm(queries).transposed(0, 2, 1, 3)
+        queries = rope(queries, offset: donorPreUpdateOffset)
+
+        let output: MLXArray
+        if L == 1 && raCache.isSparseEligible {
+            output = raCache.sparseAttend(queries: queries, scale: scale)
+        } else {
+            // L > 1 prefill or dense-band fallback — read donor's full K/V
+            // and run plain SDPA. Matches the donor branch's fallback path.
+            let cache = raCache.inner
+            let (k, v, mask) = cache.getCachedWithMask()
+            output = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: k, values: v,
+                scale: scale, mask: .array(mask))
+        }
+        return oProj(output.transposed(0, 2, 1, 3).reshaped(B, L, -1))
+    }
 }
 
 extension Gemma4TransformerBlock {
 
     /// Sparse forward over Gemma 4's pre/post norm + rmsNormResidual fusion.
-    /// MoE / PLE / per-layer scalar are preserved exactly as in the dense
-    /// `callAsFunction`. KV-shared layers are not supported on this path —
-    /// caller must skip them (see ModelInner precondition).
+    /// `donorPreUpdateOffset` is `nil` for donor layers (this layer owns
+    /// its cache) and `Some(offset)` for KV-shared layers (caller captured
+    /// the donor's offset before the donor's attention ran).
+    /// `mlp` MoE expert routing is preserved exactly as in the dense path.
     public func fullyBatchedSparseForward(
         _ x: MLXArray,
         raCache: BatchedRetrievalAttentionKVCache,
-        perLayerInput: MLXArray? = nil
+        perLayerInput: MLXArray? = nil,
+        donorPreUpdateOffset: Int? = nil
     ) -> MLXArray {
         let inputNorm = inputLayerNorm(x)
-        let attnOut = selfAttention.fullyBatchedSparseForward(
-            inputNorm, raCache: raCache)
+        let attnOut: MLXArray
+        if let offset = donorPreUpdateOffset {
+            attnOut = selfAttention.fullyBatchedSparseSharedForward(
+                inputNorm, raCache: raCache, donorPreUpdateOffset: offset)
+        } else {
+            attnOut = selfAttention.fullyBatchedSparseForward(
+                inputNorm, raCache: raCache)
+        }
         var h = MLXFast.rmsNormResidual(
             attnOut, residual: x,
             weight: postAttentionLayerNorm.weight,
             eps: postAttentionLayerNorm.eps)
 
-        // FFN — shared MLP path only. The MoE expert-routing code lives in
-        // the dense `callAsFunction` and uses a fileprivate top-k helper
-        // (`gemma4TopK`) that is not available from this extension file.
-        // Sparse decode on MoE Gemma 4 checkpoints would need the same
-        // routing wired in; until then this extension preconditions on
-        // non-MoE configs (synthetic smoke uses dense FFN).
-        precondition(experts == nil && router == nil,
-            "Gemma4 batched sparse decode does not yet support MoE blocks")
-        let preFFNNorm = preFeedforwardLayerNorm(h)
-        let ffnOut = sharedMLP(preFFNNorm)
-        h = MLXFast.rmsNormResidual(
-            ffnOut, residual: h,
-            weight: postFeedforwardLayerNorm.weight,
-            eps: postFeedforwardLayerNorm.eps)
+        // FFN. MoE checkpoints route through the experts + shared-MLP fork;
+        // dense checkpoints take the single shared-MLP branch. Expert
+        // routing is orthogonal to sparse attention (lives in `mlp`-style
+        // submodules, not the attention step) — mirrors Qwen3MoE+Sparse.
+        if let experts, let router,
+           let postNorm1 = postFeedforwardLayerNorm1,
+           let preNorm2 = preFeedforwardLayerNorm2,
+           let postNorm2 = postFeedforwardLayerNorm2
+        {
+            // MoE path — pre/post norms wrap both the shared MLP and the
+            // expert MoE branch, then fuse via add.
+            let preFFNNorm = preFeedforwardLayerNorm(h)
+            var h1 = sharedMLP(preFFNNorm)
+            h1 = postNorm1(h1)
+
+            // Route: router gets h (pre-norm), experts get norm2(h).
+            let routerLogits = router(h)
+            let (topKLogits, topKIndices) = gemma4TopKSparse(
+                routerLogits, k: topKExperts, axis: -1)
+            let stopIndices = MLX.stopGradient(topKIndices)
+            var expertWeights = softmax(topKLogits, axis: -1, precise: true)
+            expertWeights = expertWeights * router.perExpertScale[topKIndices]
+            let preFFNNorm2 = preNorm2(h)
+            var h2 = experts(preFFNNorm2, stopIndices)
+            h2 = h2 * expandedDimensions(expertWeights, axis: -1)
+            h2 = h2.sum(axis: -2)
+            h2 = postNorm2(h2)
+
+            let ffnOut = h1 + h2
+            h = MLXFast.rmsNormResidual(
+                ffnOut, residual: h,
+                weight: postFeedforwardLayerNorm.weight,
+                eps: postFeedforwardLayerNorm.eps)
+        } else {
+            let preFFNNorm = preFeedforwardLayerNorm(h)
+            let ffnOut = sharedMLP(preFFNNorm)
+            h = MLXFast.rmsNormResidual(
+                ffnOut, residual: h,
+                weight: postFeedforwardLayerNorm.weight,
+                eps: postFeedforwardLayerNorm.eps)
+        }
 
         // Per-Layer Embeddings (PLE) gate + projection.
         if let gate = perLayerInputGate,
@@ -157,22 +234,34 @@ private let compiledGeluMulSparse: @Sendable (MLXArray, MLXArray) -> MLXArray =
         geluApproximate(gate) * x
     }
 
+/// Local mirror of `gemma4TopK` (fileprivate to Gemma4.swift). Pure
+/// argPartition-based top-k — duplicated here to keep this extension
+/// additive (no source-file edits).
+private func gemma4TopKSparse(
+    _ a: MLXArray, k: Int, axis: Int = -1
+) -> (values: MLXArray, indices: MLXArray) {
+    let partitionedIndices = argPartition(a, kth: -k, axis: axis)
+    let topKIndices = partitionedIndices[.ellipsis, (-k)...]
+    let topKValues = takeAlong(a, topKIndices, axis: axis)
+    return (topKValues, topKIndices)
+}
+
 extension Gemma4ModelInner {
 
     /// Per-layer sparse forward. Caller is responsible for:
     ///   - Building one `BatchedRetrievalAttentionKVCache` per layer whose
     ///     `inner.keys` shape matches the layer's K (sliding vs global K-shape).
-    ///   - Configuring `numKvSharedLayers == 0` (KV-shared layers are not
-    ///     wired on this path yet — they would need shared-K routing through
-    ///     the cache list, which is a future spec).
+    ///   - For KV-shared layers, the entry at index `j` in `raCaches` MUST be
+    ///     the SAME `BatchedRetrievalAttentionKVCache` instance as the donor
+    ///     layer's entry (`raCaches[previousKVs[j]] === raCaches[j]`). This
+    ///     mirrors how the dense path keys all shared layers off the donor's
+    ///     KV cache via `previousKVs`.
     public func fullyBatchedSparseForward(
         _ inputs: MLXArray,
         raCaches: [BatchedRetrievalAttentionKVCache]
     ) -> MLXArray {
         precondition(raCaches.count == layers.count,
             "raCaches count (\(raCaches.count)) must match layers count (\(layers.count))")
-        precondition(config.numKvSharedLayers == 0,
-            "Gemma4 batched sparse decode does not yet support KV-shared layers")
 
         var h = embedTokens(inputs)
         // sqrt(hiddenSize) embedding scale.
@@ -198,10 +287,36 @@ extension Gemma4ModelInner {
             perLayerInputs = pli
         }
 
+        // Per-layer donor-offset capture. For each donor layer we record
+        // `raCaches[i].inner.offsets[0]` BEFORE its attention call so any
+        // downstream shared layer can RoPE its Q at the same position the
+        // donor used. (Mirrors `donorPreUpdateOffsets[i]` in the dense
+        // path.) Defaults to 0; only donors write into this map.
+        var donorPreUpdateOffsets = [Int](repeating: 0, count: layers.count)
+
         for (i, layer) in layers.enumerated() {
             let pli = perLayerInputs.map { $0[0..., 0..., i, 0...] }
-            h = layer.fullyBatchedSparseForward(
-                h, raCache: raCaches[i], perLayerInput: pli)
+            let donorIdx = previousKVs[i]
+            let isShared = donorIdx != i
+
+            if isShared {
+                // Shared layer: reuse the donor's cache + donor's pre-update
+                // offset for Q RoPE. The donor must have already run — this
+                // is true because layer order is the donor index < shared
+                // index by construction of `previousKVs` in the dense path.
+                let donorOffset = donorPreUpdateOffsets[donorIdx]
+                h = layer.fullyBatchedSparseForward(
+                    h, raCache: raCaches[donorIdx],
+                    perLayerInput: pli,
+                    donorPreUpdateOffset: donorOffset)
+            } else {
+                // Donor: capture the cache's offset BEFORE running attention,
+                // then run as normal. The cache's offset is identical across
+                // active slots in the rectangular-T decode case.
+                donorPreUpdateOffsets[i] = raCaches[i].inner.offsets[0]
+                h = layer.fullyBatchedSparseForward(
+                    h, raCache: raCaches[i], perLayerInput: pli)
+            }
         }
         return norm(h)
     }

--- a/Libraries/MLXLLM/Models/Llama+Sparse.swift
+++ b/Libraries/MLXLLM/Models/Llama+Sparse.swift
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// Batched sparse decode hooks for Llama (and Mistral, which shares the
+// model type). Mirrors Qwen2 — no Q/K norm, simpler than Qwen3.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+extension LlamaAttention {
+
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache,
+        layerIndex: Int
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+        let cache = raCache.inner
+
+        var queries = wq(x)
+        var keys = wk(x)
+        var values = wv(x)
+
+        queries = queries.reshaped(B, L, args.attentionHeads, -1).transposed(0, 2, 1, 3)
+        keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
+        values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
+
+        // RoPE + cache update — RoPELayer supports `(x, offset: Int)`.
+        let allSameOffset = cache.offsets[0 ..< cache.active]
+            .allSatisfy { $0 == cache.offsets[0] }
+        let preUpdateK: MLXArray
+        if allSameOffset {
+            let offset = cache.offsets[0]
+            queries = rope(queries, offset: offset)
+            keys = rope(keys, offset: offset)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        } else {
+            let qSlices = split(queries, parts: B, axis: 0)
+            let kSlices = split(keys, parts: B, axis: 0)
+            var rotQ = [MLXArray]()
+            var rotK = [MLXArray]()
+            rotQ.reserveCapacity(B)
+            rotK.reserveCapacity(B)
+            for i in 0 ..< B {
+                let off = cache.offsets[i]
+                rotQ.append(rope(qSlices[i], offset: off))
+                rotK.append(rope(kSlices[i], offset: off))
+            }
+            queries = concatenated(rotQ, axis: 0)
+            keys = concatenated(rotK, axis: 0)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        }
+
+        raCache.updateIndex(newKeys: preUpdateK)
+
+        let output: MLXArray
+        if L == 1 && raCache.isSparseEligible {
+            output = raCache.sparseAttend(queries: queries, scale: scale)
+        } else {
+            let (k, v, mask) = cache.getCachedWithMask()
+            output = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: k, values: v,
+                scale: scale, mask: .array(mask))
+        }
+        return wo(output.transposed(0, 2, 1, 3).reshaped(B, L, -1))
+    }
+}
+
+extension LlamaTransformerBlock {
+
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache,
+        layerIndex: Int
+    ) -> MLXArray {
+        var r = attention.fullyBatchedSparseForward(
+            inputLayerNorm(x), raCache: raCache, layerIndex: layerIndex)
+        let h = x + r
+        r = mlp(postAttentionLayerNorm(h))
+        return h + r
+    }
+}
+
+extension LlamaModelInner {
+
+    public func fullyBatchedSparseForward(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        precondition(raCaches.count == layers.count,
+            "raCaches count must match layers count")
+        var h = embedTokens(inputs)
+        for (i, layer) in layers.enumerated() {
+            h = layer.fullyBatchedSparseForward(h, raCache: raCaches[i], layerIndex: i)
+        }
+        return norm(h)
+    }
+}
+
+extension LlamaModel: BatchedSparseLLM {
+
+    public func fullyBatchedSparseDecode(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        var out = model.fullyBatchedSparseForward(inputs, raCaches: raCaches)
+        if let lmHead {
+            out = lmHead(out)
+        } else {
+            out = model.embedTokens.asLinear(out)
+        }
+        return out
+    }
+}

--- a/Libraries/MLXLLM/Models/Mistral3+Sparse.swift
+++ b/Libraries/MLXLLM/Models/Mistral3+Sparse.swift
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// BatchedSparseLLM conformance for Mistral3TextModel. Pairs with the
+// shared `Mistral3.{Attention, TransformerBlock, ModelInner}.fullyBatchedSparseForward`
+// hooks in MLXLMCommon/Models/Mistral3+Sparse.swift.
+
+import Foundation
+import MLX
+import MLXLMCommon
+
+extension Mistral3TextModel: BatchedSparseLLM {
+
+    /// Single-step batched sparse decode. Per-layer
+    /// `BatchedRetrievalAttentionKVCache` list must match `model.layers.count`.
+    /// Llama-4 scaling and sliding-vs-full layer dispatch are handled inside
+    /// the shared `Mistral3.ModelInner` extension.
+    public func fullyBatchedSparseDecode(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        let out = model.fullyBatchedSparseForward(inputs, raCaches: raCaches)
+        if let lmHead {
+            return lmHead(out)
+        } else {
+            return model.embedTokens.asLinear(out)
+        }
+    }
+}

--- a/Libraries/MLXLLM/Models/NemotronH+Sparse.swift
+++ b/Libraries/MLXLLM/Models/NemotronH+Sparse.swift
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// Batched sparse decode hooks for the NemotronH hybrid family. NemotronH
+// interleaves four block kinds via the `hybridOverridePattern` string:
+//   - 'M' → Mamba2 mixer (selective-SSM; per-slot conv + recurrent state)
+//   - '*' → attention (RoPE-free, no Q/K norm — Llama-style stripped)
+//   - '-' → MLP (no cache)
+//   - 'E' → MoE (no cache)
+//
+// Sparse hookup mirrors `Qwen35+Sparse.swift`:
+//   - Attention layers run through `BatchedRetrievalAttentionKVCache`
+//     (`.sparseAttention` slot). NemotronH's attention is the simplest
+//     possible — no RoPE, no Q/K norm — so the sparse path is a strict
+//     subset of Llama+Sparse.
+//   - Mamba2 layers run through a batched `ssmUpdate` against a
+//     `BatchedMambaCache`. `BatchedMambaCache.recDtype` is set to the
+//     model's compute dtype so NemotronH's input-dtype SSM state contract
+//     (the kernel returns state in input dtype, not fp32 as GDN does) is
+//     preserved through writeback.
+//   - MLP / MoE blocks pass through unchanged — sparse only touches the
+//     attention SDPA step; expert routing is orthogonal.
+//
+// Per-layer cache list mirrors the dense `newCache` shape: ONE entry per
+// mamba OR attention block (mlp / moe blocks contribute no cache, so they
+// don't advance the cache index). `fullyBatchedSparseDecode` walks
+// `backbone.layers` and uses a running `cacheIdx` that only advances on
+// mamba/attention.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+extension NemotronHAttention {
+
+    /// Llama-style batched sparse forward — no RoPE, no Q/K norm.
+    /// Mirrors `LlamaAttention.fullyBatchedSparseForward` minus the
+    /// RoPE rotations.
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+        let cache = raCache.inner
+
+        let queries = wq(x).reshaped(B, L, numHeads, headDim).transposed(0, 2, 1, 3)
+        let keys = wk(x).reshaped(B, L, numKeyValueHeads, headDim).transposed(0, 2, 1, 3)
+        let values = wv(x).reshaped(B, L, numKeyValueHeads, headDim).transposed(0, 2, 1, 3)
+
+        // No RoPE on NemotronH attention; cache update + index update sit
+        // directly on the projected K / V.
+        cache.update(newKeys: keys, newValues: values)
+        raCache.updateIndex(newKeys: keys)
+
+        let output: MLXArray
+        if L == 1 && raCache.isSparseEligible {
+            output = raCache.sparseAttend(queries: queries, scale: scale)
+        } else {
+            let (k, v, mask) = cache.getCachedWithMask()
+            output = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: k, values: v,
+                scale: scale, mask: .array(mask))
+        }
+        return wo(output.transposed(0, 2, 1, 3).reshaped(B, L, -1))
+    }
+}
+
+extension NemotronHMamba2Mixer {
+
+    /// Batched single-step Mamba2 forward against `BatchedMambaCache`. Reads
+    /// the live conv + recurrent state slices for the active prefix, runs
+    /// the (already-B-aware) `ssmUpdate` kernel, and writes back.
+    /// `BatchedMambaCache.recDtype` should match the model's compute dtype
+    /// so the writeback round-trip is dtype-stable.
+    public func fullyBatchedForward(
+        _ inputs: MLXArray, cache: BatchedMambaCache
+    ) -> MLXArray {
+        let B = inputs.dim(0)
+        precondition(B == cache.active,
+            "NemotronH Mamba2 fullyBatchedForward: input B (\(B)) ≠ cache.active (\(cache.active))")
+
+        let projected = inProj(inputs)
+        let splits = split(
+            projected, indices: [intermediateSize, intermediateSize + convDim], axis: -1)
+        let gate = splits[0]
+        let convInput = splits[1]
+        let dt = splits[2]
+
+        // Slice the live conv + recurrent state. Views over the cache —
+        // safe to mutate only via `cache.writeback(...)`.
+        let (convStateSlice, recStateSlice) = cache.slice(active: B)
+
+        // Pre-pend the rolling conv window, then convolve.
+        let padded = concatenated([convStateSlice, convInput], axis: 1)
+        let end = padded.dim(1)
+        let start = max(0, end - (convKernelSize - 1))
+        let newConvState = padded[0..., start ..< end, 0...].contiguous()
+        let convOutput = silu(conv1d(padded))
+
+        let convSplits = split(
+            convOutput,
+            indices: [intermediateSize, intermediateSize + numGroups * ssmStateSize],
+            axis: -1)
+        var hidden = convSplits[0]
+        var bMat = convSplits[1]
+        var cMat = convSplits[2]
+
+        hidden = hidden.reshaped([hidden.dim(0), hidden.dim(1), numHeads, headDim])
+        bMat = bMat.reshaped([bMat.dim(0), bMat.dim(1), numGroups, ssmStateSize])
+        cMat = cMat.reshaped([cMat.dim(0), cMat.dim(1), numGroups, ssmStateSize])
+
+        let dtArray = dt.reshaped([dt.dim(0), dt.dim(1), numHeads])
+
+        // Cast the cached recurrent state to the model's compute dtype so
+        // `ssmUpdate`'s kernel-template `T` (which it reads from the input
+        // dtype) matches. `BatchedMambaCache.writeback` casts back to
+        // `recDtype` on commit.
+        let inputDtype = inputs.dtype
+        let prevState: MLXArray? =
+            recStateSlice.dtype == inputDtype
+                ? recStateSlice : recStateSlice.asType(inputDtype)
+
+        let (y, nextState) = ssmUpdate(
+            hiddenStates: hidden,
+            ALog: aLog,
+            B: bMat,
+            C: cMat,
+            D: D,
+            dt: dtArray,
+            dtBias: dtBias,
+            state: prevState,
+            timeStepLimit: timeStepLimit,
+            mask: nil  // single-step decode (S == 1) — no SSM mask needed
+        )
+
+        cache.writeback(conv: newConvState, rec: nextState)
+
+        let flattenedY = y.flattened(start: 2)
+        return outProj(norm(flattenedY, gate: gate))
+    }
+}
+
+extension NemotronHAttention {
+
+    /// Dense batched forward against a plain `BatchedKVCache`. Used by the
+    /// `BatchedHybridLLM` parent surface (sparse extension's parent
+    /// protocol requires a dense path too).
+    public func fullyBatchedForward(
+        _ x: MLXArray, cache: BatchedKVCache
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+
+        let queries = wq(x).reshaped(B, L, numHeads, headDim).transposed(0, 2, 1, 3)
+        let keys = wk(x).reshaped(B, L, numKeyValueHeads, headDim).transposed(0, 2, 1, 3)
+        let values = wv(x).reshaped(B, L, numKeyValueHeads, headDim).transposed(0, 2, 1, 3)
+
+        cache.update(newKeys: keys, newValues: values)
+        let (k, v, mask) = cache.getCachedWithMask()
+        let output = MLXFast.scaledDotProductAttention(
+            queries: queries, keys: k, values: v,
+            scale: scale, mask: .array(mask))
+        return wo(output.transposed(0, 2, 1, 3).reshaped(B, L, -1))
+    }
+}
+
+extension NemotronHBlock {
+
+    /// Per-block-type batched dispatch — handles both sparse (when the
+    /// slot is `.sparseAttention`) and dense (`.attention`). `cacheSlot`
+    /// is `nil` for mlp/moe blocks (no cache).
+    func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        cacheSlot: BatchedHybridCache.BatchedLayerCache?
+    ) -> MLXArray {
+        let hidden = norm(x)
+        let output: MLXArray
+
+        switch (blockType, cacheSlot) {
+        case (.attention, .sparseAttention(let raCache)?):
+            guard let attn = mixer as? NemotronHAttention else {
+                fatalError("NemotronH attention block: mixer is not NemotronHAttention")
+            }
+            output = attn.fullyBatchedSparseForward(hidden, raCache: raCache)
+
+        case (.attention, .attention(let kv)?):
+            // Dense-band path — used by `fullyBatchedDecode` (the parent
+            // `BatchedHybridLLM` surface).
+            guard let attn = mixer as? NemotronHAttention else {
+                fatalError("NemotronH attention block: mixer is not NemotronHAttention")
+            }
+            output = attn.fullyBatchedForward(hidden, cache: kv)
+
+        case (.mamba, .gdn(let mambaCache)?):
+            guard let mamba = mixer as? NemotronHMamba2Mixer else {
+                fatalError("NemotronH mamba block: mixer is not NemotronHMamba2Mixer")
+            }
+            output = mamba.fullyBatchedForward(hidden, cache: mambaCache)
+
+        case (.mlp, nil), (.moe, nil):
+            // MLP / MoE: no cache, just pass through the unary mixer.
+            guard let m = mixer as? UnaryLayer else {
+                fatalError("NemotronH mlp/moe block: mixer is not UnaryLayer")
+            }
+            output = m(hidden)
+
+        default:
+            fatalError(
+                "NemotronH+Sparse: block/cache mismatch (blockType=\(blockType), cacheSlot present? \(cacheSlot != nil))")
+        }
+
+        return x + output
+    }
+}
+
+extension NemotronHBackbone {
+
+    /// Per-layer batched sparse forward. Walks every block; advances the
+    /// hybrid cache index only for mamba/attention blocks (mlp/moe carry
+    /// no cache slot, mirroring `newCache`).
+    func fullyBatchedSparseForward(
+        _ inputs: MLXArray,
+        caches: BatchedHybridCache
+    ) -> MLXArray {
+        var hidden = embeddings(inputs)
+        var cacheIdx = 0
+
+        for layer in layers {
+            let slot: BatchedHybridCache.BatchedLayerCache?
+            switch layer.blockType {
+            case .mamba, .attention:
+                precondition(cacheIdx < caches.layers.count,
+                    "NemotronH+Sparse: hybrid cache too small for layer pattern")
+                slot = caches.layers[cacheIdx]
+                cacheIdx += 1
+            case .mlp, .moe:
+                slot = nil
+            }
+            hidden = layer.fullyBatchedSparseForward(hidden, cacheSlot: slot)
+        }
+        precondition(cacheIdx == caches.layers.count,
+            "NemotronH+Sparse: cache had \(caches.layers.count) slots, but layer pattern consumed only \(cacheIdx)")
+        return normF(hidden)
+    }
+}
+
+extension NemotronHModel: BatchedHybridLLM {
+
+    /// Dense batched decode — required by `BatchedHybridSparseLLM`'s
+    /// parent protocol. Reuses `fullyBatchedSparseForward` since per-block
+    /// dispatch already handles both `.attention` and `.sparseAttention`.
+    public func fullyBatchedDecode(
+        _ inputs: MLXArray, caches: BatchedHybridCache
+    ) -> MLXArray {
+        var out = backbone.fullyBatchedSparseForward(inputs, caches: caches)
+        if let lmHead {
+            out = lmHead(out)
+        } else {
+            out = backbone.embeddings.asLinear(out)
+        }
+        return out
+    }
+
+    /// Build a dense `BatchedHybridCache` — `.attention` + `.gdn` slots,
+    /// one per mamba/attention block. mlp/moe blocks contribute no slot.
+    public func newBatchedHybridCache(
+        maxBatch: Int, parameters: GenerateParameters?
+    ) -> BatchedHybridCache {
+        let cfg = configuration
+        let pattern = Array(cfg.hybridOverridePattern)
+
+        let mambaIntermediate = cfg.mambaNumHeads * cfg.mambaHeadDim
+        let mambaConvDim =
+            mambaIntermediate + 2 * cfg.nGroups * cfg.ssmStateSize
+        let mambaKernelMinusOne = cfg.convKernel - 1
+        let attnHeadDim = cfg.headDim ?? (cfg.hiddenSize / cfg.numAttentionHeads)
+        let maxSeq = parameters?.maxKVSize ?? 2048
+        let modelDtype: DType = backbone.embeddings.weight.dtype
+
+        var slots: [BatchedHybridCache.BatchedLayerCache] = []
+        for ch in pattern {
+            switch NemotronHBlockType(from: ch) {
+            case .mamba:
+                slots.append(.gdn(BatchedMambaCache(
+                    maxBatch: maxBatch,
+                    kernelMinusOne: mambaKernelMinusOne,
+                    convDim: mambaConvDim,
+                    Hv: cfg.mambaNumHeads,
+                    Dv: cfg.mambaHeadDim,
+                    Dk: cfg.ssmStateSize,
+                    dtype: modelDtype,
+                    recDtype: modelDtype)))
+            case .attention:
+                slots.append(.attention(BatchedKVCache(
+                    maxBatch: maxBatch,
+                    kvHeads: cfg.numKeyValueHeads,
+                    headDim: attnHeadDim,
+                    maxSeq: maxSeq,
+                    dtype: modelDtype)))
+            case .mlp, .moe:
+                continue
+            }
+        }
+        return BatchedHybridCache(layers: slots)
+    }
+}
+
+extension NemotronHModel: BatchedHybridSparseLLM {
+
+    public func fullyBatchedSparseDecode(
+        _ inputs: MLXArray, caches: BatchedHybridCache
+    ) -> MLXArray {
+        var out = backbone.fullyBatchedSparseForward(inputs, caches: caches)
+        if let lmHead {
+            out = lmHead(out)
+        } else {
+            out = backbone.embeddings.asLinear(out)
+        }
+        return out
+    }
+
+    /// Build a `BatchedHybridCache` for NemotronH:
+    ///   - Mamba blocks → `.gdn(BatchedMambaCache)`.
+    ///   - Attention blocks → `.sparseAttention(BatchedRetrievalAttentionKVCache)`.
+    ///   - mlp / moe blocks contribute NO slot — matches `newCache`'s shape.
+    ///
+    /// `recDtype` of each `BatchedMambaCache` is set to the model's compute
+    /// dtype (bf16 default) so the input-dtype SSM state contract holds.
+    public func newBatchedHybridSparseCache(
+        maxBatch: Int,
+        parameters: GenerateParameters?,
+        raConfig: RetrievalAttentionConfig
+    ) -> BatchedHybridCache {
+        let cfg = configuration
+        let pattern = Array(cfg.hybridOverridePattern)
+
+        // NemotronH Mamba2 cache shape — derived from the dense
+        // `NemotronHMamba2Mixer.init` plumbing.
+        let mambaIntermediate = cfg.mambaNumHeads * cfg.mambaHeadDim
+        let mambaConvDim =
+            mambaIntermediate + 2 * cfg.nGroups * cfg.ssmStateSize
+        let mambaKernelMinusOne = cfg.convKernel - 1
+
+        // Attention shape.
+        let attnHeadDim = cfg.headDim ?? (cfg.hiddenSize / cfg.numAttentionHeads)
+        let maxSeq = parameters?.maxKVSize ?? 2048
+
+        // Count attention blocks up front so each
+        // `BatchedRetrievalAttentionKVCache` knows its
+        // total-attention-layer-count for dense-band predicates.
+        let attentionTotal = pattern.reduce(0) { acc, ch in
+            acc + (NemotronHBlockType(from: ch) == .attention ? 1 : 0)
+        }
+        var attentionIdx = 0
+
+        // Detect compute dtype from a model parameter sample. NemotronH's
+        // `castPredicate` keeps `e_score_correction_bias` + `A_log` in fp32,
+        // so we deliberately read a different parameter (embeddings) for
+        // the model-wide compute dtype.
+        let modelDtype: DType = backbone.embeddings.weight.dtype
+
+        var slots: [BatchedHybridCache.BatchedLayerCache] = []
+        slots.reserveCapacity(attentionTotal + pattern.filter { $0 == "M" }.count)
+        for ch in pattern {
+            switch NemotronHBlockType(from: ch) {
+            case .mamba:
+                slots.append(.gdn(BatchedMambaCache(
+                    maxBatch: maxBatch,
+                    kernelMinusOne: mambaKernelMinusOne,
+                    convDim: mambaConvDim,
+                    Hv: cfg.mambaNumHeads,
+                    Dv: cfg.mambaHeadDim,
+                    Dk: cfg.ssmStateSize,
+                    dtype: modelDtype,
+                    recDtype: modelDtype)))
+            case .attention:
+                let inner = BatchedKVCache(
+                    maxBatch: maxBatch,
+                    kvHeads: cfg.numKeyValueHeads,
+                    headDim: attnHeadDim,
+                    maxSeq: maxSeq,
+                    dtype: modelDtype)
+                let raCache = BatchedRetrievalAttentionKVCache(
+                    inner: inner,
+                    B: maxBatch,
+                    nKVHeads: cfg.numKeyValueHeads,
+                    dHead: attnHeadDim,
+                    layerIdx: attentionIdx,
+                    totalLayers: attentionTotal,
+                    raConfig: raConfig)
+                attentionIdx += 1
+                slots.append(.sparseAttention(raCache))
+            case .mlp, .moe:
+                // No cache slot — mirror `newCache`.
+                continue
+            }
+        }
+        return BatchedHybridCache(layers: slots)
+    }
+}

--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -20,7 +20,11 @@ private enum NemotronHDefaults {
 
 // MARK: - Block Type
 
-private enum NemotronHBlockType {
+// Visibility note: widened from `private` to default-internal alongside
+// `NemotronHBlock` (which carries a `blockType` property) so the
+// `NemotronH+Sparse` extension can pattern-match block kinds for
+// per-block-type sparse dispatch.
+enum NemotronHBlockType {
     case mamba  // "M"
     case attention  // "*"
     case mlp  // "-"
@@ -59,7 +63,10 @@ private func relu2(_ x: MLXArray) -> MLXArray {
 
 // MARK: - MambaRMSNormGated
 
-private class NemotronHRMSNormGated: Module {
+// Visibility note: widened from `private` to default-internal so it can
+// appear as a property type on the (now default-internal) Mamba2 mixer
+// — required for the `NemotronH+Sparse` extension to extend the mixer.
+class NemotronHRMSNormGated: Module {
     @ParameterInfo(key: "weight") var weight: MLXArray
     let eps: Float
     let groupSize: Int
@@ -98,7 +105,10 @@ private class NemotronHRMSNormGated: Module {
 
 // MARK: - Mamba2Mixer
 
-private class NemotronHMamba2Mixer: Module, NemotronHMixer {
+// Visibility note: widened from `private` to default-internal so the
+// `NemotronH+Sparse` extension can add a batched Mamba2 forward against
+// `BatchedMambaCache` for the hybrid sparse decode path.
+class NemotronHMamba2Mixer: Module, NemotronHMixer {
     let numHeads: Int
     let hiddenSize: Int
     let ssmStateSize: Int
@@ -291,7 +301,10 @@ private class NemotronHMamba2Mixer: Module, NemotronHMixer {
 
 // MARK: - Attention
 
-private class NemotronHAttention: Module, NemotronHMixer {
+// Visibility note: widened from `private` to default-internal so the
+// `NemotronH+Sparse` extension (separate file) can extend this class with a
+// `fullyBatchedSparseForward(...)` overload. No external API surface change.
+class NemotronHAttention: Module, NemotronHMixer {
     let args: NemotronHConfiguration
     let scale: Float
     let numHeads: Int
@@ -589,7 +602,11 @@ private class NemotronHMoE: Module, UnaryLayer, NemotronHMixer {
 
 // MARK: - Decoder Block
 
-private class NemotronHBlock: Module {
+// Visibility note: widened from `private` to default-internal so the
+// `NemotronH+Sparse` extension can extend this with per-block-type sparse
+// dispatch. Mamba blocks stay dense (no sparse concept for fixed-size SSM
+// state); attention blocks route through `BatchedRetrievalAttentionKVCache`.
+class NemotronHBlock: Module {
     let blockType: NemotronHBlockType
 
     @ModuleInfo(key: "norm") var norm: RMSNorm
@@ -636,7 +653,11 @@ private class NemotronHBlock: Module {
 
 // MARK: - Backbone (matches Python's NemotronHModel which is stored as self.backbone)
 
-private class NemotronHBackbone: Module {
+// Visibility note: widened from `private` to default-internal so the
+// `NemotronH+Sparse` extension can drive the per-layer batched sparse
+// forward loop from the backbone level (mirrors Qwen35TextModelInner's
+// sparse-aware extension).
+class NemotronHBackbone: Module {
     let args: NemotronHConfiguration
 
     @ModuleInfo(key: "embeddings") var embeddings: Embedding
@@ -750,7 +771,10 @@ public class NemotronHModel: Module, LLMModel, KVCacheDimensionProvider, LoRAMod
     public let vocabularySize: Int
     public let kvHeads: [Int]
 
-    @ModuleInfo(key: "backbone") private var backbone: NemotronHBackbone
+    // Visibility note: widened from `private` to default-internal so the
+    // `NemotronH+Sparse` extension can reach the backbone's layer list to
+    // drive per-layer sparse dispatch + build the per-layer cache list.
+    @ModuleInfo(key: "backbone") var backbone: NemotronHBackbone
     let configuration: NemotronHConfiguration
 
     @ModuleInfo(key: "lm_head") var lmHead: Linear?

--- a/Libraries/MLXLLM/Models/Phi3+Sparse.swift
+++ b/Libraries/MLXLLM/Models/Phi3+Sparse.swift
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// Batched sparse decode hooks for Phi3. Phi3 specifics:
+//   - Fused qkv_proj split via indices (Q | K | V along last dim, with
+//     Q occupying heads*headDim and K/V occupying kvHeads*headDim each).
+//   - partialRotaryFactor baked into `ropeDim` at init time, so the
+//     RoPE layer naturally rotates only the leading `ropeDim` slice.
+//   - LongRoPE (SuScaledRoPE) shares the `RoPELayer` callable surface
+//     with standard RoPE — no special-casing needed.
+//   - No Q/K RMSNorm (Llama-style attention).
+//   - tieWordEmbeddings → lmHead nil → fall back to embedTokens.asLinear.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+extension Phi3Attention {
+
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache,
+        layerIndex: Int
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+        let cache = raCache.inner
+
+        let queryPos = heads * headDim
+        let qkv = split(
+            wqkv(x), indices: [queryPos, queryPos + kvHeads * headDim], axis: -1)
+        var queries = qkv[0]
+        var keys = qkv[1]
+        var values = qkv[2]
+
+        queries = queries.reshaped(B, L, args.attentionHeads, -1).transposed(0, 2, 1, 3)
+        keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
+        values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
+
+        let allSameOffset = cache.offsets[0 ..< cache.active]
+            .allSatisfy { $0 == cache.offsets[0] }
+        let preUpdateK: MLXArray
+        if allSameOffset {
+            let offset = cache.offsets[0]
+            queries = rope(queries, offset: offset)
+            keys = rope(keys, offset: offset)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        } else {
+            let qSlices = split(queries, parts: B, axis: 0)
+            let kSlices = split(keys, parts: B, axis: 0)
+            var rotQ = [MLXArray]()
+            var rotK = [MLXArray]()
+            rotQ.reserveCapacity(B)
+            rotK.reserveCapacity(B)
+            for i in 0 ..< B {
+                let off = cache.offsets[i]
+                rotQ.append(rope(qSlices[i], offset: off))
+                rotK.append(rope(kSlices[i], offset: off))
+            }
+            queries = concatenated(rotQ, axis: 0)
+            keys = concatenated(rotK, axis: 0)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        }
+
+        raCache.updateIndex(newKeys: preUpdateK)
+
+        let output: MLXArray
+        if L == 1 && raCache.isSparseEligible {
+            output = raCache.sparseAttend(queries: queries, scale: scale)
+        } else {
+            let (k, v, mask) = cache.getCachedWithMask()
+            output = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: k, values: v,
+                scale: scale, mask: .array(mask))
+        }
+        return wo(output.transposed(0, 2, 1, 3).reshaped(B, L, -1))
+    }
+}
+
+extension Phi3TransformerBlock {
+
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache,
+        layerIndex: Int
+    ) -> MLXArray {
+        var r = attention.fullyBatchedSparseForward(
+            inputLayerNorm(x), raCache: raCache, layerIndex: layerIndex)
+        let h = x + r
+        r = mlp(postAttentionLayerNorm(h))
+        return h + r
+    }
+}
+
+extension Phi3ModelInner {
+
+    public func fullyBatchedSparseForward(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        precondition(raCaches.count == layers.count,
+            "raCaches count must match layers count")
+        var h = embedTokens(inputs)
+        for (i, layer) in layers.enumerated() {
+            h = layer.fullyBatchedSparseForward(h, raCache: raCaches[i], layerIndex: i)
+        }
+        return norm(h)
+    }
+}
+
+extension Phi3Model: BatchedSparseLLM {
+
+    public func fullyBatchedSparseDecode(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        let out = model.fullyBatchedSparseForward(inputs, raCaches: raCaches)
+        if let lmHead {
+            return lmHead(out)
+        } else {
+            return model.embedTokens.asLinear(out)
+        }
+    }
+}

--- a/Libraries/MLXLLM/Models/Phi3.swift
+++ b/Libraries/MLXLLM/Models/Phi3.swift
@@ -148,7 +148,7 @@ public class Phi3ModelInner: Module {
 
     @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
 
-    fileprivate let layers: [Phi3TransformerBlock]
+    let layers: [Phi3TransformerBlock]
     let norm: RMSNorm
     let args: Phi3Configuration
 

--- a/Libraries/MLXLLM/Models/Qwen2+Sparse.swift
+++ b/Libraries/MLXLLM/Models/Qwen2+Sparse.swift
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// BatchedSparseLLM conformance for Qwen2Model. Pairs with the
+// `Qwen2.{Attention, DecoderLayer, ModelInner}.fullyBatchedSparseForward`
+// hooks in the shared layer stack (MLXLMCommon/Models/Qwen2+Sparse.swift).
+
+import Foundation
+import MLX
+import MLXLMCommon
+
+extension Qwen2Model: BatchedSparseLLM {
+
+    /// Single-step batched sparse decode. The caller is responsible for
+    /// providing a per-layer `BatchedRetrievalAttentionKVCache` list whose
+    /// inner caches have B slots reserved and per-slot offsets that reflect
+    /// completed prefill.
+    public func fullyBatchedSparseDecode(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        var out = model.fullyBatchedSparseForward(inputs, raCaches: raCaches)
+        if let lmHead {
+            out = lmHead(out)
+        } else {
+            out = model.embedTokens.asLinear(out)
+        }
+        return out
+    }
+}

--- a/Libraries/MLXLLM/Models/Qwen3+Sparse.swift
+++ b/Libraries/MLXLLM/Models/Qwen3+Sparse.swift
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// Batched sparse decode hooks for Qwen3. Mirrors Qwen3.fullyBatchedForward
+// but routes through BatchedRetrievalAttentionKVCache.sparseAttend at L=1
+// on sparse-eligible layers. Preserves Qwen3's pre-RoPE q_norm + k_norm
+// ordering (the architectural difference vs Qwen2).
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+extension Qwen3Attention {
+
+    /// Batched sparse forward. Same shape contract as `fullyBatchedForward`
+    /// but takes a `BatchedRetrievalAttentionKVCache` and dispatches to
+    /// sparse SDPA on sparse-eligible decode steps.
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache,
+        layerIndex: Int
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+        let cache = raCache.inner
+
+        // Q/K/V projections.
+        var queries = wq(x)
+        var keys = wk(x)
+        var values = wv(x)
+
+        // q_norm / k_norm on per-head views, THEN transpose.
+        queries = qNorm(queries.reshaped(B, L, args.attentionHeads, -1))
+            .transposed(0, 2, 1, 3)
+        keys = kNorm(keys.reshaped(B, L, args.kvHeads, -1))
+            .transposed(0, 2, 1, 3)
+        values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
+
+        // RoPE + cache update.
+        let allSameOffset = cache.offsets[0 ..< cache.active]
+            .allSatisfy { $0 == cache.offsets[0] }
+        let preUpdateK: MLXArray
+        if allSameOffset {
+            let offset = cache.offsets[0]
+            queries = rope(queries, offset: offset)
+            keys = rope(keys, offset: offset)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        } else {
+            let qSlices = split(queries, parts: B, axis: 0)
+            let kSlices = split(keys, parts: B, axis: 0)
+            var rotQ = [MLXArray]()
+            var rotK = [MLXArray]()
+            rotQ.reserveCapacity(B)
+            rotK.reserveCapacity(B)
+            for i in 0 ..< B {
+                let off = cache.offsets[i]
+                rotQ.append(rope(qSlices[i], offset: off))
+                rotK.append(rope(kSlices[i], offset: off))
+            }
+            queries = concatenated(rotQ, axis: 0)
+            keys = concatenated(rotK, axis: 0)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        }
+
+        raCache.updateIndex(newKeys: preUpdateK)
+
+        let output: MLXArray
+        if L == 1 && raCache.isSparseEligible {
+            output = raCache.sparseAttend(queries: queries, scale: scale)
+        } else {
+            // Dense path — prefill chunk or dense-band layer.
+            let (k, v, mask) = cache.getCachedWithMask()
+            output = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: k, values: v,
+                scale: scale, mask: .array(mask))
+        }
+        return wo(output.transposed(0, 2, 1, 3).reshaped(B, L, -1))
+    }
+}
+
+extension Qwen3TransformerBlock {
+
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache,
+        layerIndex: Int
+    ) -> MLXArray {
+        let normed = inputLayerNorm(x)
+        var r = attention.fullyBatchedSparseForward(
+            normed, raCache: raCache, layerIndex: layerIndex)
+        let h = x + r
+        r = mlp(postAttentionLayerNorm(h))
+        return h + r
+    }
+}
+
+extension Qwen3ModelInner {
+
+    public func fullyBatchedSparseForward(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        precondition(raCaches.count == layers.count,
+            "raCaches count must match layers count")
+        var h = embedTokens(inputs)
+        for (i, layer) in layers.enumerated() {
+            h = layer.fullyBatchedSparseForward(h, raCache: raCaches[i], layerIndex: i)
+        }
+        return norm(h)
+    }
+}
+
+extension Qwen3Model: BatchedSparseLLM {
+
+    public func fullyBatchedSparseDecode(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        var out = model.fullyBatchedSparseForward(inputs, raCaches: raCaches)
+        if let lmHead {
+            out = lmHead(out)
+        } else {
+            out = model.embedTokens.asLinear(out)
+        }
+        return out
+    }
+}

--- a/Libraries/MLXLLM/Models/Qwen3.swift
+++ b/Libraries/MLXLLM/Models/Qwen3.swift
@@ -282,7 +282,7 @@ class Qwen3TransformerBlock: Module {
 public class Qwen3ModelInner: Module {
     @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
 
-    fileprivate let layers: [Qwen3TransformerBlock]
+    let layers: [Qwen3TransformerBlock]
     let norm: RMSNorm
 
     public init(_ args: Qwen3Configuration) {

--- a/Libraries/MLXLLM/Models/Qwen35+Sparse.swift
+++ b/Libraries/MLXLLM/Models/Qwen35+Sparse.swift
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// Batched sparse decode hooks for the Qwen 3.5 / Qwen 3.6 hybrid family
+// (attention + GatedDeltaNet). Per-layer-type dispatch routes attention
+// layers through `BatchedRetrievalAttentionKVCache.sparseAttend` at L=1
+// while GDN layers stay on the existing batched GDN path.
+//
+// Conformance lands on `Qwen35TextModel`, which is also the base class
+// for the MoE variant (`Qwen35MoEModel`) — both checkpoints share the
+// same hybrid layer pattern, so this single conformance serves both.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+extension Qwen35Attention {
+
+    /// Batched sparse forward over `BatchedRetrievalAttentionKVCache`.
+    /// Preserves the Qwen 3.5 gated-Q split (q_proj outputs 2× heads —
+    /// queries + gate, then sigmoid-multiplied at the output projection).
+    /// Q/K RMSNorm is applied pre-RoPE on the per-head views.
+    /// `denseMask` is used only on the dense fallback (prefill chunks /
+    /// dense-band layers); sparse decode builds its own per-slot mask.
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache,
+        denseMask: MLXArray
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+        let cache = raCache.inner
+
+        // q_proj outputs 2x heads (queries + gate). Split before the head
+        // reshape so the gate stays at hidden granularity.
+        let qProjOutput = qProj(x)
+        let qSplit = qProjOutput.reshaped(B, L, attentionHeads, -1).split(parts: 2, axis: -1)
+        var queries = qSplit[0]
+        let gate = qSplit[1].reshaped(B, L, -1)
+
+        var keys = kProj(x)
+        var values = vProj(x)
+
+        queries = qNorm(queries).transposed(0, 2, 1, 3)
+        keys = kNorm(keys.reshaped(B, L, kvHeads, -1)).transposed(0, 2, 1, 3)
+        values = values.reshaped(B, L, kvHeads, -1).transposed(0, 2, 1, 3)
+
+        let allSameOffset = cache.offsets[0 ..< cache.active]
+            .allSatisfy { $0 == cache.offsets[0] }
+        let preUpdateK: MLXArray
+        if allSameOffset {
+            let offset = cache.offsets[0]
+            queries = rope(queries, offset: offset)
+            keys = rope(keys, offset: offset)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        } else {
+            let qSlices = MLX.split(queries, parts: B, axis: 0)
+            let kSlices = MLX.split(keys, parts: B, axis: 0)
+            var rotQ = [MLXArray]()
+            var rotK = [MLXArray]()
+            rotQ.reserveCapacity(B)
+            rotK.reserveCapacity(B)
+            for i in 0..<B {
+                let off = cache.offsets[i]
+                rotQ.append(rope(qSlices[i], offset: off))
+                rotK.append(rope(kSlices[i], offset: off))
+            }
+            queries = concatenated(rotQ, axis: 0)
+            keys = concatenated(rotK, axis: 0)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        }
+
+        raCache.updateIndex(newKeys: preUpdateK)
+
+        let output: MLXArray
+        if L == 1 && raCache.isSparseEligible {
+            output = raCache.sparseAttend(queries: queries, scale: scale)
+        } else {
+            let maxOffset = cache.offsets[0..<cache.active].max() ?? 0
+            let allK = cache.keys[..<cache.active, 0..., ..<maxOffset, 0...]
+            let allV = cache.values[..<cache.active, 0..., ..<maxOffset, 0...]
+            output = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: allK, values: allV,
+                scale: scale, mask: .array(denseMask)
+            )
+        }
+        return oProj(sigmoidMultiply(output.transposed(0, 2, 1, 3).reshaped(B, L, -1), gate))
+    }
+}
+
+extension Qwen35DecoderLayer {
+
+    /// Per-layer-type batched sparse forward. Dispatches on `isLinear`:
+    ///   - `(false, .sparseAttention)` → sparse attention path.
+    ///   - `(false, .attention)`       → existing dense batched path
+    ///     (fall-through when the caller mixes plain `.attention` slots in
+    ///     for some attention layers, e.g. dense-band first/last layers).
+    ///   - `(true,  .gdn)`             → existing batched GDN path.
+    func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        layerCache: BatchedHybridCache.BatchedLayerCache,
+        attnMask: MLXArray
+    ) -> MLXArray {
+        let r: MLXArray
+        switch (isLinear, layerCache) {
+        case (true, .gdn(let mambaCache)):
+            r = linearAttn!.fullyBatchedForward(inputLayerNorm(x), cache: mambaCache)
+        case (false, .sparseAttention(let raCache)):
+            r = selfAttn!.fullyBatchedSparseForward(
+                inputLayerNorm(x), raCache: raCache, denseMask: attnMask)
+        case (false, .attention(let kvCache)):
+            r = selfAttn!.fullyBatchedForward(
+                inputLayerNorm(x), cache: kvCache, mask: attnMask)
+        default:
+            fatalError("Qwen35DecoderLayer: layer/cache type mismatch (isLinear=\(isLinear))")
+        }
+        let h = x + r
+        return h + (mlp as! UnaryLayer)(postAttentionLayerNorm(h))
+    }
+}
+
+extension Qwen35TextModelInner {
+
+    /// Fully batched sparse single-step forward. Builds the dense fallback
+    /// mask once from the first `.attention` (non-sparse) layer if one
+    /// exists; otherwise emits a placeholder zero-size tensor (sparse
+    /// layers compute their own mask internally via the selector index).
+    func fullyBatchedSparseForward(
+        _ inputs: MLXArray, caches: BatchedHybridCache
+    ) -> MLXArray {
+        precondition(caches.layers.count == layers.count,
+                     "fullyBatchedSparseForward: cache layer count mismatch")
+        var h = embedTokens(inputs)
+
+        // Build a fallback dense attention mask. Sparse-attention layers
+        // generate their per-slot mask internally, but dense-band layers
+        // (including any sparse layer hitting the L>1 prefill path) still
+        // need a plain `[B, 1, 1, T+1]` mask. Either `.attention` or
+        // `.sparseAttention` can supply the shape — both wrap a
+        // `BatchedKVCache`.
+        var sampleAttnCache: BatchedKVCache?
+        for layer in caches.layers {
+            switch layer {
+            case .attention(let c): sampleAttnCache = c
+            case .sparseAttention(let ra): sampleAttnCache = ra.inner
+            case .gdn: continue
+            }
+            if sampleAttnCache != nil { break }
+        }
+
+        let attnMask: MLXArray
+        if let c = sampleAttnCache {
+            let B = c.active
+            let cacheDtype = c.keys.dtype
+            let allSame = c.offsets[0..<B].allSatisfy { $0 == c.offsets[0] }
+            let maxPostOffset = (c.offsets[0..<B].max() ?? 0) + 1
+            if allSame {
+                attnMask = MLXArray.zeros(
+                    [B, 1, 1, maxPostOffset], dtype: cacheDtype)
+            } else {
+                let positions = MLXArray(0..<maxPostOffset).reshaped(1, maxPostOffset)
+                let offsetsArr = MLXArray(c.offsets[0..<B].map { $0 + 1 }).reshaped(B, 1)
+                let valid = positions .< offsetsArr
+                attnMask = MLX.where(
+                    valid,
+                    MLXArray(Float(0)).asType(cacheDtype),
+                    MLXArray(Float(-1e9)).asType(cacheDtype)
+                ).reshaped(B, 1, 1, maxPostOffset)
+            }
+        } else {
+            attnMask = MLXArray.zeros([0, 1, 1, 0], dtype: h.dtype)
+        }
+
+        let modelDtype = h.dtype
+        for (i, layer) in layers.enumerated() {
+            h = layer.fullyBatchedSparseForward(
+                h, layerCache: caches.layers[i], attnMask: attnMask)
+            // Defensive cast: quantized ops can promote bf16 → fp32 inside
+            // the lazy graph. asType is zero-cost when dtype already matches.
+            h = h.asType(modelDtype)
+        }
+        return norm(h)
+    }
+}
+
+extension Qwen35TextModel: BatchedHybridSparseLLM {
+
+    public func fullyBatchedSparseDecode(
+        _ inputs: MLXArray, caches: BatchedHybridCache
+    ) -> MLXArray {
+        var out = model.fullyBatchedSparseForward(inputs, caches: caches)
+        if let lmHead {
+            out = lmHead(out)
+        } else {
+            out = model.embedTokens.asLinear(out)
+        }
+        return out
+    }
+
+    /// Build a `BatchedHybridCache` whose attention layers wrap a
+    /// `BatchedRetrievalAttentionKVCache` for sparse decode while GDN
+    /// layers stay on the standard `BatchedMambaCache` path.
+    public func newBatchedHybridSparseCache(
+        maxBatch: Int,
+        parameters: GenerateParameters?,
+        raConfig: RetrievalAttentionConfig
+    ) -> BatchedHybridCache {
+        let cfg = configuration
+        let headDim = cfg.headDim ?? (cfg.hiddenSize / cfg.attentionHeads)
+        let kernelMinusOne = cfg.linearConvKernelDim - 1
+        let keyDim = cfg.linearKeyHeadDim * cfg.linearNumKeyHeads
+        let valueDim = cfg.linearValueHeadDim * cfg.linearNumValueHeads
+        let convDim = keyDim * 2 + valueDim
+        let maxSeq = parameters?.maxKVSize ?? 2048
+
+        // Count attention layers up front so we can pass the correct
+        // `totalLayers` to each `BatchedRetrievalAttentionKVCache` —
+        // RetrievalAttentionConfig's dense-band predicate is total-layer
+        // -relative; passing model.layers.count would mis-bias the bands.
+        let attentionTotal = model.layers.reduce(0) { acc, l in
+            acc + (l.isLinear ? 0 : 1)
+        }
+        var attentionIdx = 0
+
+        let layerCaches: [BatchedHybridCache.BatchedLayerCache] = model.layers.map { layer in
+            if layer.isLinear {
+                return .gdn(BatchedMambaCache(
+                    maxBatch: maxBatch,
+                    kernelMinusOne: kernelMinusOne,
+                    convDim: convDim,
+                    Hv: cfg.linearNumValueHeads,
+                    Dv: cfg.linearValueHeadDim,
+                    Dk: cfg.linearKeyHeadDim))
+            } else {
+                let inner = BatchedKVCache(
+                    maxBatch: maxBatch,
+                    kvHeads: cfg.kvHeads,
+                    headDim: headDim,
+                    maxSeq: maxSeq)
+                let raCache = BatchedRetrievalAttentionKVCache(
+                    inner: inner,
+                    B: maxBatch,
+                    nKVHeads: cfg.kvHeads,
+                    dHead: headDim,
+                    layerIdx: attentionIdx,
+                    totalLayers: attentionTotal,
+                    raConfig: raConfig)
+                attentionIdx += 1
+                return .sparseAttention(raCache)
+            }
+        }
+        return BatchedHybridCache(layers: layerCaches)
+    }
+}

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -702,7 +702,7 @@ final class Qwen35DecoderLayer: Module {
 public class Qwen35TextModelInner: Module {
     @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
 
-    fileprivate let layers: [Qwen35DecoderLayer]
+    let layers: [Qwen35DecoderLayer]
     let norm: RMSNorm
 
     let ssmIdx: Int

--- a/Libraries/MLXLLM/Models/Qwen3MoE+Sparse.swift
+++ b/Libraries/MLXLLM/Models/Qwen3MoE+Sparse.swift
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// Batched sparse decode hooks for Qwen3MoE. Mirrors Qwen3 (q_norm/k_norm
+// pre-RoPE). MoE expert routing inside `mlp` (Qwen3MoESparseMoeBlock or
+// dense Qwen3MoEMLP) is orthogonal to sparse decode — both already
+// conform to `UnaryLayer` and run unchanged on the batched [B, 1] tensor.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+extension Qwen3MoEAttention {
+
+    /// Batched sparse forward. Shape contract mirrors Qwen3Attention — takes
+    /// a `BatchedRetrievalAttentionKVCache`, runs Q/K norm pre-RoPE, updates
+    /// the index, then dispatches to either dense SDPA or sparse SDPA based
+    /// on layer eligibility.
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache,
+        layerIndex: Int
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+        let cache = raCache.inner
+
+        var queries = wq(x)
+        var keys = wk(x)
+        var values = wv(x)
+
+        // q_norm / k_norm on per-head views, THEN transpose.
+        queries = qNorm(queries.reshaped(B, L, args.attentionHeads, -1))
+            .transposed(0, 2, 1, 3)
+        keys = kNorm(keys.reshaped(B, L, args.kvHeads, -1))
+            .transposed(0, 2, 1, 3)
+        values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
+
+        // RoPE + cache update — fast/slow path on offset uniformity.
+        let allSameOffset = cache.offsets[0 ..< cache.active]
+            .allSatisfy { $0 == cache.offsets[0] }
+        let preUpdateK: MLXArray
+        if allSameOffset {
+            let offset = cache.offsets[0]
+            queries = rope(queries, offset: offset)
+            keys = rope(keys, offset: offset)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        } else {
+            let qSlices = split(queries, parts: B, axis: 0)
+            let kSlices = split(keys, parts: B, axis: 0)
+            var rotQ = [MLXArray]()
+            var rotK = [MLXArray]()
+            rotQ.reserveCapacity(B)
+            rotK.reserveCapacity(B)
+            for i in 0 ..< B {
+                let off = cache.offsets[i]
+                rotQ.append(rope(qSlices[i], offset: off))
+                rotK.append(rope(kSlices[i], offset: off))
+            }
+            queries = concatenated(rotQ, axis: 0)
+            keys = concatenated(rotK, axis: 0)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        }
+
+        raCache.updateIndex(newKeys: preUpdateK)
+
+        let output: MLXArray
+        if L == 1 && raCache.isSparseEligible {
+            output = raCache.sparseAttend(queries: queries, scale: scale)
+        } else {
+            let (k, v, mask) = cache.getCachedWithMask()
+            output = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: k, values: v,
+                scale: scale, mask: .array(mask))
+        }
+        return wo(output.transposed(0, 2, 1, 3).reshaped(B, L, -1))
+    }
+}
+
+extension Qwen3MoeDecoderLayer {
+
+    /// Layer-level wrapper: pre-norm → sparse attention → residual → MoE/MLP.
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache,
+        layerIndex: Int
+    ) -> MLXArray {
+        let normed = inputLayerNorm(x)
+        var r = selfAttn.fullyBatchedSparseForward(
+            normed, raCache: raCache, layerIndex: layerIndex)
+        let h = x + r
+        r = mlp(postAttentionLayerNorm(h))
+        return h + r
+    }
+}
+
+extension Qwen3MoEModelInner {
+
+    public func fullyBatchedSparseForward(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        precondition(raCaches.count == layers.count,
+            "raCaches count must match layers count")
+        var h = embedTokens(inputs)
+        for (i, layer) in layers.enumerated() {
+            h = layer.fullyBatchedSparseForward(h, raCache: raCaches[i], layerIndex: i)
+        }
+        return norm(h)
+    }
+}
+
+extension Qwen3MoEModel: BatchedSparseLLM {
+
+    public func fullyBatchedSparseDecode(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        var out = model.fullyBatchedSparseForward(inputs, raCaches: raCaches)
+        if let lmHead {
+            out = lmHead(out)
+        } else {
+            out = model.embedTokens.asLinear(out)
+        }
+        return out
+    }
+}

--- a/Libraries/MLXLLM/Models/Qwen3MoE.swift
+++ b/Libraries/MLXLLM/Models/Qwen3MoE.swift
@@ -154,7 +154,7 @@ class Qwen3MoeDecoderLayer: Module {
     @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
     @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
 
-    fileprivate let mlp: UnaryLayer
+    let mlp: UnaryLayer
 
     init(_ args: Qwen3MoEConfiguration, layerIdx: Int) {
         self.args = args
@@ -189,7 +189,7 @@ class Qwen3MoeDecoderLayer: Module {
 public class Qwen3MoEModelInner: Module {
     @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
 
-    fileprivate let layers: [Qwen3MoeDecoderLayer]
+    let layers: [Qwen3MoeDecoderLayer]
     let norm: RMSNorm
     let args: Qwen3MoEConfiguration
 

--- a/Libraries/MLXLMCommon/BatchedHybridCache.swift
+++ b/Libraries/MLXLMCommon/BatchedHybridCache.swift
@@ -139,6 +139,11 @@ public class BatchedHybridCache {
     public enum BatchedLayerCache {
         case attention(BatchedKVCache)
         case gdn(BatchedMambaCache)
+        /// Sparse-attention layer. Wraps a `BatchedKVCache` so the hybrid
+        /// lockstep slot management can still read/write `inner.active`,
+        /// `inner.offsets`, and the K/V buffers identically to a plain
+        /// `.attention` case.
+        case sparseAttention(BatchedRetrievalAttentionKVCache)
     }
 
     public let layers: [BatchedLayerCache]
@@ -149,6 +154,7 @@ public class BatchedHybridCache {
         switch first {
         case .attention(let c): return c.active
         case .gdn(let c): return c.active
+        case .sparseAttention(let ra): return ra.inner.active
         }
     }
 
@@ -167,6 +173,7 @@ public class BatchedHybridCache {
             switch layer {
             case .attention(let c): slot = c.addRequest()
             case .gdn(let c): slot = c.addSlot()
+            case .sparseAttention(let ra): slot = ra.inner.addRequest()
             }
             if assigned < 0 { assigned = slot }
             assert(slot == assigned,
@@ -192,6 +199,19 @@ public class BatchedHybridCache {
                 c.active -= 1
             case .gdn(let c):
                 c.removeSlot(slot)
+            case .sparseAttention(let ra):
+                // Same swap-from-end semantics applied to the inner cache.
+                // Selector index state stays consistent because it indexes
+                // by slot too (rebuilt on demand at the next sparseAttend).
+                let c = ra.inner
+                let last = c.active - 1
+                if slot != last {
+                    c.keys[slot, 0..., 0..., 0...] = c.keys[last, 0..., 0..., 0...]
+                    c.values[slot, 0..., 0..., 0...] = c.values[last, 0..., 0..., 0...]
+                    c.offsets[slot] = c.offsets[last]
+                }
+                c.offsets[last] = 0
+                c.active -= 1
             }
         }
     }
@@ -202,6 +222,7 @@ public class BatchedHybridCache {
             switch layer {
             case .attention(let c): c.reset()
             case .gdn(let c): c.reset()
+            case .sparseAttention(let ra): ra.inner.reset()
             }
         }
     }

--- a/Libraries/MLXLMCommon/BatchedHybridCache.swift
+++ b/Libraries/MLXLMCommon/BatchedHybridCache.swift
@@ -33,8 +33,16 @@ public class BatchedMambaCache {
     /// Conv state: [maxBatch, kernel-1, convDim]
     public var convState: MLXArray
 
-    /// Recurrent state: [maxBatch, Hv, Dv, Dk] fp32
+    /// Recurrent state: [maxBatch, Hv, Dv, Dk]. Dtype is `recDtype`.
     public var recState: MLXArray
+
+    /// Recurrent-state storage dtype. Defaults to fp32 (the GDN contract used
+    /// by Qwen 3.5 / 3.6 / Qwen3-Next). NemotronH's Mamba2 follows an
+    /// input-dtype SSM state contract — `ssmUpdate` returns state in the
+    /// input dtype — and constructs the cache with `recDtype: .bfloat16`
+    /// (or whatever the model dtype is). The `writeback` cast adapts to
+    /// whichever storage dtype the cache was built with.
+    public let recDtype: DType
 
     /// Active slot count (first `active` slots are in use)
     public var active: Int = 0
@@ -46,7 +54,8 @@ public class BatchedMambaCache {
         Hv: Int,
         Dv: Int,
         Dk: Int,
-        dtype: DType = .bfloat16
+        dtype: DType = .bfloat16,
+        recDtype: DType = .float32
     ) {
         self.maxBatch = maxBatch
         self.kernelMinusOne = kernelMinusOne
@@ -54,13 +63,14 @@ public class BatchedMambaCache {
         self.Hv = Hv
         self.Dv = Dv
         self.Dk = Dk
+        self.recDtype = recDtype
 
         // Don't bother zeroing here — slots get zeroed lazily in addSlot.
         // (We still allocate so the buffer exists with the right shape.)
         self.convState = MLXArray.zeros(
             [maxBatch, kernelMinusOne, convDim], dtype: dtype)
         self.recState = MLXArray.zeros(
-            [maxBatch, Hv, Dv, Dk], dtype: .float32)
+            [maxBatch, Hv, Dv, Dk], dtype: recDtype)
         eval(self.convState, self.recState)
     }
 
@@ -100,14 +110,14 @@ public class BatchedMambaCache {
 
     /// Writeback updated conv + rec state for the first `active` slots.
     /// `conv` shape: [active, kernel-1, convDim].
-    /// `rec` shape:  [active, Hv, Dv, Dk] (fp32).
+    /// `rec` shape:  [active, Hv, Dv, Dk]. Cast to `recDtype` on commit so
+    /// callers can hand back whatever dtype the model's recurrence emits.
     public func writeback(conv: MLXArray, rec: MLXArray) {
         let B = conv.dim(0)
         precondition(B <= active, "writeback B (\(B)) exceeds active (\(active))")
         convState[..<B, 0..., 0...] = conv
-        // Force fp32 to match storage; defensive — caller should already be fp32.
         recState[..<B, 0..., 0..., 0...] =
-            (rec.dtype == .float32) ? rec : rec.asType(.float32)
+            (rec.dtype == recDtype) ? rec : rec.asType(recDtype)
     }
 
     /// Reset all slots.
@@ -122,7 +132,7 @@ public class BatchedMambaCache {
     private func zeroSlot(_ slot: Int) {
         let convZ = MLXArray.zeros(
             [kernelMinusOne, convDim], dtype: convState.dtype)
-        let recZ = MLXArray.zeros([Hv, Dv, Dk], dtype: .float32)
+        let recZ = MLXArray.zeros([Hv, Dv, Dk], dtype: recDtype)
         convState[slot, 0..., 0...] = convZ
         recState[slot, 0..., 0..., 0...] = recZ
     }

--- a/Libraries/MLXLMCommon/BatchedHybridSparseLLM.swift
+++ b/Libraries/MLXLMCommon/BatchedHybridSparseLLM.swift
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// Conformance hook for hybrid LLMs (interleaved attention + GDN / Mamba)
+// that can route their attention sublayers through the batched sparse
+// decode path. The bridge `as?`-casts a loaded model to this protocol
+// and dispatches `fullyBatchedSparseDecode` when its session pool has
+// a `BatchedHybridCache` whose attention slots use `.sparseAttention`.
+
+import Foundation
+import MLX
+
+/// Hybrid models (e.g. Qwen 3.5 / 3.6, Nemotron H) that can interleave a
+/// batched GDN / Mamba path with a batched sparse attention path. The
+/// caller builds a `BatchedHybridCache` whose layers mix
+/// `.sparseAttention(...)` for attention layers and `.gdn(...)` for
+/// linear layers.
+///
+/// Inputs:
+///   - `[B, 1]` token IDs.
+///
+/// Returns:
+///   - `[B, 1, vocab]` logits.
+public protocol BatchedHybridSparseLLM: BatchedHybridLLM {
+
+    /// Single-step batched decode with sparse attention on attention layers.
+    /// Per-layer dispatch is the model's responsibility — `.gdn` cases route
+    /// to the existing GDN batched path, `.sparseAttention` cases route to
+    /// the batched sparse decode site.
+    func fullyBatchedSparseDecode(
+        _ inputs: MLXArray,
+        caches: BatchedHybridCache
+    ) -> MLXArray
+
+    /// Build a fresh `BatchedHybridCache` whose attention layers use
+    /// `.sparseAttention(BatchedRetrievalAttentionKVCache)` wrappers built
+    /// from the supplied `raConfig`. Linear (GDN / Mamba) layers stay on
+    /// the standard `.gdn(BatchedMambaCache)` path.
+    func newBatchedHybridSparseCache(
+        maxBatch: Int,
+        parameters: GenerateParameters?,
+        raConfig: RetrievalAttentionConfig
+    ) -> BatchedHybridCache
+}

--- a/Libraries/MLXLMCommon/BatchedRetrievalAttentionConfig.swift
+++ b/Libraries/MLXLMCommon/BatchedRetrievalAttentionConfig.swift
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// Configuration + Johnson-Lindenstrauss projection helper for the batched
+// retrieval-attention path (selector index + sparse-aware KV cache).
+//
+// This file contains the minimal subset of the broader retrieval-attention
+// infrastructure required by the BATCHED decode path. Per-request (B=1)
+// retrieval-attention machinery (cache, kernel zoo, scheduler) is not
+// included — those types are not used by the batched stack here.
+
+import Foundation
+import MLX
+
+// MARK: - Config
+
+/// Tunables for block-sparse retrieval attention. Defaults are the same
+/// ship configuration validated in the broader retrieval-attention work
+/// (static prefix 128, sliding window 2048, fine-block size 64, fine top-K
+/// 32 with adaptive scaling, coarse rescue 2x1024 enabled).
+///
+/// The batched sparse decode path is BW-bound by K/V loads at long context;
+/// the selector picks per-(B, KV-head) top-K blocks and dispatches a
+/// fused fp16 additive mask + MLXFast SDPA so the SDPA tiled kernel walks
+/// the masked region as a no-op.
+public struct RetrievalAttentionConfig: Sendable {
+
+    // ----- Static / sliding window
+
+    /// Number of initial tokens always attended.
+    public var staticInit: Int = 128
+
+    /// Number of trailing tokens always attended.
+    public var slidingWindow: Int = 2048
+
+    // ----- Fine block retrieval
+
+    /// Tokens per fine block. 64 is the published sweet spot for
+    /// block-sparse attention (NSA/SeerAttention) — small enough for
+    /// fine selectivity, large enough for coalesced gather.
+    public var fineBlockSize: Int = 64
+
+    /// Floor for fine top-K. When `adaptiveTopK` is true, the effective
+    /// top-K at gather time is `max(fineTopK, ceil(seqLen / divisor))`.
+    public var fineTopK: Int = 32
+
+    /// Scale fineTopK with sequence length at gather time.
+    public var adaptiveTopK: Bool = true
+
+    /// Divisor for adaptive top-K scaling. `topK = ceil(seqLen / divisor)`.
+    /// 256 = sweet spot on long-context Qwen at decode.
+    public var adaptiveTopKDivisor: Int = 256
+
+    /// Compute the effective fine top-K to use at gather time given the
+    /// current cache length.
+    public func effectiveFineTopK(seqLen: Int) -> Int {
+        guard adaptiveTopK else { return fineTopK }
+        let scaled = (seqLen + adaptiveTopKDivisor - 1) / adaptiveTopKDivisor
+        return max(fineTopK, scaled)
+    }
+
+    // ----- Coarse rescue
+
+    /// Tokens per coarse rescue block.
+    public var coarseBlockSize: Int = 1024
+
+    /// Number of coarse blocks to retrieve per query.
+    public var coarseTopK: Int = 2
+
+    /// Whether the coarse-rescue branch is enabled.
+    public var coarseRescueEnabled: Bool = true
+
+    // ----- Selector dim
+
+    /// JL content-projection output dim.
+    public var contentDim: Int = 16
+
+    /// Trig position-features dim (sin/cos of relative positions). Unused
+    /// in the batched path (selector is pure content / λ=0). Kept on the
+    /// config struct for symmetry with the non-batched surface.
+    public var trigDim: Int = 16
+
+    /// Total selector dim — content + trig.
+    public var selectorDim: Int { contentDim + trigDim }
+
+    /// Content-vs-position blend. 0 = pure content (the ship default —
+    /// no trig features computed, indexB asserts λ == 0).
+    public var lambdaPos: Float = 0.0
+
+    /// True if the selector path needs to compute / store trig features.
+    /// Always false at λ=0 (the batched path's only supported mode).
+    public var usesTrigFeatures: Bool { lambdaPos > 0.0 }
+
+    /// Effective stored selector width — equals `contentDim` at λ=0.
+    public var effectiveSelectorDim: Int {
+        usesTrigFeatures ? selectorDim : contentDim
+    }
+
+    // ----- Per-layer hybrid
+
+    /// Number of initial dense layers (run dense, skip sparse selector).
+    public var denseFirstN: Int = 4
+
+    /// Number of trailing dense layers.
+    public var denseLastN: Int = 4
+
+    /// True if this layer index should run sparse attention. Layers at
+    /// the front (first-N) and back (last-N) of the stack stay dense —
+    /// they're the high-recall layers in practice.
+    public func isSparseLayer(layerIdx: Int, totalLayers: Int) -> Bool {
+        guard layerIdx >= denseFirstN else { return false }
+        guard layerIdx < totalLayers - denseLastN else { return false }
+        return true
+    }
+
+    /// Minimum cache size before sparse kicks in. Below this the selector
+    /// + mask construction overhead outweighs the BW saving from masking
+    /// out unselected positions.
+    public var sparseMinContext: Int = 16384
+
+    public init() {}
+
+    /// Deterministic seed for the JL random projection. Same matrix
+    /// across prefill / decode / chunk boundaries — critical for the
+    /// dot-product preservation argument in JL.
+    public static var jlSeed: UInt32 { 0x4F50_4E53 }  // "OPNS"
+}
+
+// MARK: - JL projection
+
+/// Build the Johnson-Lindenstrauss random-projection matrix used to
+/// compress d_head down to `contentDim`. Entries are i.i.d.
+/// `N(0, 1/contentDim)` — preserves `E[||Wx||^2] = ||x||^2`. Same matrix
+/// applied to both Q and K so `(Wq) . (Wk) = q . (W^T W) . k ~ q . k`
+/// in expectation.
+///
+/// - Parameters:
+///   - dHead: head dim of the underlying model.
+///   - config: backend config (for `contentDim` and JL seed).
+/// - Returns: `[contentDim, dHead]` fp32 array.
+public func retrievalAttentionJLProjection(
+    dHead: Int,
+    config: RetrievalAttentionConfig = RetrievalAttentionConfig()
+) -> MLXArray {
+    // Use a scoped RandomState seeded with the JL seed so we don't perturb
+    // the caller's global PRNG. Sampling with `key:` scopes randomness.
+    let key = MLXRandom.key(UInt64(RetrievalAttentionConfig.jlSeed))
+    let scale = Float(1.0 / Float(config.contentDim).squareRoot())
+    let W = MLXRandom.normal([config.contentDim, dHead], key: key) * scale
+    return W.asType(.float32)
+}

--- a/Libraries/MLXLMCommon/BatchedRetrievalAttentionIndexB.swift
+++ b/Libraries/MLXLMCommon/BatchedRetrievalAttentionIndexB.swift
@@ -1,0 +1,475 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// BatchedRetrievalAttentionIndexB — block-feature selector index with an
+// explicit per-request batch dimension. Each (B, KV-head) gets its own
+// running mean of block features in the JL-projected content space and
+// produces its own top-K block selection per decode step.
+//
+// Shape conventions:
+//   fineBlockFeatures:    [B, nKVHeads, nFineBlocks, contentDim]
+//   coarseBlockFeatures:  [B, nKVHeads, nCoarseBlocks, contentDim]
+//   q (input to project): [B, nKVHeads, dHead]
+//   projectedQ:           [B, nKVHeads, contentDim]
+//   topK output:          [B, nKVHeads, K_fine]  / [B, nKVHeads, K_coarse]
+//
+// Storage decision: drops per-token feature storage; maintains block
+// features INCREMENTALLY via running mean. This is the lower-memory
+// path — saves on the order of tens of GB at B=8 T=128K for a 14B model.
+//
+// Running-mean math (per block b, per content dim c):
+//   mean_new = mean_old + (added - mean_old) / new_count
+// Cheap to update as each new K row arrives — no scan over T.
+
+import Foundation
+import MLX
+
+public final class BatchedRetrievalAttentionIndexB {
+
+    public let config: RetrievalAttentionConfig
+    public let B: Int
+    public let dHead: Int
+    public let nKVHeads: Int
+    public let ropeBase: Float
+    public let layerIdx: Int
+
+    /// JL projection matrix `[dHead, contentDim]`. Shared across all
+    /// (B, KV-head) — JL is a model-architecture property, not per-slot.
+    private var jlMatrixT: MLXArray?
+    public var jlW: MLXArray? { jlMatrixT }
+
+    /// Block-pooled features, `[B, nKVH, blockCap, contentDim]` fp32.
+    /// Grown geometrically. Valid prefix is `[0..<currentFineBlocks]`.
+    /// Only contentDim — trig features are skipped (λ=0 ship config).
+    private var fineBlockBuffer: MLXArray?
+    private var coarseBlockBuffer: MLXArray?
+    private var fineBlockCapacity: Int = 0
+    private var coarseBlockCapacity: Int = 0
+
+    /// Per (B, KV-head) running-sum tracking for the partial last block.
+    /// Currently uses in-place rolling mean — no separate sum tensors
+    /// needed since `mean_new = mean_old + (added - mean_old) / count`.
+    private var fineTokensInCurrentBlock: [[Int]]   // [B][nKVH]
+    private var coarseTokensInCurrentBlock: [[Int]]
+
+    /// Per-slot populated count. Decode / prefill can advance independently
+    /// (e.g. continuous batching) so each slot tracks its own T.
+    private var populatedPerSlot: [Int]
+    /// Convenience: max-populated across slots (drives block-buffer capacity).
+    public var seqLenMax: Int { populatedPerSlot.max() ?? 0 }
+    /// Convenience: min populated (for rectangular T assumption check).
+    public var seqLenMin: Int { populatedPerSlot.min() ?? 0 }
+    /// Per-slot getter.
+    public func seqLen(slot: Int) -> Int { populatedPerSlot[slot] }
+
+    /// Block counts driven by `seqLenMax` — buffer holds enough for the
+    /// "tallest" slot; shorter slots have zeros at the tail.
+    public var currentFineBlocks: Int {
+        let m = seqLenMax
+        guard m > 0 else { return 0 }
+        return (m + config.fineBlockSize - 1) / config.fineBlockSize
+    }
+    public var currentCoarseBlocks: Int {
+        let m = seqLenMax
+        guard m > 0 else { return 0 }
+        return (m + config.coarseBlockSize - 1) / config.coarseBlockSize
+    }
+
+    /// Public views (valid prefix only).
+    public var fineBlockFeatures: MLXArray? {
+        guard let buf = fineBlockBuffer, currentFineBlocks > 0 else { return nil }
+        return buf[0..., 0..., ..<currentFineBlocks, 0...]
+    }
+    public var coarseBlockFeatures: MLXArray? {
+        guard let buf = coarseBlockBuffer, currentCoarseBlocks > 0 else { return nil }
+        return buf[0..., 0..., ..<currentCoarseBlocks, 0...]
+    }
+
+    public init(
+        config: RetrievalAttentionConfig = RetrievalAttentionConfig(),
+        B: Int,
+        dHead: Int,
+        nKVHeads: Int,
+        ropeBase: Float = 10_000.0,
+        layerIdx: Int
+    ) {
+        precondition(B > 0, "B must be > 0")
+        self.config = config
+        self.B = B
+        self.dHead = dHead
+        self.nKVHeads = nKVHeads
+        self.ropeBase = ropeBase
+        self.layerIdx = layerIdx
+        self.populatedPerSlot = Array(repeating: 0, count: B)
+        self.fineTokensInCurrentBlock =
+            Array(repeating: Array(repeating: 0, count: nKVHeads), count: B)
+        self.coarseTokensInCurrentBlock =
+            Array(repeating: Array(repeating: 0, count: nKVHeads), count: B)
+        // `usesTrigFeatures` path not supported here; selector ships
+        // λ=0 (pure content). Revisit if a customer flips lambdaPos > 0.
+        precondition(!config.usesTrigFeatures,
+            "BatchedRetrievalAttentionIndexB supports λ=0 (no trig) only")
+    }
+
+    private func ensureJL() {
+        guard jlMatrixT == nil else { return }
+        let W = retrievalAttentionJLProjection(dHead: dHead, config: config)
+        jlMatrixT = W.transposed(1, 0)
+        eval(jlMatrixT!)
+    }
+
+    /// Update with a chunk of new K rows for ALL slots and ALL heads.
+    ///
+    /// - Parameter newKeys: `[B, nKVHeads, L, dHead]` post-RoPE keys.
+    ///   All slots get the same L — assumes rectangular prefill / decode.
+    ///   For continuous batching where slots have different L per step,
+    ///   call this once per (slot, L) — ragged path is a future concern.
+    public func update(newKeys: MLXArray) {
+        precondition(newKeys.shape.count == 4,
+            "expected [B, nKVHeads, L, dHead], got \(newKeys.shape)")
+        precondition(newKeys.dim(0) == B, "B mismatch (got \(newKeys.dim(0)) expected \(B))")
+        precondition(newKeys.dim(1) == nKVHeads, "nKVHeads mismatch")
+        precondition(newKeys.dim(3) == dHead, "dHead mismatch")
+        ensureJL()
+        let L = newKeys.dim(2)
+        let WT = jlMatrixT!
+
+        // Project all (B, KV-head) tokens at once.
+        //   [B, nKVH, L, dHead] @ [dHead, contentDim] = [B, nKVH, L, contentDim]
+        let content = matmul(newKeys.asType(.float32), WT).asType(.float32)
+        // Force materialization here — downstream blockwise pool reads
+        // contiguous slabs, and lazy graph through index slicing showed up
+        // as a perf cliff in the single-batch index path.
+        eval(content)
+
+        for slot in 0..<B {
+            let oldT = populatedPerSlot[slot]
+            let newT = oldT + L
+            populatedPerSlot[slot] = newT
+        }
+
+        // Grow buffers BEFORE writing.
+        let contentDim = content.dim(3)
+        ensureBlockBuffer(isFine: true, contentDim: contentDim)
+        if config.coarseRescueEnabled {
+            ensureBlockBuffer(isFine: false, contentDim: contentDim)
+        }
+
+        // For prefill (L large) recompute affected blocks via slab mean
+        // — cheaper than running-sum because we're rewriting the whole
+        // tail. For decode (L=1) running-mean wins: just bump 1 partial-
+        // block update.
+        if L == 1 {
+            updateDecodeStep(content: content, contentDim: contentDim)
+        } else {
+            updatePrefillChunk(content: content, L: L, contentDim: contentDim)
+        }
+    }
+
+    /// L=1 decode update — running-mean of the partial last block per slot.
+    private func updateDecodeStep(content: MLXArray, contentDim: Int) {
+        // content: [B, nKVH, 1, contentDim] → squeeze L → [B, nKVH, contentDim]
+        let added = content[0..., 0..., 0, 0...]
+        // For each slot, fold into fine + coarse partial blocks.
+        // mean_new = mean_old + (added - mean_old) / new_count
+        updateRunningMean(isFine: true, added: added)
+        if config.coarseRescueEnabled {
+            updateRunningMean(isFine: false, added: added)
+        }
+    }
+
+    /// Closed-form rolling-mean update of the per-slot partial last block.
+    private func updateRunningMean(isFine: Bool, added: MLXArray) {
+        let bs = isFine ? config.fineBlockSize : config.coarseBlockSize
+        let buf = isFine ? fineBlockBuffer! : coarseBlockBuffer!
+        for slot in 0..<B {
+            let popPost = populatedPerSlot[slot]
+            // Block index of the new token = (popPost - 1) / bs.
+            let blockIdx = (popPost - 1) / bs
+            // Count of tokens now in this block (1..bs).
+            let countInBlock = popPost - blockIdx * bs
+            let addedRow = added[slot, 0..., 0...]  // [nKVH, contentDim]
+            let oldMean = buf[slot, 0..., blockIdx, 0...]
+            let countF = Float(countInBlock)
+            let newMean: MLXArray
+            if countInBlock == 1 {
+                // First token in this block = mean = added.
+                newMean = addedRow
+            } else {
+                newMean = oldMean + (addedRow - oldMean) / countF
+            }
+            buf[slot, 0..., blockIdx, 0...] = newMean
+        }
+    }
+
+    /// Multi-token prefill update — recompute every affected block via
+    /// slab-mean. Cheaper than per-token running-mean when L is large.
+    private func updatePrefillChunk(content: MLXArray, L: Int, contentDim: Int) {
+        let rectangular: Bool = {
+            guard B > 0 else { return false }
+            let firstPop = populatedPerSlot[0]
+            return populatedPerSlot.allSatisfy { $0 == firstPop }
+        }()
+
+        if rectangular {
+            updatePrefillRectangular(content: content, L: L, contentDim: contentDim)
+        } else {
+            // Fallback per-slot path (ragged-T continuous batching path).
+            for slot in 0..<B {
+                let slotContent = content[slot ..< (slot + 1), 0..., 0..., 0...]
+                updateSlotPrefillSlice(
+                    slot: slot, slotContent: slotContent,
+                    L: L, contentDim: contentDim)
+            }
+        }
+    }
+
+    /// Rectangular prefill — all slots at the same oldT. Vectorize across B.
+    private func updatePrefillRectangular(content: MLXArray, L: Int, contentDim: Int) {
+        let newT = populatedPerSlot[0]
+        let oldT = newT - L
+        updateBlockRectangularInPlace(
+            content: content, oldT: oldT, newT: newT, L: L,
+            isFine: true)
+        if config.coarseRescueEnabled {
+            updateBlockRectangularInPlace(
+                content: content, oldT: oldT, newT: newT, L: L,
+                isFine: false)
+        }
+    }
+
+    /// Per-block mean recompute for the rectangular case.
+    /// content: [B, nKVH, L, contentDim]
+    private func updateBlockRectangularInPlace(
+        content: MLXArray, oldT: Int, newT: Int, L: Int, isFine: Bool
+    ) {
+        let bs = isFine ? config.fineBlockSize : config.coarseBlockSize
+        let buf = isFine ? fineBlockBuffer! : coarseBlockBuffer!
+        let firstBlock = oldT / bs
+        let lastBlock = (newT - 1) / bs  // inclusive
+        for blk in firstBlock ... lastBlock {
+            let blockStartAbs = blk * bs
+            let blockEndAbs = min(blockStartAbs + bs, newT)
+            let leftStart = max(0, blockStartAbs)
+            let leftEnd = min(oldT, blockEndAbs)
+            let leftCount = max(0, leftEnd - leftStart)
+            let rightStart = max(oldT, blockStartAbs)
+            let rightEnd = blockEndAbs
+            let rightCount = max(0, rightEnd - rightStart)
+            let cStart = rightStart - oldT
+            let cEnd = rightEnd - oldT
+            let totalCount = leftCount + rightCount
+            precondition(totalCount > 0, "block must have >=1 token")
+            let rightSlice = content[0..., 0..., cStart ..< cEnd, 0...]
+            let rightSum = rightSlice.sum(axis: 2)   // [B, nKVH, contentDim]
+            if leftCount == 0 {
+                let mean = rightSum / Float(totalCount)
+                buf[0..., 0..., blk, 0...] = mean
+            } else {
+                let oldMean = buf[0..., 0..., blk, 0...]
+                let leftSum = oldMean * Float(leftCount)
+                let mean = (leftSum + rightSum) / Float(totalCount)
+                buf[0..., 0..., blk, 0...] = mean
+            }
+        }
+    }
+
+    /// Per-slot prefill slice update. Slow path for non-rectangular.
+    private func updateSlotPrefillSlice(
+        slot: Int, slotContent: MLXArray, L: Int, contentDim: Int
+    ) {
+        let newT = populatedPerSlot[slot]
+        let oldT = newT - L
+        for isFine in [true, false] {
+            if !isFine && !config.coarseRescueEnabled { continue }
+            let bs = isFine ? config.fineBlockSize : config.coarseBlockSize
+            let buf = isFine ? fineBlockBuffer! : coarseBlockBuffer!
+            let firstBlock = oldT / bs
+            let lastBlock = (newT - 1) / bs
+            for blk in firstBlock ... lastBlock {
+                let blockStartAbs = blk * bs
+                let blockEndAbs = min(blockStartAbs + bs, newT)
+                let leftStart = blockStartAbs
+                let leftEnd = min(oldT, blockEndAbs)
+                let leftCount = max(0, leftEnd - leftStart)
+                let rightStart = max(oldT, blockStartAbs)
+                let rightEnd = blockEndAbs
+                let rightCount = max(0, rightEnd - rightStart)
+                let cStart = rightStart - oldT
+                let cEnd = rightEnd - oldT
+                let totalCount = leftCount + rightCount
+                let rightSlice = slotContent[0..., 0..., cStart ..< cEnd, 0...]
+                let rightSum = rightSlice.sum(axis: 2)   // [1, nKVH, contentDim]
+                if leftCount == 0 {
+                    let mean = rightSum / Float(totalCount)
+                    buf[slot ..< (slot + 1), 0..., blk, 0...] = mean
+                } else {
+                    let oldMean = buf[slot ..< (slot + 1), 0..., blk, 0...]
+                    let leftSum = oldMean * Float(leftCount)
+                    let mean = (leftSum + rightSum) / Float(totalCount)
+                    buf[slot ..< (slot + 1), 0..., blk, 0...] = mean
+                }
+            }
+        }
+    }
+
+    private func ensureBlockBuffer(isFine: Bool, contentDim: Int) {
+        let needed = isFine ? currentFineBlocks : currentCoarseBlocks
+        let cap = isFine ? fineBlockCapacity : coarseBlockCapacity
+        let existing = isFine ? fineBlockBuffer : coarseBlockBuffer
+        if cap >= needed && existing != nil {
+            return
+        }
+        // Geometric growth — contentDim is small (16) and block counts at
+        // T=128K with fineBS=64 = 2048 blocks. At B=8, nKVH=8, contentDim=16
+        // that's ~8 MB fp32 — cheap.
+        let chunkSize = 256
+        var newCap = max(cap, chunkSize)
+        while newCap < needed { newCap *= 2 }
+        let dtype: DType = .float32
+        let newBuf = MLXArray.zeros([B, nKVHeads, newCap, contentDim], dtype: dtype)
+        if cap > 0, let old = existing {
+            newBuf[0..., 0..., ..<cap, 0...] = old[0..., 0..., ..<cap, 0...]
+        }
+        if isFine {
+            fineBlockBuffer = newBuf
+            fineBlockCapacity = newCap
+        } else {
+            coarseBlockBuffer = newBuf
+            coarseBlockCapacity = newCap
+        }
+    }
+
+    // MARK: - scoring + top-K
+
+    /// Project decode queries for all (B, KV-heads) in one batched matmul.
+    /// - Parameter q: `[B, nKVHeads, dHead]` decode-step query (rep-per-group).
+    /// - Returns: `[B, nKVHeads, contentDim]`.
+    public func projectQueriesBatched(_ q: MLXArray) -> MLXArray {
+        precondition(q.shape == [B, nKVHeads, dHead],
+            "expected [\(B), \(nKVHeads), \(dHead)], got \(q.shape)")
+        ensureJL()
+        let WT = jlMatrixT!
+        // [B, nKVH, dHead] @ [dHead, contentDim] = [B, nKVH, contentDim]
+        return matmul(q.asType(.float32), WT)
+    }
+
+    /// Per-(B, KV-head) top-K fine block starts.
+    /// - Parameter projectedQ: `[B, nKVHeads, contentDim]`
+    /// - Returns: `[B, nKVHeads, K_fine]` int32 token-position block starts.
+    public func topKFineBlockStarts(projectedQ: MLXArray) -> MLXArray {
+        guard let features = fineBlockFeatures else {
+            return MLXArray.zeros([B, nKVHeads, 1], dtype: .int32)
+        }
+        let k = config.effectiveFineTopK(seqLen: seqLenMax)
+        return computeTopK(
+            features: features, projectedQ: projectedQ,
+            k: k, blockSize: config.fineBlockSize)
+    }
+
+    public func topKCoarseBlockStarts(projectedQ: MLXArray) -> MLXArray {
+        guard config.coarseRescueEnabled,
+              let features = coarseBlockFeatures
+        else {
+            return MLXArray.zeros([B, nKVHeads, 1], dtype: .int32)
+        }
+        return computeTopK(
+            features: features, projectedQ: projectedQ,
+            k: config.coarseTopK, blockSize: config.coarseBlockSize)
+    }
+
+    /// Score + argPartition on a [B, nKVH, nBlocks, contentDim] buffer.
+    /// Returns top-K block starts `[B, nKVH, k]` in token coords.
+    private func computeTopK(
+        features: MLXArray, projectedQ: MLXArray, k: Int, blockSize: Int
+    ) -> MLXArray {
+        let nBlocks = features.dim(2)
+        let take = min(k, nBlocks)
+        guard take > 0 else {
+            return MLXArray.zeros([B, nKVHeads, 1], dtype: .int32)
+        }
+        // Score: per (B, nKVH, block, content) inner-product with projectedQ.
+        //   features: [B, nKVH, nBlocks, contentDim]
+        //   projQ:    [B, nKVH, contentDim] → reshape [B, nKVH, 1, contentDim]
+        let qExp = projectedQ.reshaped(B, nKVHeads, 1, projectedQ.dim(2))
+        let scores = (features * qExp).sum(axis: -1)  // [B, nKVH, nBlocks]
+        // argPartition on axis -1 picks top-`take` at positions [N-take..N).
+        let pivot = nBlocks - take
+        let partitioned: MLXArray
+        if pivot <= 0 {
+            let rangeArr = MLXArray(0..<Int32(nBlocks))
+                .reshaped(1, 1, nBlocks)
+            partitioned = broadcast(rangeArr, to: [B, nKVHeads, nBlocks])
+        } else {
+            partitioned = argPartition(scores, kth: pivot, axis: -1)
+        }
+        let topKIdx = partitioned[0..., 0..., (nBlocks - take)...]
+        return topKIdx * Int32(blockSize)
+    }
+
+    /// Per-(B, KV-head) sorted gather list of ALL positions to attend
+    /// (static prefix + sliding window + top-K fine + optional top-K
+    /// coarse). Padded to fixed K_padded for the kernel grid; positions
+    /// are clipped to `[0, T-1]` so OOB protection in the kernel doesn't
+    /// fire.
+    ///
+    /// All slots share the same static / sliding range when rectangular.
+    ///
+    /// - Parameters:
+    ///   - projectedQ: `[B, nKVHeads, contentDim]`
+    ///   - T: rectangular cache length (caller passes K.dim(2)).
+    /// - Returns: (gather [B, nKVHeads, K_padded] int32, K_padded)
+    public func perKVHeadGatherBatched(
+        projectedQ: MLXArray, seqLen T: Int
+    ) -> (MLXArray, Int) {
+        let staticInit = config.staticInit
+        let slidingWindow = config.slidingWindow
+        let fineBS = config.fineBlockSize
+        let coarseBS = config.coarseBlockSize
+        let kFineEff = min(config.effectiveFineTopK(seqLen: T),
+                           fineBlockFeatures?.dim(2) ?? 0)
+        let kCoarseEff = config.coarseRescueEnabled
+            ? min(config.coarseTopK, coarseBlockFeatures?.dim(2) ?? 0)
+            : 0
+        let staticEnd = min(staticInit, T)
+        let slidingStart = max(0, T - slidingWindow)
+        let staticCount = staticEnd
+        let slidingCount = max(0, T - slidingStart)
+        let kPadded = staticCount + slidingCount
+            + kFineEff * fineBS + kCoarseEff * coarseBS
+
+        // Static + sliding ranges — same across (B, nKVH).
+        let staticPositions = staticCount > 0
+            ? MLXArray(Int32(0)..<Int32(staticEnd))
+            : MLXArray.zeros([0], dtype: .int32)
+        let slidingPositions = slidingCount > 0
+            ? MLXArray(Int32(slidingStart)..<Int32(T))
+            : MLXArray.zeros([0], dtype: .int32)
+        let baseSS = concatenated([staticPositions, slidingPositions], axis: 0)
+            .reshaped(1, 1, staticCount + slidingCount)
+        let staticBroadcast = broadcast(
+            baseSS, to: [B, nKVHeads, staticCount + slidingCount])
+
+        var pieces: [MLXArray] = [staticBroadcast]
+        if kFineEff > 0 {
+            let fineStarts = topKFineBlockStarts(projectedQ: projectedQ)
+            // expand to per-token block positions:
+            //   [B, nKVH, kFineEff] + [1, 1, 1, fineBS] = [B, nKVH, kFineEff, fineBS]
+            let offsets = MLXArray(0..<Int32(fineBS)).reshaped(1, 1, 1, fineBS)
+            let expanded = fineStarts.expandedDimensions(axis: 3) + offsets
+            pieces.append(expanded.reshaped(B, nKVHeads, kFineEff * fineBS))
+        }
+        if kCoarseEff > 0 {
+            let coarseStarts = topKCoarseBlockStarts(projectedQ: projectedQ)
+            let offsets = MLXArray(0..<Int32(coarseBS)).reshaped(1, 1, 1, coarseBS)
+            let expanded = coarseStarts.expandedDimensions(axis: 3) + offsets
+            pieces.append(expanded.reshaped(B, nKVHeads, kCoarseEff * coarseBS))
+        }
+        let unsorted = concatenated(pieces, axis: 2)  // [B, nKVH, kPadded]
+        let clipped = clip(unsorted, min: Int32(0), max: Int32(T - 1))
+        // `sorted` on int32 returns int64; group SDPA kernel takes int32
+        // gather. Force back to int32 before handing to the kernel.
+        let sortedGather = sorted(clipped, axis: -1).asType(.int32)
+        return (sortedGather, kPadded)
+    }
+}

--- a/Libraries/MLXLMCommon/BatchedRetrievalAttentionKVCache.swift
+++ b/Libraries/MLXLMCommon/BatchedRetrievalAttentionKVCache.swift
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// BatchedRetrievalAttentionKVCache — sparse-aware decode wrapper for the
+// flat batched KV cache.
+//
+// Composition: an inner BatchedKVCache holds the rectangular fp16 K/V.
+// The batched selector index sits alongside. At decode L=1:
+//   1. cache.update writes new K/V into the rectangular buffer.
+//   2. updateIndex folds the new K (post-RoPE) into per-slot block features.
+//   3. sparseAttend projects per-(B, KV) Q -> top-K -> emits a per-slot
+//      fp16 mask + dispatches MLXFast.SDPA on the sdpa_vector_2pass path.
+//
+// Assumes rectangular T (all slots at the same offset) at decode time.
+// Continuous-batching ragged-T is a future concern.
+
+import Foundation
+import MLX
+
+public final class BatchedRetrievalAttentionKVCache {
+
+    /// Inner batched K/V cache. We hold a strong ref but don't own
+    /// lifecycle exclusively — the model's per-layer cache list owns it.
+    public let inner: BatchedKVCache
+
+    /// Per-(B, KV-head) selector index.
+    public let index: BatchedRetrievalAttentionIndexB
+
+    public let raConfig: RetrievalAttentionConfig
+    public let layerIdx: Int
+    public let totalLayers: Int
+    public let ropeBase: Float
+
+    /// Cached `[B, nKVH]` int32 array of representative Q-head indices per
+    /// KV group. Built lazily on first sparseAttend.
+    private var cachedHeadIdx: MLXArray?
+
+    /// Env-gated kernel selection. Default is the batched mask kernel
+    /// (`fp16 additive mask + MLXFast SDPA` on the sdpa_vector_2pass path
+    /// — this hits the tuned Metal fast path on M-series GPUs).
+    ///
+    /// Values:
+    ///   "mask"  (default) — batched fp16 mask + MLXFast SDPA
+    ///   "loop"            — Swift loop over per-slot single-batch mask + SDPA
+    ///   "group"           — fused sparse SDPA group kernel (gather-based)
+    ///   "gather"          — compose-gather (per-slot K/V materialize then dense SDPA)
+    public static let envBatchedKernel: String = {
+        ProcessInfo.processInfo.environment["VSM_SPARSE_BATCHED_KERNEL"]
+            ?? "mask"
+    }()
+
+    public var isSparseEligible: Bool {
+        raConfig.isSparseLayer(layerIdx: layerIdx, totalLayers: totalLayers)
+    }
+
+    public init(
+        inner: BatchedKVCache,
+        B: Int,
+        nKVHeads: Int,
+        dHead: Int,
+        layerIdx: Int,
+        totalLayers: Int,
+        raConfig: RetrievalAttentionConfig = RetrievalAttentionConfig(),
+        ropeBase: Float = 10_000.0
+    ) {
+        self.inner = inner
+        self.layerIdx = layerIdx
+        self.totalLayers = totalLayers
+        self.raConfig = raConfig
+        self.ropeBase = ropeBase
+        self.index = BatchedRetrievalAttentionIndexB(
+            config: raConfig, B: B, dHead: dHead, nKVHeads: nKVHeads,
+            ropeBase: ropeBase, layerIdx: layerIdx)
+    }
+
+    /// Apply a new K chunk to the selector index. Caller has ALREADY
+    /// written K/V into the inner cache; this only updates selector state.
+    /// Decode-step (L=1) is the common path; prefill chunks (L>1) also.
+    public func updateIndex(newKeys: MLXArray) {
+        guard isSparseEligible else { return }
+        // Skip index updates on decode tokens — they live in the sliding
+        // window so block-feature membership doesn't help selection.
+        let L = newKeys.dim(2)
+        if L > 1 {
+            index.update(newKeys: newKeys.asType(.float32))
+        }
+        // (no L==1 update — sliding window covers it)
+    }
+
+    /// Sparse attend at decode step (L=1).
+    ///
+    /// - Parameters:
+    ///   - queries: `[B, nQH, 1, D]` post-RoPE Q (already broadcasted with
+    ///     GQA group expansion).
+    ///   - scale: SDPA scale (1/sqrt(D)).
+    /// - Returns: `[B, nQH, 1, D]` attention output.
+    ///
+    /// Dispatches by `VSM_SPARSE_BATCHED_KERNEL` env (see static doc).
+    public func sparseAttend(
+        queries: MLXArray, scale: Float
+    ) -> MLXArray {
+        precondition(queries.shape.count == 4, "queries must be [B, nQH, 1, D]")
+        precondition(queries.dim(2) == 1, "decode-step L=1 only")
+        let B = queries.dim(0)
+        let nQH = queries.dim(1)
+        precondition(B == index.B, "B mismatch")
+
+        // Pull rectangular K/V at the current offset. All slots assumed
+        // to share offset (rectangular T) — caller responsible if not.
+        let off = inner.offsets[0]
+        let cachedK = inner.keys[..<B, 0..., ..<off, 0...]
+        let cachedV = inner.values[..<B, 0..., ..<off, 0...]
+        let nKVH = cachedK.dim(1)
+        let T = cachedK.dim(2)
+        precondition(nQH % nKVH == 0)
+        let groupSize = nQH / nKVH
+
+        // Build rep-per-group Q indices once.
+        if cachedHeadIdx == nil {
+            cachedHeadIdx = MLXArray((0..<nKVH).map { Int32($0 * groupSize) })
+            eval(cachedHeadIdx!)
+        }
+        let qSqueezed = queries[0..., 0..., 0, 0...]                         // [B, nQH, D]
+        let qRep = qSqueezed.take(cachedHeadIdx!, axis: 1).asType(.float32)  // [B, nKVH, D]
+        let projQ = index.projectQueriesBatched(qRep)                        // [B, nKVH, contentDim]
+
+        let kernelChoice = BatchedRetrievalAttentionKVCache.envBatchedKernel
+        switch kernelChoice {
+        case "group":
+            let (gather, _) = index.perKVHeadGatherBatched(projectedQ: projQ, seqLen: T)
+            return retrievalAttentionGroupSparseSDPA(
+                queries: queries,
+                keys: cachedK,
+                values: cachedV,
+                perKVHeadGather: gather,
+                scale: scale
+            )
+
+        case "loop":
+            return sparseAttendLoopMask(
+                queries: queries, projQ: projQ, K: cachedK, V: cachedV,
+                T: T, scale: scale)
+
+        case "gather":
+            return sparseAttendComposeGather(
+                queries: queries, projQ: projQ, K: cachedK, V: cachedV,
+                T: T, scale: scale)
+
+        default:  // "mask" + anything else
+            return sparseAttendBatchedMask(
+                queries: queries, projQ: projQ, K: cachedK, V: cachedV,
+                T: T, scale: scale)
+        }
+    }
+
+    /// Default — one batched mask-kernel launch + MLXFast SDPA on the
+    /// sdpa_vector_2pass kernel variant. Mask is fp16 additive.
+    private func sparseAttendBatchedMask(
+        queries: MLXArray, projQ: MLXArray,
+        K: MLXArray, V: MLXArray, T: Int, scale: Float
+    ) -> MLXArray {
+        // Per-slot per-KV-head top-K block starts. Both shapes [B, nKVH, K].
+        let fineStarts = index.topKFineBlockStarts(projectedQ: projQ)
+        let coarseStarts = index.topKCoarseBlockStarts(projectedQ: projQ)
+        let mask = retrievalAttentionBuildMaskFusedBatched(
+            fineStarts: fineStarts,
+            coarseStarts: coarseStarts,
+            T: T,
+            staticInit: raConfig.staticInit,
+            slidingWindow: raConfig.slidingWindow,
+            fineBS: raConfig.fineBlockSize,
+            coarseBS: raConfig.coarseBlockSize,
+            outputDtype: K.dtype
+        )
+        // mask is [B, 1, 1, T] — broadcasts over nQH and L=1.
+        return MLXFast.scaledDotProductAttention(
+            queries: queries, keys: K, values: V,
+            scale: scale, mask: .array(mask)
+        )
+    }
+
+    /// Fallback: B Swift-side launches of the single-batch mask kernel +
+    /// per-slot MLXFast SDPA. Only for A/B sanity; expected slower at B>1.
+    private func sparseAttendLoopMask(
+        queries: MLXArray, projQ: MLXArray,
+        K: MLXArray, V: MLXArray, T: Int, scale: Float
+    ) -> MLXArray {
+        let B = queries.dim(0)
+        let fineStarts = index.topKFineBlockStarts(projectedQ: projQ)
+        let coarseStarts = index.topKCoarseBlockStarts(projectedQ: projQ)
+        var outputs: [MLXArray] = []
+        outputs.reserveCapacity(B)
+        for b in 0..<B {
+            let fineB = fineStarts[b, 0..., 0...]    // [nKVH, K_fine]
+            let coarseB = coarseStarts[b, 0..., 0...]
+            let mask = retrievalAttentionBuildMaskFused(
+                fineStarts: fineB,
+                coarseStarts: coarseB,
+                T: T,
+                staticInit: raConfig.staticInit,
+                slidingWindow: raConfig.slidingWindow,
+                fineBS: raConfig.fineBlockSize,
+                coarseBS: raConfig.coarseBlockSize,
+                outputDtype: K.dtype
+            )  // [1, 1, 1, T]
+            let qSlot = queries[b ..< (b + 1), 0..., 0..., 0...]  // [1, nQH, 1, D]
+            let kSlot = K[b ..< (b + 1), 0..., 0..., 0...]
+            let vSlot = V[b ..< (b + 1), 0..., 0..., 0...]
+            let oSlot = MLXFast.scaledDotProductAttention(
+                queries: qSlot, keys: kSlot, values: vSlot,
+                scale: scale, mask: .array(mask)
+            )
+            outputs.append(oSlot)
+        }
+        return concatenated(outputs, axis: 0)
+    }
+
+    /// Compose-gather: build per-(B, nKVH) gather index `[B, nKVH, K_padded]`,
+    /// take K/V along axis 2 to materialize `[B, nKVH, K_padded, D]` slabs,
+    /// then call dense MLXFast SDPA with `mask: .none` on the small slab.
+    /// GQA broadcast (nKVH → nQH) is handled internally by MLXFast.
+    private func sparseAttendComposeGather(
+        queries: MLXArray, projQ: MLXArray,
+        K: MLXArray, V: MLXArray, T: Int, scale: Float
+    ) -> MLXArray {
+        let (gather, kPadded) = index.perKVHeadGatherBatched(
+            projectedQ: projQ, seqLen: T)
+        precondition(gather.shape.count == 3, "gather must be [B, nKVH, K_padded]")
+        precondition(gather.dim(0) == queries.dim(0), "gather B mismatch")
+        let gExp = gather.expandedDimensions(axis: 3)        // [B, nKVH, K_padded, 1]
+        let kSmall = takeAlong(K, gExp, axis: 2)             // [B, nKVH, K_padded, D]
+        let vSmall = takeAlong(V, gExp, axis: 2)             // [B, nKVH, K_padded, D]
+        _ = kPadded
+        return MLXFast.scaledDotProductAttention(
+            queries: queries, keys: kSmall, values: vSmall,
+            scale: scale, mask: .none
+        )
+    }
+}

--- a/Libraries/MLXLMCommon/BatchedRetrievalAttentionKernels.swift
+++ b/Libraries/MLXLMCommon/BatchedRetrievalAttentionKernels.swift
@@ -1,0 +1,511 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// Custom Metal kernels for the batched retrieval-attention decode path.
+//
+// Three kernels live here:
+//   1. ra_build_mask          — single-slot fp32 mask builder (per-position
+//                               membership check vs static / sliding /
+//                               top-K-fine / top-K-coarse selections).
+//   2. ra_build_mask_b        — batched sibling; one TG per (slot, T-tile).
+//   3. ra_group_sdpa_decode   — NSA-style fused sparse SDPA decode kernel
+//                               with per-(B, KV-head) gather list. Each
+//                               threadgroup serves one (B, Q-head); group
+//                               sharing of K/V loads across the GQA group
+//                               is done at the threadgroup level (1024
+//                               threads = 32 simdgroups x 32 lanes).
+//
+// These are the minimal subset required by the BATCHED decode stack here.
+
+import Foundation
+import MLX
+
+/// Cached one-time-constructed kernel handles. Built lazily on first call.
+private final class _BatchedRAKernelCache: @unchecked Sendable {
+    static let shared = _BatchedRAKernelCache()
+    private let lock = NSLock()
+    private var groupSDPAKernel: MLXFast.MLXFastKernel?
+    private var buildMaskKernel: MLXFast.MLXFastKernel?
+    private var buildMaskBatchedKernel: MLXFast.MLXFastKernel?
+
+    /// NSA-style group-centric fused sparse SDPA. One threadgroup per
+    /// (B, Q head); BN=32 simdgroups process BN gather positions in
+    /// parallel via simd_sum.
+    func getGroupSDPA() -> MLXFast.MLXFastKernel {
+        lock.lock()
+        defer { lock.unlock() }
+        if let k = groupSDPAKernel { return k }
+        let header = """
+            // Group-centric fused sparse SDPA decode kernel.
+
+            """
+        let source = """
+            // Template constants: HEAD_DIM, GROUP_SIZE
+            // Inputs:
+            //   q:       [B, NQH, 1, HEAD_DIM]
+            //   k:       [B, NKVH, T, HEAD_DIM]
+            //   v:       [B, NKVH, T, HEAD_DIM]
+            //   gather:  [B * NKVH * K_padded] int32 (sorted, may carry -1 sentinels)
+            //   params:  [scale, NQH_f, NKVH_f, T_f, K_padded_f]
+            // Output:
+            //   out:     [B, NQH, 1, HEAD_DIM]  (fp32 inside; Swift casts to Q dtype)
+            //
+            // Layout matches mlx-swift sdpa_vector:
+            //   threadgroup = BN=32 simdgroups x BD=32 lanes = 1024 threads
+            //   qk_per_thread = HEAD_DIM / BD
+            //   inner gather loop: for i = simd_gid; i < K_padded; i += BN
+            //   simd_sum for QK reduction (no threadgroup barriers)
+            //
+            // Grid: (B * NQH * 1024, 1, 1). One threadgroup per (B, Q head).
+
+            constexpr int BN = 32;
+            constexpr int BD = 32;
+            constexpr int qk_per_thread = HEAD_DIM / BD;
+            constexpr int v_per_thread = HEAD_DIM / BD;
+
+            const float scale = params[0];
+            const uint NQH = (uint)params[1];
+            const uint NKVH = (uint)params[2];
+            const uint T = (uint)params[3];
+            const uint K_padded = (uint)params[4];
+
+            const uint qh_idx = threadgroup_position_in_grid.x;
+            const uint simd_gid = simdgroup_index_in_threadgroup;
+            const uint simd_lid = thread_index_in_simdgroup;
+            const uint b = qh_idx / NQH;
+            const uint qh = qh_idx % NQH;
+            const uint kvh = qh / GROUP_SIZE;
+
+            // Threadgroup state for cross-simd reduce at the end.
+            threadgroup float outputs[BN * BD];
+            threadgroup float max_scores[BN];
+            threadgroup float sum_exp_scores[BN];
+
+            // Per-thread Q register file: qk_per_thread elements pre-scaled.
+            float q_local[qk_per_thread];
+            float k_local[qk_per_thread];
+            float o_local[v_per_thread];
+
+            // Load Q (this thread owns lanes [simd_lid * qk_per_thread, ...]).
+            const uint q_base = (b * NQH + qh) * HEAD_DIM
+                                 + simd_lid * qk_per_thread;
+            for (int i = 0; i < qk_per_thread; i++) {
+                q_local[i] = scale * (float)q[q_base + i];
+            }
+            for (int i = 0; i < v_per_thread; i++) {
+                o_local[i] = 0.0f;
+            }
+
+            float max_score = -INFINITY;
+            float sum_exp_score = 0.0f;
+
+            const uint gather_base = (b * NKVH + kvh) * K_padded;
+
+            // Each simdgroup processes a strided slice of K_padded.
+            for (uint i = simd_gid; i < K_padded; i += BN) {
+                const int pos = gather[gather_base + i];
+                // Sentinel skip: -1 marks adjacent-dup positions deduped upstream.
+                if (pos < 0) continue;
+
+                const uint kv_base = (b * NKVH + kvh) * T * HEAD_DIM
+                                     + (uint)pos * HEAD_DIM
+                                     + simd_lid * qk_per_thread;
+
+                // Load qk_per_thread K elements
+                for (int j = 0; j < qk_per_thread; j++) {
+                    k_local[j] = (float)k[kv_base + j];
+                }
+
+                // Compute partial QK dot
+                float score = 0.0f;
+                for (int j = 0; j < qk_per_thread; j++) {
+                    score += q_local[j] * k_local[j];
+                }
+                // simd-level reduction across BD=32 lanes - no barriers.
+                score = simd_sum(score);
+
+                // Online softmax update (every lane sees same score).
+                const float new_max = fmax(max_score, score);
+                const float factor = (max_score == -INFINITY)
+                    ? 0.0f : exp(max_score - new_max);
+                const float exp_score = exp(score - new_max);
+                max_score = new_max;
+                sum_exp_score = sum_exp_score * factor + exp_score;
+
+                // V accumulate
+                for (int j = 0; j < v_per_thread; j++) {
+                    const float v_local = (float)v[kv_base + j];
+                    o_local[j] = o_local[j] * factor + exp_score * v_local;
+                }
+            }
+
+            // Cross-simdgroup reduce (mirrors mlx-swift sdpa_vector).
+            if (simd_lid == 0) {
+                max_scores[simd_gid] = max_score;
+                sum_exp_scores[simd_gid] = sum_exp_score;
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+            max_score = max_scores[simd_lid];
+            const float new_max = simd_max(max_score);
+            const float factor = exp(max_score - new_max);
+            sum_exp_score = simd_sum(sum_exp_scores[simd_lid] * factor);
+
+            // Aggregate per-output-dim partials across simdgroups.
+            const uint out_base = (b * NQH + qh) * HEAD_DIM
+                                   + simd_gid * v_per_thread;
+            for (int i = 0; i < v_per_thread; i++) {
+                outputs[simd_lid * BD + simd_gid] = o_local[i];
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                float reduced = simd_sum(outputs[simd_gid * BD + simd_lid] * factor);
+                if (simd_lid == 0) {
+                    out[out_base + i] = sum_exp_score == 0.0f
+                        ? reduced
+                        : (reduced / sum_exp_score);
+                }
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+            }
+            """
+        let k = MLXFast.metalKernel(
+            name: "ra_group_sdpa_decode",
+            inputNames: ["q", "k", "v", "gather", "params"],
+            outputNames: ["out"],
+            source: source,
+            header: header,
+            ensureRowContiguous: true
+        )
+        groupSDPAKernel = k
+        return k
+    }
+
+    /// Single-slot mask builder. Takes per-KV-head top-K block start
+    /// positions plus static/sliding window params and writes the
+    /// [1, 1, 1, T] additive attention mask. One thread per mask position.
+    func getBuildMask() -> MLXFast.MLXFastKernel {
+        lock.lock()
+        defer { lock.unlock() }
+        if let k = buildMaskKernel { return k }
+        let header = """
+            // Fused build-mask kernel (single slot).
+
+            """
+        let source = """
+            // Template constants: FINE_BS, COARSE_BS, NKVH, K_FINE, K_COARSE
+            // Inputs:
+            //   fine_starts:   [NKVH * K_FINE]   int32 block start positions
+            //   coarse_starts: [NKVH * K_COARSE] int32 block start positions
+            //   params:        [T_f, staticInit_f, slidingWindow_f]
+            // Output:
+            //   mask:          [T] float — additive (0 valid, -inf masked)
+
+            const uint p = thread_position_in_grid.x;
+            const uint T = (uint)params[0];
+            if (p >= T) return;
+            const uint staticInit = (uint)params[1];
+            const uint slidingWindow = (uint)params[2];
+            const uint sliding_start = (T > slidingWindow) ? (T - slidingWindow) : 0u;
+
+            // Cache the topK start arrays in threadgroup memory.
+            threadgroup int fine_tg[NKVH * K_FINE];
+            threadgroup int coarse_tg[NKVH * K_COARSE];
+
+            const uint tid = thread_position_in_threadgroup.x;
+            const uint tg_size = threads_per_threadgroup.x;
+            for (uint i = tid; i < NKVH * K_FINE; i += tg_size) {
+                fine_tg[i] = fine_starts[i];
+            }
+            for (uint i = tid; i < NKVH * K_COARSE; i += tg_size) {
+                coarse_tg[i] = coarse_starts[i];
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            bool valid = (p < staticInit) || (p >= sliding_start);
+
+            if (!valid) {
+                for (uint i = 0; i < NKVH * K_FINE && !valid; i++) {
+                    const int start = fine_tg[i];
+                    if ((int)p >= start && (int)p < start + (int)FINE_BS) {
+                        valid = true;
+                    }
+                }
+            }
+            if (!valid) {
+                for (uint i = 0; i < NKVH * K_COARSE && !valid; i++) {
+                    const int start = coarse_tg[i];
+                    if ((int)p >= start && (int)p < start + (int)COARSE_BS) {
+                        valid = true;
+                    }
+                }
+            }
+
+            mask[p] = valid ? 0.0f : -INFINITY;
+            """
+        let k = MLXFast.metalKernel(
+            name: "ra_build_mask",
+            inputNames: ["fine_starts", "coarse_starts", "params"],
+            outputNames: ["mask"],
+            source: source,
+            header: header,
+            ensureRowContiguous: true
+        )
+        buildMaskKernel = k
+        return k
+    }
+
+    /// Batched mask builder. Takes per-slot top-K block starts and writes
+    /// the `[B, 1, 1, T]` additive attention mask in one launch. Grid Y
+    /// axis indexes the batch slot; X axis the mask position.
+    func getBuildMaskBatched() -> MLXFast.MLXFastKernel {
+        lock.lock()
+        defer { lock.unlock() }
+        if let k = buildMaskBatchedKernel { return k }
+        let header = """
+            // Batched build-mask kernel.
+
+            """
+        let source = """
+            // Template constants: FINE_BS, COARSE_BS, NKVH, K_FINE, K_COARSE
+            // Inputs:
+            //   fine_starts:   [B * NKVH * K_FINE]   int32 block start positions
+            //   coarse_starts: [B * NKVH * K_COARSE] int32 block start positions
+            //   params:        [T_f, staticInit_f, slidingWindow_f]
+            // Output:
+            //   mask:          [B * T] float — additive (0 valid, -inf masked)
+
+            const uint p = thread_position_in_grid.x;
+            const uint b = threadgroup_position_in_grid.y;
+            const uint T = (uint)params[0];
+            if (p >= T) return;
+            const uint staticInit = (uint)params[1];
+            const uint slidingWindow = (uint)params[2];
+            const uint sliding_start = (T > slidingWindow) ? (T - slidingWindow) : 0u;
+
+            const uint fine_off = b * (uint)NKVH * (uint)K_FINE;
+            const uint coarse_off = b * (uint)NKVH * (uint)K_COARSE;
+
+            threadgroup int fine_tg[NKVH * K_FINE];
+            threadgroup int coarse_tg[NKVH * K_COARSE];
+
+            const uint tid = thread_position_in_threadgroup.x;
+            const uint tg_size = threads_per_threadgroup.x;
+            for (uint i = tid; i < NKVH * K_FINE; i += tg_size) {
+                fine_tg[i] = fine_starts[fine_off + i];
+            }
+            for (uint i = tid; i < NKVH * K_COARSE; i += tg_size) {
+                coarse_tg[i] = coarse_starts[coarse_off + i];
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            bool valid = (p < staticInit) || (p >= sliding_start);
+
+            if (!valid) {
+                for (uint i = 0; i < NKVH * K_FINE && !valid; i++) {
+                    const int start = fine_tg[i];
+                    if ((int)p >= start && (int)p < start + (int)FINE_BS) {
+                        valid = true;
+                    }
+                }
+            }
+            if (!valid) {
+                for (uint i = 0; i < NKVH * K_COARSE && !valid; i++) {
+                    const int start = coarse_tg[i];
+                    if ((int)p >= start && (int)p < start + (int)COARSE_BS) {
+                        valid = true;
+                    }
+                }
+            }
+
+            mask[b * T + p] = valid ? 0.0f : -INFINITY;
+            """
+        let k = MLXFast.metalKernel(
+            name: "ra_build_mask_b",
+            inputNames: ["fine_starts", "coarse_starts", "params"],
+            outputNames: ["mask"],
+            source: source,
+            header: header,
+            ensureRowContiguous: true
+        )
+        buildMaskBatchedKernel = k
+        return k
+    }
+}
+
+// MARK: - Public wrappers
+
+/// Run the group-centric fused sparse SDPA decode kernel.
+///
+/// - Parameters:
+///   - queries: `[B, nQH, 1, D]` decode-step Q.
+///   - keys: `[B, nKVH, T, D]` cached K (rectangular).
+///   - values: `[B, nKVH, T, D]` cached V (rectangular).
+///   - perKVHeadGather: `[B, nKVH, K_padded]` int32 sorted positions; -1
+///     sentinel marks deduped slots.
+///   - scale: SDPA scale (typically `1/sqrt(D)`).
+/// - Returns: `[B, nQH, 1, D]` attention output, dtype = queries.dtype.
+public func retrievalAttentionGroupSparseSDPA(
+    queries: MLXArray,
+    keys: MLXArray,
+    values: MLXArray,
+    perKVHeadGather: MLXArray,
+    scale: Float
+) -> MLXArray {
+    precondition(queries.shape.count == 4, "queries must be [B, nQH, 1, D]")
+    precondition(keys.shape.count == 4, "keys must be [B, nKVH, T, D]")
+    precondition(values.shape.count == 4, "values must be [B, nKVH, T, D]")
+    precondition(perKVHeadGather.shape.count == 3,
+        "gather must be [B, nKVH, K_padded] (got \(perKVHeadGather.shape))")
+    let B = queries.dim(0)
+    let nQH = queries.dim(1)
+    precondition(queries.dim(2) == 1, "decode-step L=1 only")
+    let D = queries.dim(3)
+    let nKVH = keys.dim(1)
+    let T = keys.dim(2)
+    precondition(perKVHeadGather.dim(0) == B && perKVHeadGather.dim(1) == nKVH,
+        "gather batch/heads mismatch")
+    let kPadded = perKVHeadGather.dim(2)
+    precondition(keys.dim(3) == D, "K head_dim must match Q")
+    precondition(values.dim(3) == D, "V head_dim must equal K (Dv==D)")
+    precondition(nQH % nKVH == 0, "Q heads must be a multiple of KV heads")
+    let groupSize = nQH / nKVH
+    precondition([32, 64, 96, 128, 256].contains(D),
+        "head_dim \(D) outside the supported template list")
+
+    let params = MLXArray([
+        scale,
+        Float(nQH),
+        Float(nKVH),
+        Float(T),
+        Float(kPadded),
+    ])
+    let gatherFlat = perKVHeadGather.reshaped(B * nKVH * kPadded)
+
+    let kernel = _BatchedRAKernelCache.shared.getGroupSDPA()
+    // One threadgroup per (B, Q head). 1024 threads/TG (32 simdgroups
+    // x 32 lanes), matching mlx-swift sdpa_vector layout.
+    let TGSize = 1024
+    let totalThreads = B * nQH * TGSize
+    let outputs = kernel(
+        [queries, keys, values, gatherFlat, params],
+        template: [
+            ("HEAD_DIM", D),
+            ("GROUP_SIZE", groupSize),
+        ],
+        grid: (totalThreads, 1, 1),
+        threadGroup: (TGSize, 1, 1),
+        outputShapes: [[B, nQH, 1, D]],
+        outputDTypes: [.float32]
+    )
+    return outputs[0].asType(queries.dtype)
+}
+
+/// Build a single-slot `[1, 1, 1, T]` additive attention mask via the
+/// fused membership-check kernel.
+///
+/// - Parameters:
+///   - fineStarts: `[nKVH, K_fine]` int32 block-start positions.
+///   - coarseStarts: `[nKVH, K_coarse]` int32 block-start positions.
+///   - T: total cache positions.
+///   - staticInit / slidingWindow / fineBS / coarseBS: window params.
+///   - outputDtype: cast for the returned mask (typically `K.dtype`).
+/// - Returns: `[1, 1, 1, T]` additive mask (0 valid, -inf masked).
+public func retrievalAttentionBuildMaskFused(
+    fineStarts: MLXArray,
+    coarseStarts: MLXArray,
+    T: Int,
+    staticInit: Int,
+    slidingWindow: Int,
+    fineBS: Int,
+    coarseBS: Int,
+    outputDtype: DType
+) -> MLXArray {
+    precondition(fineStarts.shape.count == 2, "fineStarts must be [nKVH, K_fine]")
+    precondition(coarseStarts.shape.count == 2, "coarseStarts must be [nKVH, K_coarse]")
+    let nKVH = fineStarts.dim(0)
+    let kFine = fineStarts.dim(1)
+    let kCoarse = coarseStarts.dim(1)
+    precondition(coarseStarts.dim(0) == nKVH, "head count mismatch")
+
+    let params = MLXArray([
+        Float(T), Float(staticInit), Float(slidingWindow),
+    ])
+    let fineFlat = fineStarts.reshaped(nKVH * kFine)
+    let coarseFlat = coarseStarts.reshaped(nKVH * kCoarse)
+
+    let kernel = _BatchedRAKernelCache.shared.getBuildMask()
+    let tgSize = 256
+    // Round up grid to threadgroup multiple so the kernel only does
+    // bounds-check on `p`.
+    let gridX = ((T + tgSize - 1) / tgSize) * tgSize
+    let outputs = kernel(
+        [fineFlat, coarseFlat, params],
+        template: [
+            ("FINE_BS", fineBS),
+            ("COARSE_BS", coarseBS),
+            ("NKVH", nKVH),
+            ("K_FINE", kFine),
+            ("K_COARSE", kCoarse),
+        ],
+        grid: (gridX, 1, 1),
+        threadGroup: (tgSize, 1, 1),
+        outputShapes: [[1, 1, 1, T]],
+        outputDTypes: [.float32]
+    )
+    return outputs[0].asType(outputDtype)
+}
+
+/// Build a batched `[B, 1, 1, T]` additive attention mask in one launch
+/// from per-slot top-K block starts.
+///
+/// - Parameters:
+///   - fineStarts: `[B, nKVH, K_fine]` int32 token positions.
+///   - coarseStarts: `[B, nKVH, K_coarse]` int32 token positions.
+///   - T: total cache positions (rectangular across slots).
+///   - staticInit / slidingWindow / fineBS / coarseBS: window params.
+///   - outputDtype: cast for the returned mask (typically `K.dtype`).
+/// - Returns: `[B, 1, 1, T]` additive mask.
+public func retrievalAttentionBuildMaskFusedBatched(
+    fineStarts: MLXArray,
+    coarseStarts: MLXArray,
+    T: Int,
+    staticInit: Int,
+    slidingWindow: Int,
+    fineBS: Int,
+    coarseBS: Int,
+    outputDtype: DType
+) -> MLXArray {
+    precondition(fineStarts.shape.count == 3,
+        "fineStarts must be [B, nKVH, K_fine] (got \(fineStarts.shape))")
+    precondition(coarseStarts.shape.count == 3,
+        "coarseStarts must be [B, nKVH, K_coarse] (got \(coarseStarts.shape))")
+    let B = fineStarts.dim(0)
+    let nKVH = fineStarts.dim(1)
+    let kFine = fineStarts.dim(2)
+    let kCoarse = coarseStarts.dim(2)
+    precondition(coarseStarts.dim(0) == B, "B mismatch")
+    precondition(coarseStarts.dim(1) == nKVH, "head count mismatch")
+
+    let params = MLXArray([
+        Float(T), Float(staticInit), Float(slidingWindow),
+    ])
+    let fineFlat = fineStarts.reshaped(B * nKVH * kFine)
+    let coarseFlat = coarseStarts.reshaped(B * nKVH * kCoarse)
+
+    let kernel = _BatchedRAKernelCache.shared.getBuildMaskBatched()
+    let tgSize = 256
+    let gridX = ((T + tgSize - 1) / tgSize) * tgSize
+    let outputs = kernel(
+        [fineFlat, coarseFlat, params],
+        template: [
+            ("FINE_BS", fineBS),
+            ("COARSE_BS", coarseBS),
+            ("NKVH", nKVH),
+            ("K_FINE", kFine),
+            ("K_COARSE", kCoarse),
+        ],
+        // Grid: (T-tile X) x (B slots Y) x 1.
+        grid: (gridX, B, 1),
+        threadGroup: (tgSize, 1, 1),
+        outputShapes: [[B, 1, 1, T]],
+        outputDTypes: [.float32]
+    )
+    return outputs[0].asType(outputDtype)
+}

--- a/Libraries/MLXLMCommon/BatchedSparseLLM.swift
+++ b/Libraries/MLXLMCommon/BatchedSparseLLM.swift
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// Conformance hook for pure-attention LLMs that can route decode through
+// the batched sparse attention path. The bridge / engine `as?`-casts a
+// loaded model to this protocol and dispatches `fullyBatchedSparseDecode`
+// when a `BatchedRetrievalAttentionKVCache` list exists for the active
+// session pool.
+
+import Foundation
+import MLX
+
+/// Models that can decode one step in a single batched call with sparse
+/// attention should conform to this protocol. The decode path expects a
+/// pre-built per-layer `BatchedRetrievalAttentionKVCache` list — the
+/// caller is responsible for cache lifetime (slot add / remove / reset).
+///
+/// Inputs:
+///   - `[B, 1]` token IDs.
+///
+/// Returns:
+///   - `[B, 1, vocab]` logits.
+public protocol BatchedSparseLLM: AnyObject {
+    func fullyBatchedSparseDecode(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray
+}

--- a/Libraries/MLXLMCommon/Models/Gemma3+Sparse.swift
+++ b/Libraries/MLXLMCommon/Models/Gemma3+Sparse.swift
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// Batched sparse decode hooks for the shared Gemma 3 layer stack.
+// Gemma 3 specifics:
+//   - Q/K RMSNorm applied AFTER the [B, H, L, D] transpose, BEFORE RoPE.
+//   - Sliding-window vs global attention alternate per `slidingWindowPattern`
+//     (typically 6: every 6th layer is global, the rest are sliding). Each
+//     layer has its own RoPE — sliding uses local rope base, global uses
+//     the standard rope base + scaling.
+//   - Backbone scales embedded inputs by sqrt(hiddenSize) before the stack.
+//   - Clip-residual (no plain addition) between attn / mlp residuals.
+//   - Pre/post-feedforward layernorms wrap the MLP.
+
+import Foundation
+import MLX
+import MLXNN
+
+extension Gemma3.Attention {
+
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+        let cache = raCache.inner
+
+        var queries = queryProj(x)
+        var keys = keyProj(x)
+        var values = valueProj(x)
+
+        queries = queries.reshaped(B, L, nHeads, -1).transposed(0, 2, 1, 3)
+        keys = keys.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
+        values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
+
+        // Gemma3-specific: norm BEFORE RoPE, on [B, H, L, D] tensors.
+        queries = queryNorm(queries)
+        keys = keyNorm(keys)
+
+        let allSameOffset = cache.offsets[0 ..< cache.active]
+            .allSatisfy { $0 == cache.offsets[0] }
+        let preUpdateK: MLXArray
+        if allSameOffset {
+            let offset = cache.offsets[0]
+            queries = rope(queries, offset: offset)
+            keys = rope(keys, offset: offset)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        } else {
+            let qSlices = split(queries, parts: B, axis: 0)
+            let kSlices = split(keys, parts: B, axis: 0)
+            var rotQ = [MLXArray]()
+            var rotK = [MLXArray]()
+            rotQ.reserveCapacity(B)
+            rotK.reserveCapacity(B)
+            for i in 0 ..< B {
+                let off = cache.offsets[i]
+                rotQ.append(rope(qSlices[i], offset: off))
+                rotK.append(rope(kSlices[i], offset: off))
+            }
+            queries = concatenated(rotQ, axis: 0)
+            keys = concatenated(rotK, axis: 0)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        }
+
+        raCache.updateIndex(newKeys: preUpdateK)
+
+        let output: MLXArray
+        if L == 1 && raCache.isSparseEligible {
+            output = raCache.sparseAttend(queries: queries, scale: scale)
+        } else {
+            let (k, v, mask) = cache.getCachedWithMask()
+            output = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: k, values: v,
+                scale: scale, mask: .array(mask))
+        }
+        return outputProj(output.transposed(0, 2, 1, 3).reshaped(B, L, -1))
+    }
+}
+
+extension Gemma3.TransformerBlock {
+
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache
+    ) -> MLXArray {
+        let r = selfAttention.fullyBatchedSparseForward(inputLayerNorm(x), raCache: raCache)
+        let h = Gemma.clipResidual(x, postAttentionLayerNorm(r))
+        let r2 = mlp(preFeedforwardLayerNorm(h))
+        return Gemma.clipResidual(h, postFeedforwardLayerNorm(r2))
+    }
+}
+
+extension Gemma3.Backbone {
+
+    public func fullyBatchedSparseForward(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        precondition(raCaches.count == layers.count,
+            "raCaches count (\(raCaches.count)) must match layers count (\(layers.count))")
+        var h = embedTokens(inputs)
+
+        // sqrt(hiddenSize) scale (computed in bf16 then cast to runtime dtype).
+        let scale = MLXArray(sqrt(Float(config.hiddenSize)), dtype: .bfloat16)
+            .asType(h.dtype)
+        h = h * scale
+
+        for (i, layer) in layers.enumerated() {
+            h = layer.fullyBatchedSparseForward(h, raCache: raCaches[i])
+        }
+        return norm(h)
+    }
+}

--- a/Libraries/MLXLMCommon/Models/Mistral3+Sparse.swift
+++ b/Libraries/MLXLMCommon/Models/Mistral3+Sparse.swift
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// Batched sparse decode hooks for the shared Mistral 3 / Ministral 3 layer
+// stack. Llama-style attention with two specifics:
+//   1. Llama-4 attention scaling: caller passes a pre-computed `attnScale`
+//      tensor (computed once per forward in ModelInner), multiplied into the
+//      post-RoPE queries.
+//   2. Per-layer sliding / full attention dispatch via `layer.useSliding`.
+//      Both layer kinds route through `BatchedRetrievalAttentionKVCache` —
+//      sparse-eligibility is decided at the `RetrievalAttentionConfig` level,
+//      not per layer kind.
+
+import Foundation
+import MLX
+import MLXNN
+
+extension Mistral3.Attention {
+
+    /// Batched sparse forward for a single decode step. Takes the
+    /// pre-computed Llama-4 `attnScale` tensor — caller (ModelInner) is
+    /// responsible for either computing it from the rope params or passing
+    /// a constant-1 tensor when the model isn't Llama-4-scaled.
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        attnScale: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+        let cache = raCache.inner
+
+        var queries = wq(x)
+        var keys = wk(x)
+        var values = wv(x)
+
+        queries = queries.reshaped(B, L, nHeads, headDim).transposed(0, 2, 1, 3)
+        keys = keys.reshaped(B, L, nKVHeads, headDim).transposed(0, 2, 1, 3)
+        values = values.reshaped(B, L, nKVHeads, headDim).transposed(0, 2, 1, 3)
+
+        let allSameOffset = cache.offsets[0 ..< cache.active]
+            .allSatisfy { $0 == cache.offsets[0] }
+        let preUpdateK: MLXArray
+        if allSameOffset {
+            let offset = cache.offsets[0]
+            queries = rope(queries, offset: offset)
+            keys = rope(keys, offset: offset)
+            queries = queries * attnScale
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        } else {
+            let qSlices = split(queries, parts: B, axis: 0)
+            let kSlices = split(keys, parts: B, axis: 0)
+            var rotQ = [MLXArray]()
+            var rotK = [MLXArray]()
+            rotQ.reserveCapacity(B)
+            rotK.reserveCapacity(B)
+            for i in 0 ..< B {
+                let off = cache.offsets[i]
+                rotQ.append(rope(qSlices[i], offset: off))
+                rotK.append(rope(kSlices[i], offset: off))
+            }
+            queries = concatenated(rotQ, axis: 0) * attnScale
+            keys = concatenated(rotK, axis: 0)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        }
+
+        raCache.updateIndex(newKeys: preUpdateK)
+
+        let output: MLXArray
+        if L == 1 && raCache.isSparseEligible {
+            output = raCache.sparseAttend(queries: queries, scale: scale)
+        } else {
+            let (k, v, mask) = cache.getCachedWithMask()
+            output = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: k, values: v,
+                scale: scale, mask: .array(mask))
+        }
+        return wo(output.transposed(0, 2, 1, 3).reshaped(B, L, -1))
+    }
+}
+
+extension Mistral3.TransformerBlock {
+
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        attnScale: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache
+    ) -> MLXArray {
+        let r = attention.fullyBatchedSparseForward(
+            inputLayerNorm(x), attnScale: attnScale, raCache: raCache)
+        let h = x + r
+        return h + mlp(postAttentionLayerNorm(h))
+    }
+}
+
+extension Mistral3.ModelInner {
+
+    /// Per-layer dispatch. Caller passes a per-layer `BatchedRetrievalAttentionKVCache`
+    /// list whose length matches `layers.count`. Sliding vs full attention is
+    /// reflected in each layer's `useSliding` — the dense fallback path picks
+    /// the right mask from the inner cache.
+    public func fullyBatchedSparseForward(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        precondition(raCaches.count == layers.count,
+            "raCaches count (\(raCaches.count)) must match layers count (\(layers.count))")
+        var h = embedTokens(inputs)
+
+        // Compute the per-token attention scale once (constant tensor when
+        // Llama-4 scaling isn't configured).
+        let offset = raCaches.first?.inner.offsets[0] ?? 0
+        let attnScale: MLXArray
+        if let ropeParams = args.ropeParameters,
+            let beta = ropeParams["llama_4_scaling_beta"]?.asFloat(),
+            let originalMaxPos = ropeParams["original_max_position_embeddings"]?.asInt()
+        {
+            attnScale = Self.scale(
+                h: h, offset: offset, length: h.dim(1),
+                beta: beta, maxPositionEmbeddings: originalMaxPos)
+        } else {
+            attnScale = MLXArray.ones([h.dim(1), 1]).asType(h.dtype)
+        }
+
+        for (i, layer) in layers.enumerated() {
+            h = layer.fullyBatchedSparseForward(
+                h, attnScale: attnScale, raCache: raCaches[i])
+        }
+        return norm(h)
+    }
+}

--- a/Libraries/MLXLMCommon/Models/Qwen2+Sparse.swift
+++ b/Libraries/MLXLMCommon/Models/Qwen2+Sparse.swift
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// Batched sparse decode hooks for the shared Qwen2 layer stack. Adds
+// `fullyBatchedSparseForward` to Attention, DecoderLayer, and ModelInner
+// without touching the existing dense entry points. At decode L=1 on
+// sparse-eligible layers (per RetrievalAttentionConfig.isSparseLayer),
+// attention routes through BatchedRetrievalAttentionKVCache.sparseAttend.
+// Dense path is used for L>1 prefill chunks AND for dense-band layers.
+
+import Foundation
+import MLX
+import MLXNN
+
+extension Qwen2.Attention {
+
+    /// Batched sparse forward for a single decode step (L=1). The caller
+    /// passes a per-layer `BatchedRetrievalAttentionKVCache` whose inner
+    /// `BatchedKVCache` already has B slots reserved (via `addRequest()`)
+    /// and whose offsets reflect prefill completion.
+    ///
+    /// Cache update writes post-RoPE K/V into the rectangular buffer; the
+    /// selector index gets fed the post-RoPE K (skipped at L=1 — sliding
+    /// window covers decode positions). Then either dense `getCachedWithMask`
+    /// + MLXFast.SDPA or `raCache.sparseAttend` depending on layer eligibility.
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+        let cache = raCache.inner
+
+        // Q/K/V projections, transpose to [B, heads, L, headDim].
+        var queries = wq(x).reshaped(B, L, heads, headDim).transposed(0, 2, 1, 3)
+        var keys = wk(x).reshaped(B, L, kvHeads, headDim).transposed(0, 2, 1, 3)
+        let values = wv(x).reshaped(B, L, kvHeads, headDim).transposed(0, 2, 1, 3)
+
+        // RoPE — fast path when all slots share the same offset (the
+        // common steady-state decode case).
+        let allSameOffset = cache.offsets[0 ..< cache.active]
+            .allSatisfy { $0 == cache.offsets[0] }
+        let preUpdateK: MLXArray
+        if allSameOffset {
+            let offset = cache.offsets[0]
+            queries = rope(queries, offset: offset)
+            keys = rope(keys, offset: offset)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        } else {
+            // Ragged slot offsets — slot-by-slot RoPE then re-stack.
+            let qSlices = split(queries, parts: B, axis: 0)
+            let kSlices = split(keys, parts: B, axis: 0)
+            var rotQ = [MLXArray]()
+            var rotK = [MLXArray]()
+            rotQ.reserveCapacity(B)
+            rotK.reserveCapacity(B)
+            for i in 0 ..< B {
+                let off = cache.offsets[i]
+                rotQ.append(rope(qSlices[i], offset: off))
+                rotK.append(rope(kSlices[i], offset: off))
+            }
+            queries = concatenated(rotQ, axis: 0)
+            keys = concatenated(rotK, axis: 0)
+            preUpdateK = keys
+            cache.update(newKeys: keys, newValues: values)
+        }
+
+        // Feed selector index (skipped at L=1; sliding window covers it).
+        raCache.updateIndex(newKeys: preUpdateK)
+
+        let output: MLXArray
+        if L == 1 && raCache.isSparseEligible {
+            output = raCache.sparseAttend(queries: queries, scale: scale)
+        } else {
+            // Dense path — prefill chunk or dense-band layer.
+            let (k, v, mask) = cache.getCachedWithMask()
+            output = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: k, values: v,
+                scale: scale, mask: .array(mask))
+        }
+        return wo(output.transposed(0, 2, 1, 3).reshaped(B, L, -1))
+    }
+}
+
+extension Qwen2.DecoderLayer {
+
+    /// Layer-level wrapper: pre-norm → sparse attention → residual → MLP.
+    public func fullyBatchedSparseForward(
+        _ x: MLXArray,
+        raCache: BatchedRetrievalAttentionKVCache
+    ) -> MLXArray {
+        let r = attention.fullyBatchedSparseForward(
+            inputLayerNorm(x), raCache: raCache)
+        let h = x + r
+        return h + mlp(postAttentionLayerNorm(h))
+    }
+}
+
+extension Qwen2.ModelInner {
+
+    /// Per-layer dispatch: walk the stack, route each layer through its
+    /// own `BatchedRetrievalAttentionKVCache`. The cache list must have
+    /// length equal to the number of decoder layers.
+    public func fullyBatchedSparseForward(
+        _ inputs: MLXArray,
+        raCaches: [BatchedRetrievalAttentionKVCache]
+    ) -> MLXArray {
+        precondition(raCaches.count == layers.count,
+            "raCaches count (\(raCaches.count)) must match layers count (\(layers.count))")
+        var h = embedTokens(inputs)
+        for (i, layer) in layers.enumerated() {
+            h = layer.fullyBatchedSparseForward(h, raCache: raCaches[i])
+        }
+        return norm(h)
+    }
+}

--- a/Tests/MLXLMTests/BatchedHybridCacheTests.swift
+++ b/Tests/MLXLMTests/BatchedHybridCacheTests.swift
@@ -224,6 +224,7 @@ struct BatchedHybridCacheTests {
             switch layer {
             case .attention(let c): #expect(c.active == 2)
             case .gdn(let c): #expect(c.active == 2)
+            case .sparseAttention(let ra): #expect(ra.inner.active == 2)
             }
         }
     }
@@ -251,6 +252,7 @@ struct BatchedHybridCacheTests {
             switch layer {
             case .attention(let c): #expect(c.active == 2)
             case .gdn(let c): #expect(c.active == 2)
+            case .sparseAttention(let ra): #expect(ra.inner.active == 2)
             }
         }
     }

--- a/Tests/MLXLMTests/BatchedRetrievalAttentionIndexBTests.swift
+++ b/Tests/MLXLMTests/BatchedRetrievalAttentionIndexBTests.swift
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+// Unit tests for BatchedRetrievalAttentionIndexB.
+//
+// Asserts: same K + same Q across slots → same top-K; different Q per
+// slot → different top-K (per-slot selection is real, not shared).
+
+import Foundation
+import MLX
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+@Suite("BatchedRetrievalAttentionIndexB (B dim)")
+struct BatchedRetrievalAttentionIndexBTests {
+
+    @Test func b2RectangularPrefillBuildsBlockFeatures() {
+        let cfg = RetrievalAttentionConfig()  // λ=0 default
+        let B = 2
+        let nKVH = 4
+        let dHead = 64
+        let T = 256       // 4 fine blocks (256/64) + sub-coarse-block
+        let index = BatchedRetrievalAttentionIndexB(
+            config: cfg, B: B, dHead: dHead, nKVHeads: nKVH,
+            ropeBase: 10_000, layerIdx: 0)
+        // Build deterministic K via fixed seed so the test is reproducible.
+        let keys = MLXRandom.normal(
+            [B, nKVH, T, dHead], key: MLXRandom.key(42)
+        ).asType(.float32)
+        index.update(newKeys: keys)
+        // Sanity: per-slot populated count.
+        #expect(index.seqLen(slot: 0) == T)
+        #expect(index.seqLen(slot: 1) == T)
+        // Block feature shape: ceil(256/64) = 4 fine blocks.
+        let ff = index.fineBlockFeatures
+        #expect(ff != nil)
+        #expect(ff!.shape == [B, nKVH, 4, cfg.contentDim])
+    }
+
+    @Test func b2PerSlotTopKIndependent() {
+        // CORE BEHAVIOR — different Q for slot 0 vs slot 1 must pick
+        // different top-K. If we picked the same blocks for both slots,
+        // we'd be batching with a shared selector (semantically wrong).
+        var cfg = RetrievalAttentionConfig()
+        cfg.fineBlockSize = 64
+        cfg.fineTopK = 4
+        cfg.coarseRescueEnabled = false
+        cfg.adaptiveTopK = false  // keep K fixed at 4 so the assert is clean
+        let B = 2
+        let nKVH = 2
+        let dHead = 64
+        let T = 64 * 32   // 32 fine blocks
+        let index = BatchedRetrievalAttentionIndexB(
+            config: cfg, B: B, dHead: dHead, nKVHeads: nKVH,
+            ropeBase: 10_000, layerIdx: 0)
+        // SAME K across both slots so the only difference is Q.
+        let oneK = MLXRandom.normal(
+            [1, nKVH, T, dHead], key: MLXRandom.key(7)
+        ).asType(.float32)
+        let keys = concatenated([oneK, oneK], axis: 0)  // [2, nKVH, T, dHead]
+        index.update(newKeys: keys)
+        // Different Q per slot (so they hit different blocks).
+        let q0 = MLXRandom.normal([nKVH, dHead], key: MLXRandom.key(101))
+        let q1 = MLXRandom.normal([nKVH, dHead], key: MLXRandom.key(202))
+        let qBatched = MLX.stacked([q0, q1], axis: 0)  // [B, nKVH, dHead]
+        let projQ = index.projectQueriesBatched(qBatched)
+        let fineStarts = index.topKFineBlockStarts(projectedQ: projQ)
+        #expect(fineStarts.shape == [B, nKVH, cfg.fineTopK])
+        eval(fineStarts)
+        // Pull per-slot, per-head sets and assert at least one head's set
+        // differs between slot 0 and slot 1.
+        let arr = fineStarts.asArray(Int32.self)
+        var anyDiffer = false
+        for h in 0..<nKVH {
+            let base0 = h * cfg.fineTopK
+            let base1 = nKVH * cfg.fineTopK + h * cfg.fineTopK
+            let slot0Set = Set((0..<cfg.fineTopK).map { Int(arr[base0 + $0]) })
+            let slot1Set = Set((0..<cfg.fineTopK).map { Int(arr[base1 + $0]) })
+            if slot0Set != slot1Set {
+                anyDiffer = true
+            }
+        }
+        #expect(anyDiffer, "per-slot top-K must differ when Q differs")
+    }
+
+    @Test func b2SameQSameKMatchesAcrossSlots() {
+        // Symmetric to the above: SAME K, SAME Q across slots → top-K
+        // sets MUST be identical (otherwise selection is non-deterministic
+        // across batch position).
+        var cfg = RetrievalAttentionConfig()
+        cfg.fineBlockSize = 64
+        cfg.fineTopK = 4
+        cfg.coarseRescueEnabled = false
+        cfg.adaptiveTopK = false
+        let B = 2
+        let nKVH = 2
+        let dHead = 64
+        let T = 64 * 16
+        let index = BatchedRetrievalAttentionIndexB(
+            config: cfg, B: B, dHead: dHead, nKVHeads: nKVH,
+            ropeBase: 10_000, layerIdx: 0)
+        let oneK = MLXRandom.normal([1, nKVH, T, dHead], key: MLXRandom.key(11)).asType(.float32)
+        let keys = concatenated([oneK, oneK], axis: 0)
+        index.update(newKeys: keys)
+        let q = MLXRandom.normal([nKVH, dHead], key: MLXRandom.key(13))
+        let qBatched = MLX.stacked([q, q], axis: 0)
+        let projQ = index.projectQueriesBatched(qBatched)
+        let fineStarts = index.topKFineBlockStarts(projectedQ: projQ)
+        eval(fineStarts)
+        let arr = fineStarts.asArray(Int32.self)
+        for h in 0..<nKVH {
+            let base0 = h * cfg.fineTopK
+            let base1 = nKVH * cfg.fineTopK + h * cfg.fineTopK
+            let slot0Set = Set((0..<cfg.fineTopK).map { Int(arr[base0 + $0]) })
+            let slot1Set = Set((0..<cfg.fineTopK).map { Int(arr[base1 + $0]) })
+            #expect(slot0Set == slot1Set,
+                "head \(h): same K, same Q → expected matching top-K across slots")
+        }
+    }
+
+    @Test func b2GatherShapeMatchesGroupSDPASignature() {
+        // The group-SDPA kernel expects gather shape [B, nKVH, K_padded] int32.
+        // This test pins that the batched index emits that shape so the
+        // cache can hand it directly to retrievalAttentionGroupSparseSDPA.
+        var cfg = RetrievalAttentionConfig()
+        cfg.fineBlockSize = 64
+        cfg.fineTopK = 2
+        cfg.coarseRescueEnabled = false
+        cfg.adaptiveTopK = false
+        cfg.staticInit = 128
+        cfg.slidingWindow = 256
+        let B = 2
+        let nKVH = 2
+        let dHead = 64
+        let T = 1024
+        let index = BatchedRetrievalAttentionIndexB(
+            config: cfg, B: B, dHead: dHead, nKVHeads: nKVH,
+            ropeBase: 10_000, layerIdx: 0)
+        let keys = MLXRandom.normal([B, nKVH, T, dHead], key: MLXRandom.key(99)).asType(.float32)
+        index.update(newKeys: keys)
+        let q = MLXRandom.normal([B, nKVH, dHead], key: MLXRandom.key(100))
+        let projQ = index.projectQueriesBatched(q)
+        let (gather, kPadded) = index.perKVHeadGatherBatched(projectedQ: projQ, seqLen: T)
+        // Expected K_padded = static + sliding + kFine*BS + 0 = 128 + 256 + 2*64 = 512
+        #expect(kPadded == 128 + 256 + 2 * 64)
+        #expect(gather.shape == [B, nKVH, kPadded])
+        #expect(gather.dtype == .int32)
+        // All positions clipped to [0, T-1].
+        eval(gather)
+        let arr = gather.asArray(Int32.self)
+        let allInRange = arr.allSatisfy { $0 >= 0 && $0 < Int32(T) }
+        #expect(allInRange, "gather positions must be in [0, T-1]")
+    }
+
+    @Test func decodeStepRunningMeanMatchesScratchMean() {
+        // Build identical K via prefill, vs prefill-then-decode-1-token,
+        // then check the partial-block mean matches a re-computed scratch
+        // mean. Validates the running-mean shortcut.
+        var cfg = RetrievalAttentionConfig()
+        cfg.fineBlockSize = 8  // small so we hit a partial block
+        cfg.coarseRescueEnabled = false
+        let B = 1
+        let nKVH = 1
+        let dHead = 8
+        let T = 13  // 1 full block (8) + partial (5)
+        let keys = MLXRandom.normal([B, nKVH, T, dHead], key: MLXRandom.key(7)).asType(.float32)
+
+        // Path A: prefill all 13 at once.
+        let indexA = BatchedRetrievalAttentionIndexB(
+            config: cfg, B: B, dHead: dHead, nKVHeads: nKVH,
+            ropeBase: 10_000, layerIdx: 0)
+        indexA.update(newKeys: keys)
+        // Path B: prefill 12, then decode 1.
+        let indexB = BatchedRetrievalAttentionIndexB(
+            config: cfg, B: B, dHead: dHead, nKVHeads: nKVH,
+            ropeBase: 10_000, layerIdx: 0)
+        indexB.update(newKeys: keys[0..., 0..., ..<12, 0...])
+        indexB.update(newKeys: keys[0..., 0..., 12 ..< 13, 0...])
+
+        // Block features must match within float-rounding tolerance.
+        let ffA = indexA.fineBlockFeatures!
+        let ffB = indexB.fineBlockFeatures!
+        #expect(ffA.shape == ffB.shape)
+        let diff = (ffA - ffB).abs().max().item(Float.self)
+        // Running-mean is computed via (mean_old + (added - mean_old)/count)
+        // vs scratch sum/count — fp32 rounding diverges by ~1e-4 per step.
+        // For 5 tokens in the partial block, ~5e-4 is within float noise.
+        #expect(diff < 1e-3, "running-mean drift \(diff) too large")
+    }
+}

--- a/Tests/MLXLMTests/BatchedRetrievalAttentionKVCacheTests.swift
+++ b/Tests/MLXLMTests/BatchedRetrievalAttentionKVCacheTests.swift
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Smoke tests for BatchedRetrievalAttentionKVCache + sparse decode kernel.
+//
+// Asserts: shape contract holds + per-slot outputs differ when Q differs
+// across slots (proves the selector + sparseAttend path is per-slot real).
+
+import Foundation
+import MLX
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+@Suite("BatchedRetrievalAttentionKVCache (group-SDPA feeder)")
+struct BatchedRetrievalAttentionKVCacheTests {
+
+    /// Build a rectangular BatchedKVCache with T tokens of random fp32
+    /// K/V written into the first T slots of each (B, nKVH).
+    private func makeCacheWithT(
+        B: Int, nKVH: Int, T: Int, dHead: Int, seed: UInt64 = 17
+    ) -> BatchedKVCache {
+        let cache = BatchedKVCache(
+            maxBatch: B, kvHeads: nKVH, headDim: dHead, maxSeq: T + 64,
+            dtype: .float32)
+        for _ in 0..<B { _ = cache.addRequest() }
+        // Fill with one big batched chunk by writing the K/V tensors
+        // directly — bypasses the per-token update path.
+        let kAll = MLXRandom.normal(
+            [B, nKVH, T, dHead], key: MLXRandom.key(seed)
+        ).asType(.float32)
+        let vAll = MLXRandom.normal(
+            [B, nKVH, T, dHead], key: MLXRandom.key(seed &+ 1)
+        ).asType(.float32)
+        cache.keys[..<B, 0..., ..<T, 0...] = kAll
+        cache.values[..<B, 0..., ..<T, 0...] = vAll
+        for i in 0..<B { cache.offsets[i] = T }
+        return cache
+    }
+
+    @Test func b2SmokeShape() {
+        var cfg = RetrievalAttentionConfig()
+        cfg.fineBlockSize = 64
+        cfg.coarseRescueEnabled = false
+        cfg.adaptiveTopK = false
+        cfg.fineTopK = 4
+        cfg.staticInit = 128
+        cfg.slidingWindow = 256
+        cfg.denseFirstN = 0
+        cfg.denseLastN = 0
+        let B = 2
+        let nKVH = 2
+        let nQH = 4   // groupSize = 2
+        let dHead = 64
+        let T = 1024
+        let raCache = BatchedRetrievalAttentionKVCache(
+            inner: makeCacheWithT(B: B, nKVH: nKVH, T: T, dHead: dHead),
+            B: B, nKVHeads: nKVH, dHead: dHead,
+            layerIdx: 5, totalLayers: 10, raConfig: cfg)
+        // Populate selector index via prefill update with same K layout.
+        let kPrefill = MLXRandom.normal([B, nKVH, T, dHead], key: MLXRandom.key(101)).asType(.float32)
+        raCache.updateIndex(newKeys: kPrefill)
+
+        let Q = MLXRandom.normal([B, nQH, 1, dHead], key: MLXRandom.key(202))
+        let out = raCache.sparseAttend(queries: Q, scale: pow(Float(dHead), -0.5))
+        #expect(out.shape == [B, nQH, 1, dHead], "sparseAttend output shape contract")
+        eval(out)
+    }
+
+    @Test func b2PerSlotOutputsDiffer() {
+        var cfg = RetrievalAttentionConfig()
+        cfg.fineBlockSize = 64
+        cfg.coarseRescueEnabled = false
+        cfg.adaptiveTopK = false
+        cfg.fineTopK = 4
+        cfg.staticInit = 128
+        cfg.slidingWindow = 256
+        cfg.denseFirstN = 0
+        cfg.denseLastN = 0
+        let B = 2
+        let nKVH = 2
+        let nQH = 4
+        let dHead = 64
+        let T = 1024
+        // SAME K/V across slots so the only differentiator is Q.
+        let oneK = MLXRandom.normal([1, nKVH, T, dHead], key: MLXRandom.key(33)).asType(.float32)
+        let oneV = MLXRandom.normal([1, nKVH, T, dHead], key: MLXRandom.key(34)).asType(.float32)
+        let kAll = concatenated([oneK, oneK], axis: 0)
+        let vAll = concatenated([oneV, oneV], axis: 0)
+        let cache = BatchedKVCache(
+            maxBatch: B, kvHeads: nKVH, headDim: dHead, maxSeq: T + 64,
+            dtype: .float32)
+        for _ in 0..<B { _ = cache.addRequest() }
+        cache.keys[..<B, 0..., ..<T, 0...] = kAll
+        cache.values[..<B, 0..., ..<T, 0...] = vAll
+        for i in 0..<B { cache.offsets[i] = T }
+
+        let raCache = BatchedRetrievalAttentionKVCache(
+            inner: cache,
+            B: B, nKVHeads: nKVH, dHead: dHead,
+            layerIdx: 5, totalLayers: 10, raConfig: cfg)
+        // Selector index sees the same K as the cache.
+        raCache.updateIndex(newKeys: kAll)
+
+        // DIFFERENT Q per slot → different gather → different output.
+        let q0 = MLXRandom.normal([1, nQH, 1, dHead], key: MLXRandom.key(901))
+        let q1 = MLXRandom.normal([1, nQH, 1, dHead], key: MLXRandom.key(902))
+        let Q = concatenated([q0, q1], axis: 0)
+        let out = raCache.sparseAttend(queries: Q, scale: pow(Float(dHead), -0.5))
+        eval(out)
+        // The two slot outputs MUST differ — same K/V, different Q.
+        let slot0 = out[0, 0..., 0, 0...]
+        let slot1 = out[1, 0..., 0, 0...]
+        let diff = (slot0 - slot1).abs().max().item(Float.self)
+        #expect(diff > 1e-3, "expected slot-0 and slot-1 outputs to differ (diff=\(diff))")
+    }
+}

--- a/Tests/MLXLMTests/BatchedSparseMaskTests.swift
+++ b/Tests/MLXLMTests/BatchedSparseMaskTests.swift
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: Apache-2.0
+// Batched sparse mask kernel + sparseAttend path-equivalence tests.
+//
+// Asserts: per-slot batched mask matches per-slot single-batch mask;
+// mask-kernel path matches loop path numerically; compose-gather path
+// matches the group-SDPA kernel path numerically (same selector scope).
+
+import Foundation
+import MLX
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Batched sparse mask kernel + path equivalence")
+struct BatchedSparseMaskTests {
+
+    /// Populating the selector index from a chunk of K should let the
+    /// top-K return non-trivial block starts. Picking blocks 0..k-1 by
+    /// index order (the placeholder pattern) would mean
+    /// `topKFineBlockStarts` returns [0, fineBS, 2*fineBS, ...] regardless
+    /// of Q. After real population, picked starts should differ across
+    /// slots with different K.
+    @Test func selectorPicksDifferentBlocksPerSlotAfterPopulation() {
+        var cfg = RetrievalAttentionConfig()
+        cfg.fineBlockSize = 64
+        cfg.coarseRescueEnabled = false
+        cfg.adaptiveTopK = false
+        cfg.fineTopK = 4
+        cfg.staticInit = 64
+        cfg.slidingWindow = 128
+        cfg.denseFirstN = 0
+        cfg.denseLastN = 0
+
+        let B = 2
+        let nKVH = 4
+        let dHead = 64
+        let T = 2048   // 32 fine blocks (way more than fineTopK=4)
+
+        // DIFFERENT K per slot so the optimal blocks differ.
+        let k0 = MLXRandom.normal([1, nKVH, T, dHead], key: MLXRandom.key(41)).asType(.float32)
+        let k1 = MLXRandom.normal([1, nKVH, T, dHead], key: MLXRandom.key(42)).asType(.float32)
+        let kAll = concatenated([k0, k1], axis: 0)
+        let vAll = MLXRandom.normal([B, nKVH, T, dHead], key: MLXRandom.key(43)).asType(.float32)
+
+        let cache = BatchedKVCache(
+            maxBatch: B, kvHeads: nKVH, headDim: dHead, maxSeq: T + 64,
+            dtype: .float32)
+        for _ in 0..<B { _ = cache.addRequest() }
+        cache.keys[..<B, 0..., ..<T, 0...] = kAll
+        cache.values[..<B, 0..., ..<T, 0...] = vAll
+        for i in 0..<B { cache.offsets[i] = T }
+
+        let raCache = BatchedRetrievalAttentionKVCache(
+            inner: cache, B: B, nKVHeads: nKVH, dHead: dHead,
+            layerIdx: 5, totalLayers: 10, raConfig: cfg)
+        raCache.index.update(newKeys: kAll)
+
+        let qRep = MLXRandom.normal([B, nKVH, dHead], key: MLXRandom.key(44)).asType(.float32)
+        let projQ = raCache.index.projectQueriesBatched(qRep)
+        let fineStarts = raCache.index.topKFineBlockStarts(projectedQ: projQ)
+        eval(fineStarts)
+        #expect(fineStarts.shape == [B, nKVH, cfg.fineTopK])
+
+        // Across SOME (slot, head) pairs the picked starts must NOT be
+        // [0, 64, 128, 192] (the placeholder index-order pattern).
+        var pickedDifferentFromIndexOrder = false
+        let starts = fineStarts.asArray(Int32.self)
+        let perHead = cfg.fineTopK
+        outer: for b in 0..<B {
+            for h in 0..<nKVH {
+                let base = b * nKVH * perHead + h * perHead
+                let slot = Array(starts[base ..< base + perHead]).sorted()
+                let placeholder = (0..<perHead).map { Int32($0 * cfg.fineBlockSize) }
+                if slot != placeholder {
+                    pickedDifferentFromIndexOrder = true
+                    break outer
+                }
+            }
+        }
+        #expect(pickedDifferentFromIndexOrder,
+            "after selector population, selector must pick non-placeholder blocks")
+    }
+
+    /// The batched build-mask kernel must emit a mask whose per-slot
+    /// slices equal the single-batch mask for the same inputs.
+    @Test func batchedMaskMatchesPerSlotLoop() {
+        let B = 3
+        let nKVH = 4
+        let kFine = 2
+        let kCoarse = 2
+        let T = 512
+        let staticInit = 64
+        let slidingWindow = 128
+        let fineBS = 32
+        let coarseBS = 128
+
+        let fineStarts = MLXArray(
+            stride(from: Int32(0), to: Int32(B * nKVH * kFine), by: 1).map { $0 % Int32(T / fineBS) * Int32(fineBS) }
+        ).reshaped(B, nKVH, kFine)
+        let coarseStarts = MLXArray(
+            stride(from: Int32(0), to: Int32(B * nKVH * kCoarse), by: 1).map { $0 % Int32(T / coarseBS) * Int32(coarseBS) }
+        ).reshaped(B, nKVH, kCoarse)
+
+        // Batched mask in one launch.
+        let maskBatched = retrievalAttentionBuildMaskFusedBatched(
+            fineStarts: fineStarts, coarseStarts: coarseStarts,
+            T: T, staticInit: staticInit, slidingWindow: slidingWindow,
+            fineBS: fineBS, coarseBS: coarseBS, outputDtype: .float32
+        )
+        #expect(maskBatched.shape == [B, 1, 1, T], "batched mask shape")
+
+        // Per-slot single-batch masks.
+        for b in 0..<B {
+            let fineB = fineStarts[b, 0..., 0...]
+            let coarseB = coarseStarts[b, 0..., 0...]
+            let maskSingle = retrievalAttentionBuildMaskFused(
+                fineStarts: fineB, coarseStarts: coarseB,
+                T: T, staticInit: staticInit, slidingWindow: slidingWindow,
+                fineBS: fineBS, coarseBS: coarseBS, outputDtype: .float32
+            )
+            #expect(maskSingle.shape == [1, 1, 1, T])
+            let slotBatched = maskBatched[b ..< (b + 1), 0..., 0..., 0...]
+            let diff = (slotBatched - maskSingle).abs().max().item(Float.self)
+            #expect(diff == 0.0, "slot \(b) batched-vs-loop mask diff = \(diff)")
+        }
+    }
+
+    /// Batched mask path and Swift-loop single-batch mask path must
+    /// produce numerically close outputs for the same inputs. The selector
+    /// picks the SAME blocks for both paths (same projQ, same features)
+    /// so the gathered K/V support is identical.
+    @Test func batchedMaskAndLoopAgreeOnOutput() {
+        var cfg = RetrievalAttentionConfig()
+        cfg.fineBlockSize = 32
+        cfg.coarseRescueEnabled = false
+        cfg.adaptiveTopK = false
+        cfg.fineTopK = 4
+        cfg.staticInit = 64
+        cfg.slidingWindow = 128
+        cfg.denseFirstN = 0
+        cfg.denseLastN = 0
+
+        let B = 3
+        let nKVH = 4
+        let nQH = 8     // groupSize = 2
+        let dHead = 64
+        let T = 512
+
+        let kAll = MLXRandom.normal([B, nKVH, T, dHead], key: MLXRandom.key(11)).asType(.float32)
+        let vAll = MLXRandom.normal([B, nKVH, T, dHead], key: MLXRandom.key(12)).asType(.float32)
+        let Q = MLXRandom.normal([B, nQH, 1, dHead], key: MLXRandom.key(13)).asType(.float32)
+
+        let scale = pow(Float(dHead), -0.5)
+
+        // Helper to build a fresh cache + raCache with these tensors.
+        func makeRACache() -> BatchedRetrievalAttentionKVCache {
+            let cache = BatchedKVCache(
+                maxBatch: B, kvHeads: nKVH, headDim: dHead, maxSeq: T + 64,
+                dtype: .float32)
+            for _ in 0..<B { _ = cache.addRequest() }
+            cache.keys[..<B, 0..., ..<T, 0...] = kAll
+            cache.values[..<B, 0..., ..<T, 0...] = vAll
+            for i in 0..<B { cache.offsets[i] = T }
+            let raCache = BatchedRetrievalAttentionKVCache(
+                inner: cache, B: B, nKVHeads: nKVH, dHead: dHead,
+                layerIdx: 5, totalLayers: 10, raConfig: cfg)
+            raCache.updateIndex(newKeys: kAll)
+            return raCache
+        }
+
+        // Path A — batched mask kernel (default).
+        let raA = makeRACache()
+        let outA: MLXArray = {
+            let qSqueezed = Q[0..., 0..., 0, 0...]
+            let groupSize = nQH / nKVH
+            let headIdx = MLXArray((0..<nKVH).map { Int32($0 * groupSize) })
+            let qRep = qSqueezed.take(headIdx, axis: 1).asType(.float32)
+            let projQ = raA.index.projectQueriesBatched(qRep)
+            let fineStarts = raA.index.topKFineBlockStarts(projectedQ: projQ)
+            let coarseStarts = raA.index.topKCoarseBlockStarts(projectedQ: projQ)
+            let mask = retrievalAttentionBuildMaskFusedBatched(
+                fineStarts: fineStarts, coarseStarts: coarseStarts,
+                T: T, staticInit: cfg.staticInit, slidingWindow: cfg.slidingWindow,
+                fineBS: cfg.fineBlockSize, coarseBS: cfg.coarseBlockSize,
+                outputDtype: kAll.dtype
+            )
+            return MLXFast.scaledDotProductAttention(
+                queries: Q, keys: kAll, values: vAll,
+                scale: scale, mask: .array(mask))
+        }()
+        eval(outA)
+
+        // Path B — Swift loop over per-slot mask kernel + SDPA.
+        let raB = makeRACache()
+        let outB: MLXArray = {
+            let qSqueezed = Q[0..., 0..., 0, 0...]
+            let groupSize = nQH / nKVH
+            let headIdx = MLXArray((0..<nKVH).map { Int32($0 * groupSize) })
+            let qRep = qSqueezed.take(headIdx, axis: 1).asType(.float32)
+            let projQ = raB.index.projectQueriesBatched(qRep)
+            let fineStarts = raB.index.topKFineBlockStarts(projectedQ: projQ)
+            let coarseStarts = raB.index.topKCoarseBlockStarts(projectedQ: projQ)
+            var outs: [MLXArray] = []
+            for b in 0..<B {
+                let fineB = fineStarts[b, 0..., 0...]
+                let coarseB = coarseStarts[b, 0..., 0...]
+                let mask = retrievalAttentionBuildMaskFused(
+                    fineStarts: fineB, coarseStarts: coarseB,
+                    T: T, staticInit: cfg.staticInit, slidingWindow: cfg.slidingWindow,
+                    fineBS: cfg.fineBlockSize, coarseBS: cfg.coarseBlockSize,
+                    outputDtype: kAll.dtype
+                )
+                let q = Q[b ..< (b + 1), 0..., 0..., 0...]
+                let k = kAll[b ..< (b + 1), 0..., 0..., 0...]
+                let v = vAll[b ..< (b + 1), 0..., 0..., 0...]
+                outs.append(MLXFast.scaledDotProductAttention(
+                    queries: q, keys: k, values: v,
+                    scale: scale, mask: .array(mask)))
+            }
+            return concatenated(outs, axis: 0)
+        }()
+        eval(outB)
+
+        // Same mask, same SDPA — should be numerically identical.
+        let diffAB = (outA - outB).abs().max().item(Float.self)
+        #expect(diffAB < 1e-4, "batched-mask vs loop-mask diff=\(diffAB)")
+    }
+
+    /// Compose-gather (per-slot K/V materialize then dense SDPA) should
+    /// match the group-SDPA kernel numerically: same selector, same
+    /// gathered K/V scope, just different SDPA primitives.
+    @Test func composeGatherMatchesGroupSDPA() {
+        var cfg = RetrievalAttentionConfig()
+        cfg.fineBlockSize = 32
+        cfg.coarseRescueEnabled = false
+        cfg.adaptiveTopK = false
+        cfg.fineTopK = 4
+        cfg.staticInit = 64
+        cfg.slidingWindow = 128
+        cfg.denseFirstN = 0
+        cfg.denseLastN = 0
+
+        let B = 2
+        let nKVH = 4
+        let nQH = 8     // groupSize = 2
+        let dHead = 64
+        let T = 512
+
+        let kAll = MLXRandom.normal([B, nKVH, T, dHead], key: MLXRandom.key(21)).asType(.float32)
+        let vAll = MLXRandom.normal([B, nKVH, T, dHead], key: MLXRandom.key(22)).asType(.float32)
+        let Q = MLXRandom.normal([B, nQH, 1, dHead], key: MLXRandom.key(23)).asType(.float32)
+
+        let scale = pow(Float(dHead), -0.5)
+
+        func makeRACache() -> BatchedRetrievalAttentionKVCache {
+            let cache = BatchedKVCache(
+                maxBatch: B, kvHeads: nKVH, headDim: dHead, maxSeq: T + 64,
+                dtype: .float32)
+            for _ in 0..<B { _ = cache.addRequest() }
+            cache.keys[..<B, 0..., ..<T, 0...] = kAll
+            cache.values[..<B, 0..., ..<T, 0...] = vAll
+            for i in 0..<B { cache.offsets[i] = T }
+            let raCache = BatchedRetrievalAttentionKVCache(
+                inner: cache, B: B, nKVHeads: nKVH, dHead: dHead,
+                layerIdx: 5, totalLayers: 10, raConfig: cfg)
+            raCache.updateIndex(newKeys: kAll)
+            return raCache
+        }
+
+        // Common Q-rep + projQ setup (mirrors sparseAttend internals).
+        let qSqueezed = Q[0..., 0..., 0, 0...]
+        let groupSize = nQH / nKVH
+        let headIdx = MLXArray((0..<nKVH).map { Int32($0 * groupSize) })
+        let qRep = qSqueezed.take(headIdx, axis: 1).asType(.float32)
+
+        // Reference path: group-SDPA custom kernel.
+        let raRef = makeRACache()
+        let projQRef = raRef.index.projectQueriesBatched(qRep)
+        let (gatherRef, _) = raRef.index.perKVHeadGatherBatched(
+            projectedQ: projQRef, seqLen: T)
+        let outRef = retrievalAttentionGroupSparseSDPA(
+            queries: Q,
+            keys: kAll,
+            values: vAll,
+            perKVHeadGather: gatherRef,
+            scale: scale)
+        eval(outRef)
+
+        // Compose-gather path: same selector, MLXFast SDPA on gathered slab.
+        let raCG = makeRACache()
+        let projQCG = raCG.index.projectQueriesBatched(qRep)
+        let (gather, _) = raCG.index.perKVHeadGatherBatched(
+            projectedQ: projQCG, seqLen: T)
+        let gExp = gather.expandedDimensions(axis: 3)
+        let kSmall = takeAlong(kAll, gExp, axis: 2)
+        let vSmall = takeAlong(vAll, gExp, axis: 2)
+        let outCG = MLXFast.scaledDotProductAttention(
+            queries: Q, keys: kSmall, values: vSmall,
+            scale: scale, mask: .none)
+        eval(outCG)
+
+        // Both paths attend the SAME per-(B, nKVH) positions, so the only
+        // numerical difference is the SDPA primitive. Tight cosine.
+        for b in 0..<B {
+            for h in 0..<nQH {
+                let a = outRef[b, h, 0, 0...].asArray(Float.self)
+                let c = outCG[b, h, 0, 0...].asArray(Float.self)
+                var dot: Float = 0
+                var na: Float = 0
+                var nc: Float = 0
+                for i in 0..<a.count {
+                    dot += a[i] * c[i]
+                    na += a[i] * a[i]
+                    nc += c[i] * c[i]
+                }
+                let cos = dot / (sqrt(na) * sqrt(nc) + 1e-9)
+                #expect(cos >= 0.99,
+                    "compose-gather vs group-SDPA cosine = \(cos) at (b=\(b), h=\(h))")
+            }
+        }
+    }
+
+    /// Compose-gather output should be a reasonable approximation to
+    /// dense at high K_padded coverage. At small T with kFine=8, fineBS=32,
+    /// static=64, sliding=128 the gather covers ~448 of 512 positions = 88%
+    /// → cosine vs dense should be well above 0.4 — guards against total
+    /// wrong-axis bugs (slot crossover etc).
+    @Test func composeGatherSanityVsDense() {
+        var cfg = RetrievalAttentionConfig()
+        cfg.fineBlockSize = 32
+        cfg.coarseRescueEnabled = false
+        cfg.adaptiveTopK = false
+        cfg.fineTopK = 8     // 8 * 32 = 256 fine positions
+        cfg.staticInit = 64
+        cfg.slidingWindow = 128
+        cfg.denseFirstN = 0
+        cfg.denseLastN = 0
+
+        let B = 2
+        let nKVH = 4
+        let nQH = 8
+        let dHead = 64
+        let T = 512
+
+        let kAll = MLXRandom.normal([B, nKVH, T, dHead], key: MLXRandom.key(31)).asType(.float32)
+        let vAll = MLXRandom.normal([B, nKVH, T, dHead], key: MLXRandom.key(32)).asType(.float32)
+        let Q = MLXRandom.normal([B, nQH, 1, dHead], key: MLXRandom.key(33)).asType(.float32)
+        let scale = pow(Float(dHead), -0.5)
+
+        // Dense reference.
+        let outDense = MLXFast.scaledDotProductAttention(
+            queries: Q, keys: kAll, values: vAll,
+            scale: scale, mask: .none)
+        eval(outDense)
+
+        // Compose-gather.
+        let cache = BatchedKVCache(
+            maxBatch: B, kvHeads: nKVH, headDim: dHead, maxSeq: T + 64,
+            dtype: .float32)
+        for _ in 0..<B { _ = cache.addRequest() }
+        cache.keys[..<B, 0..., ..<T, 0...] = kAll
+        cache.values[..<B, 0..., ..<T, 0...] = vAll
+        for i in 0..<B { cache.offsets[i] = T }
+        let raCache = BatchedRetrievalAttentionKVCache(
+            inner: cache, B: B, nKVHeads: nKVH, dHead: dHead,
+            layerIdx: 5, totalLayers: 10, raConfig: cfg)
+        raCache.updateIndex(newKeys: kAll)
+
+        let qSqueezed = Q[0..., 0..., 0, 0...]
+        let groupSize = nQH / nKVH
+        let headIdx = MLXArray((0..<nKVH).map { Int32($0 * groupSize) })
+        let qRep = qSqueezed.take(headIdx, axis: 1).asType(.float32)
+        let projQ = raCache.index.projectQueriesBatched(qRep)
+        let (gather, _) = raCache.index.perKVHeadGatherBatched(
+            projectedQ: projQ, seqLen: T)
+        let gExp = gather.expandedDimensions(axis: 3)
+        let kSmall = takeAlong(kAll, gExp, axis: 2)
+        let vSmall = takeAlong(vAll, gExp, axis: 2)
+        let outCG = MLXFast.scaledDotProductAttention(
+            queries: Q, keys: kSmall, values: vSmall,
+            scale: scale, mask: .none)
+        eval(outCG)
+
+        var minCos: Float = 1.0
+        for b in 0..<B {
+            for h in 0..<nQH {
+                let a = outDense[b, h, 0, 0...].asArray(Float.self)
+                let c = outCG[b, h, 0, 0...].asArray(Float.self)
+                var dot: Float = 0
+                var na: Float = 0
+                var nc: Float = 0
+                for i in 0..<a.count {
+                    dot += a[i] * c[i]
+                    na += a[i] * a[i]
+                    nc += c[i] * c[i]
+                }
+                let cos = dot / (sqrt(na) * sqrt(nc) + 1e-9)
+                if cos < minCos { minCos = cos }
+            }
+        }
+        #expect(minCos >= 0.4,
+            "compose-gather vs dense min cosine = \(minCos) — too low, possible slot crossover")
+    }
+}

--- a/Tests/MLXLMTests/Gemma3BatchedSparseSmokeTests.swift
+++ b/Tests/MLXLMTests/Gemma3BatchedSparseSmokeTests.swift
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Synthetic smoke for the Gemma3 batched-sparse decode hook.
+
+import Foundation
+import MLX
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Gemma3 batched-sparse synthetic smoke")
+struct Gemma3BatchedSparseSmokeTests {
+
+    private func makeTinyConfig() -> Gemma3.TextConfiguration {
+        // slidingWindowPattern=1 ⇒ every layer is global, which uses a single
+        // shared K shape across layers. queryPreAttnScalar=1 keeps the
+        // softmax scale at 1.0 (the synthetic test only cares about finiteness).
+        Gemma3.TextConfiguration(
+            modelType: "gemma3_text",
+            hiddenSize: 128,
+            hiddenLayers: 4,
+            intermediateSize: 256,
+            attentionHeads: 4,
+            headDim: 32,
+            rmsNormEps: 1e-5,
+            vocabularySize: 256,
+            kvHeads: 2,
+            ropeTheta: 10_000.0,
+            ropeLocalBaseFreq: 10_000.0,
+            ropeTraditional: false,
+            queryPreAttnScalar: 1.0,
+            slidingWindow: 64,
+            slidingWindowPattern: 1,
+            maxPositionEmbeddings: 4096)
+    }
+
+    @Test func sparseDecodeShapesAndFiniteLogits() {
+        let cfg = makeTinyConfig()
+        let model = Gemma3TextModel(cfg)
+        eval(model)
+
+        let nLayers = 4
+        let kvHeads = 2
+        let headDim = 32
+        let vocab = 256
+
+        let B = 2
+        let maxSeq = 256
+
+        var raCfg = RetrievalAttentionConfig()
+        raCfg.fineBlockSize = 32
+        raCfg.coarseRescueEnabled = false
+        raCfg.adaptiveTopK = false
+        raCfg.fineTopK = 2
+        raCfg.staticInit = 32
+        raCfg.slidingWindow = 64
+        raCfg.denseFirstN = 1
+        raCfg.denseLastN = 1
+        raCfg.sparseMinContext = 0
+
+        let raCaches: [BatchedRetrievalAttentionKVCache] = (0..<nLayers).map { layer in
+            let inner = BatchedKVCache(
+                maxBatch: B, kvHeads: kvHeads, headDim: headDim,
+                maxSeq: maxSeq, dtype: .float32)
+            for _ in 0..<B { _ = inner.addRequest() }
+            return BatchedRetrievalAttentionKVCache(
+                inner: inner, B: B, nKVHeads: kvHeads, dHead: headDim,
+                layerIdx: layer, totalLayers: nLayers, raConfig: raCfg)
+        }
+
+        let T0 = 128
+        for raCache in raCaches {
+            let inner = raCache.inner
+            let kFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 1))
+            ).asType(.float32)
+            let vFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 101))
+            ).asType(.float32)
+            inner.keys[..<B, 0..., ..<T0, 0...] = kFill
+            inner.values[..<B, 0..., ..<T0, 0...] = vFill
+            for i in 0..<B { inner.offsets[i] = T0 }
+            raCache.updateIndex(newKeys: kFill)
+        }
+
+        let tokens = MLXArray([0, 1] as [Int32]).reshaped(B, 1)
+        let logits = model.fullyBatchedSparseDecode(tokens, raCaches: raCaches)
+        eval(logits)
+        #expect(logits.shape == [B, 1, vocab],
+            "fullyBatchedSparseDecode output shape")
+        let asArr = logits.asArray(Float.self)
+        let allFinite = asArr.allSatisfy { $0.isFinite }
+        #expect(allFinite, "logits must be finite")
+    }
+}

--- a/Tests/MLXLMTests/Gemma4BatchedSparseSmokeTests.swift
+++ b/Tests/MLXLMTests/Gemma4BatchedSparseSmokeTests.swift
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // Synthetic smoke for the Gemma4 batched-sparse decode hook.
 //
-// Synthetic config uses all-sliding layers (sliding/global mix needs
-// per-layer K-shape caches; smoke covers the homogeneous case here).
-// MoE and KV-shared layers are not exercised — the sparse extension
-// preconditions disable both for the current port.
+// Coverage:
+//   - Plain dense FFN, no KV sharing (homogeneous sliding layers) — baseline
+//     that mirrors the original smoke before KV-shared + MoE support landed.
+//   - KV-shared layers (num_kv_shared_layers > 0): trailing layers reuse
+//     the donor's `BatchedRetrievalAttentionKVCache`. Mirrors the dense
+//     `previousKVs[j] != j` path.
+//   - MoE FFN (enable_moe_block + experts/router): exercised through the
+//     sparse decode path; only the attention step routes through sparse,
+//     expert routing is orthogonal.
 
 import Foundation
 import MLX
@@ -12,10 +17,81 @@ import MLX
 @testable import MLXLMCommon
 import Testing
 
-@Suite("Gemma4 batched-sparse synthetic smoke")
+// `.serialized` — each test compiles Gemma4SharedMLP via MLX `compile()`,
+// and parallel test execution can deadlock on the compile mutex when
+// three @Test functions race the same shared compiled closure. Running
+// them in series (~50ms each) avoids the contention.
+@Suite("Gemma4 batched-sparse synthetic smoke", .serialized)
 struct Gemma4BatchedSparseSmokeTests {
 
-    private func makeTinyConfig() -> Gemma4TextConfiguration {
+    private static func makeRaConfig() -> RetrievalAttentionConfig {
+        var raCfg = RetrievalAttentionConfig()
+        raCfg.fineBlockSize = 32
+        raCfg.coarseRescueEnabled = false
+        raCfg.adaptiveTopK = false
+        raCfg.fineTopK = 2
+        raCfg.staticInit = 32
+        raCfg.slidingWindow = 64
+        raCfg.denseFirstN = 1
+        raCfg.denseLastN = 1
+        raCfg.sparseMinContext = 0
+        return raCfg
+    }
+
+    /// Build per-layer `BatchedRetrievalAttentionKVCache` list, pointing
+    /// shared layers at their donors' cache instance — mirrors how
+    /// `Gemma4ModelInner.previousKVs` keys shared layers off the donor.
+    /// Pre-fills each donor's cache with synthetic K/V at offset T0.
+    private static func buildRaCaches(
+        model: Gemma4TextModel,
+        B: Int, kvHeads: Int, headDim: Int, maxSeq: Int,
+        prefillT0: Int, raCfg: RetrievalAttentionConfig
+    ) -> [BatchedRetrievalAttentionKVCache] {
+        let inner = model.model
+        let nLayers = inner.layers.count
+        var caches = [BatchedRetrievalAttentionKVCache?](repeating: nil, count: nLayers)
+        for i in 0..<nLayers {
+            let donor = inner.previousKVs[i]
+            if donor == i {
+                // Donor: allocate its own inner BatchedKVCache + RA wrapper.
+                let innerCache = BatchedKVCache(
+                    maxBatch: B, kvHeads: kvHeads, headDim: headDim,
+                    maxSeq: maxSeq, dtype: .float32)
+                for _ in 0..<B { _ = innerCache.addRequest() }
+                let ra = BatchedRetrievalAttentionKVCache(
+                    inner: innerCache, B: B, nKVHeads: kvHeads, dHead: headDim,
+                    layerIdx: i, totalLayers: nLayers, raConfig: raCfg)
+
+                // Pre-fill K/V for the donor cache.
+                let kFill = MLXRandom.normal(
+                    [B, kvHeads, prefillT0, headDim],
+                    key: MLXRandom.key(UInt64(i + 1))
+                ).asType(.float32)
+                let vFill = MLXRandom.normal(
+                    [B, kvHeads, prefillT0, headDim],
+                    key: MLXRandom.key(UInt64(i + 101))
+                ).asType(.float32)
+                innerCache.keys[..<B, 0..., ..<prefillT0, 0...] = kFill
+                innerCache.values[..<B, 0..., ..<prefillT0, 0...] = vFill
+                for s in 0..<B { innerCache.offsets[s] = prefillT0 }
+                ra.updateIndex(newKeys: kFill)
+                caches[i] = ra
+            }
+        }
+        // Second pass: shared layers point at donor's cache instance.
+        for i in 0..<nLayers {
+            if caches[i] == nil {
+                let donor = inner.previousKVs[i]
+                precondition(caches[donor] != nil,
+                    "donor cache must be built before shared layer")
+                caches[i] = caches[donor]
+            }
+        }
+        return caches.compactMap { $0 }
+    }
+
+    @Test func sparseDecodeShapesAndFiniteLogits() {
+        // Plain dense, no KV-shared, no MoE — original baseline.
         let json = """
         {
             "model_type": "gemma4_text",
@@ -36,68 +112,140 @@ struct Gemma4BatchedSparseSmokeTests {
             "hidden_size_per_layer_input": 0
         }
         """
-        return try! JSONDecoder().decode(
+        let cfg = try! JSONDecoder().decode(
             Gemma4TextConfiguration.self, from: json.data(using: .utf8)!)
-    }
-
-    @Test func sparseDecodeShapesAndFiniteLogits() {
-        let cfg = makeTinyConfig()
         let model = Gemma4TextModel(cfg)
         eval(model)
 
-        let nLayers = 4
-        let kvHeads = 2
-        let headDim = 32
-        let vocab = 256
-
+        let raCfg = Self.makeRaConfig()
         let B = 2
-        let maxSeq = 256
+        let raCaches = Self.buildRaCaches(
+            model: model, B: B, kvHeads: 2, headDim: 32, maxSeq: 256,
+            prefillT0: 128, raCfg: raCfg)
 
-        var raCfg = RetrievalAttentionConfig()
-        raCfg.fineBlockSize = 32
-        raCfg.coarseRescueEnabled = false
-        raCfg.adaptiveTopK = false
-        raCfg.fineTopK = 2
-        raCfg.staticInit = 32
-        raCfg.slidingWindow = 64
-        raCfg.denseFirstN = 1
-        raCfg.denseLastN = 1
-        raCfg.sparseMinContext = 0
+        let tokens = MLXArray([0, 1] as [Int32]).reshaped(B, 1)
+        let logits = model.fullyBatchedSparseDecode(tokens, raCaches: raCaches)
+        eval(logits)
+        #expect(logits.shape == [B, 1, 256],
+            "fullyBatchedSparseDecode output shape")
+        let asArr = logits.asArray(Float.self)
+        #expect(asArr.allSatisfy { $0.isFinite }, "logits must be finite")
+    }
 
-        let raCaches: [BatchedRetrievalAttentionKVCache] = (0..<nLayers).map { layer in
-            let inner = BatchedKVCache(
-                maxBatch: B, kvHeads: kvHeads, headDim: headDim,
-                maxSeq: maxSeq, dtype: .float32)
-            for _ in 0..<B { _ = inner.addRequest() }
-            return BatchedRetrievalAttentionKVCache(
-                inner: inner, B: B, nKVHeads: kvHeads, dHead: headDim,
-                layerIdx: layer, totalLayers: nLayers, raConfig: raCfg)
+    @Test func sparseDecodeWithKvSharedLayers() {
+        // 6 layers, all sliding, num_kv_shared_layers=4 ⇒ layers 0,1 are
+        // donors; layers 2,3,4,5 reuse them (matching layer_types).
+        let json = """
+        {
+            "model_type": "gemma4_text",
+            "hidden_size": 128,
+            "num_hidden_layers": 6,
+            "intermediate_size": 256,
+            "moe_intermediate_size": 64,
+            "num_attention_heads": 4,
+            "head_dim": 32,
+            "global_head_dim": 32,
+            "rms_norm_eps": 1e-5,
+            "vocab_size": 256,
+            "num_key_value_heads": 2,
+            "sliding_window": 64,
+            "layer_types": [
+                "sliding_attention", "sliding_attention",
+                "sliding_attention", "sliding_attention",
+                "sliding_attention", "sliding_attention"
+            ],
+            "tie_word_embeddings": true,
+            "num_kv_shared_layers": 4,
+            "hidden_size_per_layer_input": 0
+        }
+        """
+        let cfg = try! JSONDecoder().decode(
+            Gemma4TextConfiguration.self, from: json.data(using: .utf8)!)
+        let model = Gemma4TextModel(cfg)
+        eval(model)
+
+        // Verify the model's previousKVs map. Donor-build loop in
+        // `Gemma4ModelInner.init` walks layers [0, N-numKvShared) and keeps
+        // the LATEST layer-per-type — so with all 6 layers sliding and M=2,
+        // the donor for shared layers is layer 1 (the last donor of that
+        // type before the shared band).
+        let prev = model.model.previousKVs
+        #expect(prev.count == 6)
+        #expect(prev[0] == 0 && prev[1] == 1)
+        for j in 2..<6 {
+            #expect(prev[j] == 1, "layer \(j) donor must be layer 1")
         }
 
-        let T0 = 128
-        for raCache in raCaches {
-            let inner = raCache.inner
-            let kFill = MLXRandom.normal(
-                [B, kvHeads, T0, headDim],
-                key: MLXRandom.key(UInt64(raCache.layerIdx + 1))
-            ).asType(.float32)
-            let vFill = MLXRandom.normal(
-                [B, kvHeads, T0, headDim],
-                key: MLXRandom.key(UInt64(raCache.layerIdx + 101))
-            ).asType(.float32)
-            inner.keys[..<B, 0..., ..<T0, 0...] = kFill
-            inner.values[..<B, 0..., ..<T0, 0...] = vFill
-            for i in 0..<B { inner.offsets[i] = T0 }
-            raCache.updateIndex(newKeys: kFill)
+        let raCfg = Self.makeRaConfig()
+        let B = 2
+        let raCaches = Self.buildRaCaches(
+            model: model, B: B, kvHeads: 2, headDim: 32, maxSeq: 256,
+            prefillT0: 128, raCfg: raCfg)
+
+        // Sanity: caches at shared layers MUST be the donor's instance.
+        for j in 2..<6 {
+            #expect(raCaches[j] === raCaches[1],
+                "shared layer \(j) must point at donor 1's cache")
         }
 
         let tokens = MLXArray([0, 1] as [Int32]).reshaped(B, 1)
         let logits = model.fullyBatchedSparseDecode(tokens, raCaches: raCaches)
         eval(logits)
-        #expect(logits.shape == [B, 1, vocab],
-            "fullyBatchedSparseDecode output shape")
+        #expect(logits.shape == [B, 1, 256])
         let asArr = logits.asArray(Float.self)
-        let allFinite = asArr.allSatisfy { $0.isFinite }
-        #expect(allFinite, "logits must be finite")
+        #expect(asArr.allSatisfy { $0.isFinite },
+            "logits must be finite under KV-shared sparse decode")
+    }
+
+    @Test func sparseDecodeWithMoEBlocks() {
+        // Synthetic MoE config: small expert count so SwitchLinear stays cheap.
+        // No KV sharing — keep MoE isolated as the variable under test.
+        let json = """
+        {
+            "model_type": "gemma4_text",
+            "hidden_size": 128,
+            "num_hidden_layers": 4,
+            "intermediate_size": 256,
+            "moe_intermediate_size": 64,
+            "num_attention_heads": 4,
+            "head_dim": 32,
+            "global_head_dim": 32,
+            "rms_norm_eps": 1e-5,
+            "vocab_size": 256,
+            "num_key_value_heads": 2,
+            "sliding_window": 64,
+            "layer_types": ["sliding_attention", "sliding_attention", "sliding_attention", "sliding_attention"],
+            "tie_word_embeddings": true,
+            "num_kv_shared_layers": 0,
+            "hidden_size_per_layer_input": 0,
+            "enable_moe_block": true,
+            "num_experts": 4,
+            "top_k_experts": 2
+        }
+        """
+        let cfg = try! JSONDecoder().decode(
+            Gemma4TextConfiguration.self, from: json.data(using: .utf8)!)
+        let model = Gemma4TextModel(cfg)
+        eval(model)
+
+        // Confirm the transformer blocks built the MoE experts/router.
+        for block in model.model.layers {
+            #expect(block.experts != nil, "MoE block must have experts")
+            #expect(block.router != nil, "MoE block must have router")
+        }
+
+        let raCfg = Self.makeRaConfig()
+        let B = 2
+        let raCaches = Self.buildRaCaches(
+            model: model, B: B, kvHeads: 2, headDim: 32, maxSeq: 256,
+            prefillT0: 128, raCfg: raCfg)
+
+        let tokens = MLXArray([0, 1] as [Int32]).reshaped(B, 1)
+        let logits = model.fullyBatchedSparseDecode(tokens, raCaches: raCaches)
+        eval(logits)
+        #expect(logits.shape == [B, 1, 256])
+        let asArr = logits.asArray(Float.self)
+        #expect(asArr.allSatisfy { $0.isFinite },
+            "logits must be finite under MoE sparse decode")
     }
 }

--- a/Tests/MLXLMTests/Gemma4BatchedSparseSmokeTests.swift
+++ b/Tests/MLXLMTests/Gemma4BatchedSparseSmokeTests.swift
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Synthetic smoke for the Gemma4 batched-sparse decode hook.
+//
+// Synthetic config uses all-sliding layers (sliding/global mix needs
+// per-layer K-shape caches; smoke covers the homogeneous case here).
+// MoE and KV-shared layers are not exercised — the sparse extension
+// preconditions disable both for the current port.
+
+import Foundation
+import MLX
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Gemma4 batched-sparse synthetic smoke")
+struct Gemma4BatchedSparseSmokeTests {
+
+    private func makeTinyConfig() -> Gemma4TextConfiguration {
+        let json = """
+        {
+            "model_type": "gemma4_text",
+            "hidden_size": 128,
+            "num_hidden_layers": 4,
+            "intermediate_size": 256,
+            "moe_intermediate_size": 64,
+            "num_attention_heads": 4,
+            "head_dim": 32,
+            "global_head_dim": 32,
+            "rms_norm_eps": 1e-5,
+            "vocab_size": 256,
+            "num_key_value_heads": 2,
+            "sliding_window": 64,
+            "layer_types": ["sliding_attention", "sliding_attention", "sliding_attention", "sliding_attention"],
+            "tie_word_embeddings": true,
+            "num_kv_shared_layers": 0,
+            "hidden_size_per_layer_input": 0
+        }
+        """
+        return try! JSONDecoder().decode(
+            Gemma4TextConfiguration.self, from: json.data(using: .utf8)!)
+    }
+
+    @Test func sparseDecodeShapesAndFiniteLogits() {
+        let cfg = makeTinyConfig()
+        let model = Gemma4TextModel(cfg)
+        eval(model)
+
+        let nLayers = 4
+        let kvHeads = 2
+        let headDim = 32
+        let vocab = 256
+
+        let B = 2
+        let maxSeq = 256
+
+        var raCfg = RetrievalAttentionConfig()
+        raCfg.fineBlockSize = 32
+        raCfg.coarseRescueEnabled = false
+        raCfg.adaptiveTopK = false
+        raCfg.fineTopK = 2
+        raCfg.staticInit = 32
+        raCfg.slidingWindow = 64
+        raCfg.denseFirstN = 1
+        raCfg.denseLastN = 1
+        raCfg.sparseMinContext = 0
+
+        let raCaches: [BatchedRetrievalAttentionKVCache] = (0..<nLayers).map { layer in
+            let inner = BatchedKVCache(
+                maxBatch: B, kvHeads: kvHeads, headDim: headDim,
+                maxSeq: maxSeq, dtype: .float32)
+            for _ in 0..<B { _ = inner.addRequest() }
+            return BatchedRetrievalAttentionKVCache(
+                inner: inner, B: B, nKVHeads: kvHeads, dHead: headDim,
+                layerIdx: layer, totalLayers: nLayers, raConfig: raCfg)
+        }
+
+        let T0 = 128
+        for raCache in raCaches {
+            let inner = raCache.inner
+            let kFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 1))
+            ).asType(.float32)
+            let vFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 101))
+            ).asType(.float32)
+            inner.keys[..<B, 0..., ..<T0, 0...] = kFill
+            inner.values[..<B, 0..., ..<T0, 0...] = vFill
+            for i in 0..<B { inner.offsets[i] = T0 }
+            raCache.updateIndex(newKeys: kFill)
+        }
+
+        let tokens = MLXArray([0, 1] as [Int32]).reshaped(B, 1)
+        let logits = model.fullyBatchedSparseDecode(tokens, raCaches: raCaches)
+        eval(logits)
+        #expect(logits.shape == [B, 1, vocab],
+            "fullyBatchedSparseDecode output shape")
+        let asArr = logits.asArray(Float.self)
+        let allFinite = asArr.allSatisfy { $0.isFinite }
+        #expect(allFinite, "logits must be finite")
+    }
+}

--- a/Tests/MLXLMTests/LlamaBatchedSparseSmokeTests.swift
+++ b/Tests/MLXLMTests/LlamaBatchedSparseSmokeTests.swift
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Synthetic smoke for the Llama batched-sparse decode hook.
+
+import Foundation
+import MLX
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Llama batched-sparse synthetic smoke")
+struct LlamaBatchedSparseSmokeTests {
+
+    private func makeTinyConfig() -> LlamaConfiguration {
+        let json = """
+        {
+          "hidden_size": 128,
+          "num_hidden_layers": 4,
+          "intermediate_size": 256,
+          "num_attention_heads": 4,
+          "head_dim": 32,
+          "rms_norm_eps": 1e-5,
+          "vocab_size": 256,
+          "num_key_value_heads": 2,
+          "rope_theta": 10000.0,
+          "rope_traditional": false,
+          "tie_word_embeddings": true
+        }
+        """.data(using: .utf8)!
+        return try! JSONDecoder().decode(LlamaConfiguration.self, from: json)
+    }
+
+    @Test func sparseDecodeShapesAndFiniteLogits() {
+        let cfg = makeTinyConfig()
+        let model = LlamaModel(cfg)
+        eval(model)
+
+        let nLayers = 4
+        let kvHeads = 2
+        let headDim = 32
+        let vocab = 256
+
+        let B = 2
+        let maxSeq = 256
+
+        var raCfg = RetrievalAttentionConfig()
+        raCfg.fineBlockSize = 32
+        raCfg.coarseRescueEnabled = false
+        raCfg.adaptiveTopK = false
+        raCfg.fineTopK = 2
+        raCfg.staticInit = 32
+        raCfg.slidingWindow = 64
+        raCfg.denseFirstN = 1
+        raCfg.denseLastN = 1
+        raCfg.sparseMinContext = 0
+
+        let raCaches: [BatchedRetrievalAttentionKVCache] = (0..<nLayers).map { layer in
+            let inner = BatchedKVCache(
+                maxBatch: B, kvHeads: kvHeads, headDim: headDim,
+                maxSeq: maxSeq, dtype: .float32)
+            for _ in 0..<B { _ = inner.addRequest() }
+            return BatchedRetrievalAttentionKVCache(
+                inner: inner, B: B, nKVHeads: kvHeads, dHead: headDim,
+                layerIdx: layer, totalLayers: nLayers, raConfig: raCfg)
+        }
+
+        let T0 = 128
+        for raCache in raCaches {
+            let inner = raCache.inner
+            let kFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 1))
+            ).asType(.float32)
+            let vFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 101))
+            ).asType(.float32)
+            inner.keys[..<B, 0..., ..<T0, 0...] = kFill
+            inner.values[..<B, 0..., ..<T0, 0...] = vFill
+            for i in 0..<B { inner.offsets[i] = T0 }
+            raCache.updateIndex(newKeys: kFill)
+        }
+
+        let tokens = MLXArray([0, 1] as [Int32]).reshaped(B, 1)
+        let logits = model.fullyBatchedSparseDecode(tokens, raCaches: raCaches)
+        eval(logits)
+        #expect(logits.shape == [B, 1, vocab],
+            "fullyBatchedSparseDecode output shape")
+        let asArr = logits.asArray(Float.self)
+        let allFinite = asArr.allSatisfy { $0.isFinite }
+        #expect(allFinite, "logits must be finite")
+    }
+}

--- a/Tests/MLXLMTests/Mistral3BatchedSparseSmokeTests.swift
+++ b/Tests/MLXLMTests/Mistral3BatchedSparseSmokeTests.swift
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Synthetic smoke for the Mistral3 batched-sparse decode hook.
+
+import Foundation
+import MLX
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Mistral3 batched-sparse synthetic smoke")
+struct Mistral3BatchedSparseSmokeTests {
+
+    private func makeTinyConfig() -> Mistral3TextConfiguration {
+        // All-full-attention layer types keep the synthetic config simple.
+        Mistral3TextConfiguration(
+            hiddenSize: 128,
+            hiddenLayers: 4,
+            intermediateSize: 256,
+            attentionHeads: 4,
+            rmsNormEps: 1e-5,
+            vocabularySize: 256,
+            headDimensions: 32,
+            maxPositionEmbeddings: 4096,
+            kvHeads: 2,
+            ropeTheta: 10_000,
+            ropeParameters: nil,
+            tieWordEmbeddings: true,
+            layerTypes: ["full_attention", "full_attention", "full_attention", "full_attention"],
+            slidingWindow: nil)
+    }
+
+    @Test func sparseDecodeShapesAndFiniteLogits() {
+        let cfg = makeTinyConfig()
+        let model = Mistral3TextModel(cfg)
+        eval(model)
+
+        let nLayers = 4
+        let kvHeads = 2
+        let headDim = 32
+        let vocab = 256
+
+        let B = 2
+        let maxSeq = 256
+
+        var raCfg = RetrievalAttentionConfig()
+        raCfg.fineBlockSize = 32
+        raCfg.coarseRescueEnabled = false
+        raCfg.adaptiveTopK = false
+        raCfg.fineTopK = 2
+        raCfg.staticInit = 32
+        raCfg.slidingWindow = 64
+        raCfg.denseFirstN = 1
+        raCfg.denseLastN = 1
+        raCfg.sparseMinContext = 0
+
+        let raCaches: [BatchedRetrievalAttentionKVCache] = (0..<nLayers).map { layer in
+            let inner = BatchedKVCache(
+                maxBatch: B, kvHeads: kvHeads, headDim: headDim,
+                maxSeq: maxSeq, dtype: .float32)
+            for _ in 0..<B { _ = inner.addRequest() }
+            return BatchedRetrievalAttentionKVCache(
+                inner: inner, B: B, nKVHeads: kvHeads, dHead: headDim,
+                layerIdx: layer, totalLayers: nLayers, raConfig: raCfg)
+        }
+
+        let T0 = 128
+        for raCache in raCaches {
+            let inner = raCache.inner
+            let kFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 1))
+            ).asType(.float32)
+            let vFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 101))
+            ).asType(.float32)
+            inner.keys[..<B, 0..., ..<T0, 0...] = kFill
+            inner.values[..<B, 0..., ..<T0, 0...] = vFill
+            for i in 0..<B { inner.offsets[i] = T0 }
+            raCache.updateIndex(newKeys: kFill)
+        }
+
+        let tokens = MLXArray([0, 1] as [Int32]).reshaped(B, 1)
+        let logits = model.fullyBatchedSparseDecode(tokens, raCaches: raCaches)
+        eval(logits)
+        #expect(logits.shape == [B, 1, vocab],
+            "fullyBatchedSparseDecode output shape")
+        let asArr = logits.asArray(Float.self)
+        let allFinite = asArr.allSatisfy { $0.isFinite }
+        #expect(allFinite, "logits must be finite")
+    }
+}

--- a/Tests/MLXLMTests/NemotronHBatchedSparseSmokeTests.swift
+++ b/Tests/MLXLMTests/NemotronHBatchedSparseSmokeTests.swift
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Synthetic smoke for the NemotronH hybrid batched-sparse decode hook.
+//
+// Mirrors `Qwen35BatchedSparseSmokeTests` in spirit:
+//   - `newBatchedHybridSparseCache` produces a `BatchedHybridCache` whose
+//     attention slots wrap `BatchedRetrievalAttentionKVCache` and Mamba2
+//     slots wrap `BatchedMambaCache` (with `recDtype` = model dtype).
+//   - MLP/MoE blocks contribute NO cache slot, mirroring `newCache`.
+//   - Slot lifecycle (addSlot) propagates lockstep across mamba/attention.
+//   - `fullyBatchedSparseDecode` runs end-to-end with synthetic weights.
+
+import Foundation
+import MLX
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+// `.serialized` — Mamba2 SSM kernel + `eval()` over freshly-built caches
+// don't tolerate parallel test execution well (mutex contention inside
+// MLX). Running serially keeps the smoke deterministic.
+@Suite("NemotronH hybrid batched-sparse synthetic smoke", .serialized)
+struct NemotronHBatchedSparseSmokeTests {
+
+    /// Tiny synthetic config. Pattern `MEMEM*` exercises every block kind:
+    /// mamba ('M') × 3, attention ('*') × 1, MoE ('E') × 2 — and ensures
+    /// the cache index advances only on mamba/attention.
+    private static func makeTinyConfig() -> NemotronHConfiguration {
+        NemotronHConfiguration(
+            vocabSize: 128,
+            hiddenSize: 64,
+            numHiddenLayers: 6,                  // length of `MEMEM*`
+            numAttentionHeads: 4,
+            numKeyValueHeads: 2,
+            mambaNumHeads: 4,
+            mambaHeadDim: 16,
+            ssmStateSize: 16,
+            convKernel: 4,
+            nGroups: 2,
+            intermediateSize: 128,
+            moeIntermediateSize: 64,
+            moeSharedExpertIntermediateSize: 64,
+            nRoutedExperts: 4,
+            numExpertsPerTok: 2,
+            hybridOverridePattern: "MEMEM*",
+            layerNormEpsilon: 1e-5,
+            nGroup: 2,
+            topkGroup: 1
+        )
+    }
+
+    private static func makeRaConfig() -> RetrievalAttentionConfig {
+        var ra = RetrievalAttentionConfig()
+        ra.fineBlockSize = 32
+        ra.coarseRescueEnabled = false
+        ra.adaptiveTopK = false
+        ra.fineTopK = 2
+        ra.staticInit = 32
+        ra.slidingWindow = 64
+        ra.denseFirstN = 0
+        ra.denseLastN = 0
+        ra.sparseMinContext = 0
+        return ra
+    }
+
+    @Test
+    func newBatchedHybridSparseCacheLayout() throws {
+        let cfg = Self.makeTinyConfig()
+        let model = NemotronHModel(cfg)
+
+        let cache = model.newBatchedHybridSparseCache(
+            maxBatch: 2, parameters: nil, raConfig: Self.makeRaConfig())
+
+        // `MEMEM*` → 3 mamba + 1 attention + 2 moe → 4 cache slots
+        // (mamba × 3 + attention × 1; moe contributes nothing).
+        #expect(cache.layers.count == 4,
+            "hybrid sparse cache should have one slot per mamba/attention block")
+
+        var gdnCount = 0
+        var sparseAttnCount = 0
+        for slot in cache.layers {
+            switch slot {
+            case .gdn: gdnCount += 1
+            case .sparseAttention: sparseAttnCount += 1
+            case .attention:
+                Issue.record("sparse hybrid cache must not emit .attention slots")
+            }
+        }
+        #expect(gdnCount == 3, "expected 3 mamba slots")
+        #expect(sparseAttnCount == 1, "expected 1 sparse-attention slot")
+    }
+
+    @Test
+    func mambaCacheRecDtypeMatchesModelDtype() throws {
+        let cfg = Self.makeTinyConfig()
+        let model = NemotronHModel(cfg)
+
+        let cache = model.newBatchedHybridSparseCache(
+            maxBatch: 2, parameters: nil, raConfig: Self.makeRaConfig())
+
+        // NemotronH's input-dtype SSM state contract — the gdn cache's
+        // `recDtype` should match the embedding (model compute) dtype,
+        // NOT fp32 like the GDN family's default.
+        let modelDtype = model.backbone.embeddings.weight.dtype
+        for slot in cache.layers {
+            if case .gdn(let mamba) = slot {
+                #expect(mamba.recDtype == modelDtype,
+                    "BatchedMambaCache.recDtype must follow NemotronH's input dtype")
+            }
+        }
+    }
+
+    @Test
+    func fullyBatchedSparseDecodeShapesAndFiniteLogits() throws {
+        let cfg = Self.makeTinyConfig()
+        let model = NemotronHModel(cfg)
+        eval(model)
+        // Cast to bf16 — the SSM Metal kernel registers bf16/fp16/fp32
+        // template instantiations; we pick bf16 to match `BatchedMambaCache`
+        // default conv dtype.
+        let bf16Params = model.parameters().mapValues { (v: MLXArray) in
+            v.asType(.bfloat16)
+        }
+        try model.update(parameters: bf16Params, verify: [.noUnusedKeys])
+        eval(model)
+
+        let B = 2
+        let cache = model.newBatchedHybridSparseCache(
+            maxBatch: B, parameters: nil, raConfig: Self.makeRaConfig())
+        for _ in 0..<B { cache.addSlot() }
+
+        let tokens = MLXArray([0, 1] as [Int32]).reshaped(B, 1)
+        let logits = model.fullyBatchedSparseDecode(tokens, caches: cache)
+        eval(logits)
+        #expect(logits.shape == [B, 1, cfg.vocabSize])
+        let asArr = logits.asArray(Float.self)
+        #expect(asArr.allSatisfy { $0.isFinite }, "logits must be finite")
+    }
+}

--- a/Tests/MLXLMTests/Phi3BatchedSparseSmokeTests.swift
+++ b/Tests/MLXLMTests/Phi3BatchedSparseSmokeTests.swift
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Synthetic smoke for the Phi3 batched-sparse decode hook.
+
+import Foundation
+import MLX
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Phi3 batched-sparse synthetic smoke")
+struct Phi3BatchedSparseSmokeTests {
+
+    private func makeTinyConfig() -> Phi3Configuration {
+        let json = """
+        {
+          "hidden_size": 128,
+          "num_hidden_layers": 4,
+          "intermediate_size": 256,
+          "num_attention_heads": 4,
+          "rms_norm_eps": 1e-5,
+          "vocab_size": 256,
+          "num_key_value_heads": 2,
+          "rope_theta": 10000.0,
+          "partial_rotary_factor": 1.0,
+          "max_position_embeddings": 4096,
+          "original_max_position_embeddings": 4096,
+          "tie_word_embeddings": true
+        }
+        """.data(using: .utf8)!
+        return try! JSONDecoder().decode(Phi3Configuration.self, from: json)
+    }
+
+    @Test func sparseDecodeShapesAndFiniteLogits() {
+        let cfg = makeTinyConfig()
+        let model = Phi3Model(cfg)
+        eval(model)
+
+        let nLayers = 4
+        let kvHeads = 2
+        let headDim = 32
+        let vocab = 256
+
+        let B = 2
+        let maxSeq = 256
+
+        var raCfg = RetrievalAttentionConfig()
+        raCfg.fineBlockSize = 32
+        raCfg.coarseRescueEnabled = false
+        raCfg.adaptiveTopK = false
+        raCfg.fineTopK = 2
+        raCfg.staticInit = 32
+        raCfg.slidingWindow = 64
+        raCfg.denseFirstN = 1
+        raCfg.denseLastN = 1
+        raCfg.sparseMinContext = 0
+
+        let raCaches: [BatchedRetrievalAttentionKVCache] = (0..<nLayers).map { layer in
+            let inner = BatchedKVCache(
+                maxBatch: B, kvHeads: kvHeads, headDim: headDim,
+                maxSeq: maxSeq, dtype: .float32)
+            for _ in 0..<B { _ = inner.addRequest() }
+            return BatchedRetrievalAttentionKVCache(
+                inner: inner, B: B, nKVHeads: kvHeads, dHead: headDim,
+                layerIdx: layer, totalLayers: nLayers, raConfig: raCfg)
+        }
+
+        let T0 = 128
+        for raCache in raCaches {
+            let inner = raCache.inner
+            let kFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 1))
+            ).asType(.float32)
+            let vFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 101))
+            ).asType(.float32)
+            inner.keys[..<B, 0..., ..<T0, 0...] = kFill
+            inner.values[..<B, 0..., ..<T0, 0...] = vFill
+            for i in 0..<B { inner.offsets[i] = T0 }
+            raCache.updateIndex(newKeys: kFill)
+        }
+
+        let tokens = MLXArray([0, 1] as [Int32]).reshaped(B, 1)
+        let logits = model.fullyBatchedSparseDecode(tokens, raCaches: raCaches)
+        eval(logits)
+        #expect(logits.shape == [B, 1, vocab],
+            "fullyBatchedSparseDecode output shape")
+        let asArr = logits.asArray(Float.self)
+        let allFinite = asArr.allSatisfy { $0.isFinite }
+        #expect(allFinite, "logits must be finite")
+    }
+}

--- a/Tests/MLXLMTests/Qwen2BatchedSparseB1Tests.swift
+++ b/Tests/MLXLMTests/Qwen2BatchedSparseB1Tests.swift
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the mlx-swift-lm project
+//
+// Qwen2 batched-sparse @ B=1. The batched cache is positioned as
+// "B≥1" in the rest of the suite; this file proves it ALSO covers
+// single-stream (B=1) decode, so the legacy non-batched single-stream
+// RA wrapper (`RetrievalAttentionKVCache`) is redundant and not
+// proposed for upstreaming. See `specs/044-batched-sparse-attention-decode.md`.
+//
+// Two tests:
+//   1. `sparseDecodeB1ShapesFiniteAndOffsetAdvance` — synthetic prefill +
+//      one decode step at B=1. Asserts output shape `[1, 1, vocab]`,
+//      finite logits (no NaN/Inf), AND that the inner cache's
+//      `offsets[0]` advanced from `T0` to `T0 + 1` after the step.
+//   2. `sparseDecodeB1SlotSemanticEqualsB2Slot0` — runs the same input
+//      through a B=1 cache stack AND a B=2 cache stack (with slot 1
+//      held identical), then checks slot 0's logits match within
+//      tolerance. Validates that the B=1 path is semantically equivalent
+//      to the first slot of the B≥2 path — one cache, one selector, one
+//      mask kernel covers all batch sizes.
+//
+// `.serialized` mirrors the convention used by Gemma4 / NemotronH
+// smoke suites (MLX `compile()` + random-key shared state safety).
+
+import Foundation
+import MLX
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Qwen2 batched-sparse B=1 smoke", .serialized)
+struct Qwen2BatchedSparseB1Tests {
+
+    private func makeTinyConfig() -> Qwen2Configuration {
+        let json = """
+        {
+          "hidden_size": 128,
+          "num_hidden_layers": 4,
+          "intermediate_size": 256,
+          "num_attention_heads": 4,
+          "rms_norm_eps": 1e-5,
+          "vocab_size": 256,
+          "num_key_value_heads": 2,
+          "rope_theta": 10000.0,
+          "rope_traditional": false,
+          "tie_word_embeddings": true
+        }
+        """.data(using: .utf8)!
+        return try! JSONDecoder().decode(Qwen2Configuration.self, from: json)
+    }
+
+    private func makeRaConfig() -> RetrievalAttentionConfig {
+        var raCfg = RetrievalAttentionConfig()
+        raCfg.fineBlockSize = 32
+        raCfg.coarseRescueEnabled = false
+        raCfg.adaptiveTopK = false
+        raCfg.fineTopK = 2
+        raCfg.staticInit = 32
+        raCfg.slidingWindow = 64
+        raCfg.denseFirstN = 1
+        raCfg.denseLastN = 1
+        raCfg.sparseMinContext = 0
+        return raCfg
+    }
+
+    /// Build per-layer `BatchedRetrievalAttentionKVCache` list for a given
+    /// `B`, register B slots on each inner cache, and synthetically prefill
+    /// `T0` tokens of K/V using deterministic per-layer RNG keys so that
+    /// the B=1 and B=2 paths see the SAME slot-0 contents in the
+    /// `sparseDecodeB1SlotSemanticEqualsB2Slot0` test.
+    private func buildCaches(
+        cfg: Qwen2Configuration, raCfg: RetrievalAttentionConfig,
+        B: Int, T0: Int, maxSeq: Int
+    ) -> [BatchedRetrievalAttentionKVCache] {
+        let nLayers = cfg.hiddenLayers
+        let kvHeads = cfg.kvHeads
+        let headDim = cfg.hiddenSize / cfg.attentionHeads
+
+        return (0..<nLayers).map { layer in
+            let inner = BatchedKVCache(
+                maxBatch: B, kvHeads: kvHeads, headDim: headDim,
+                maxSeq: maxSeq, dtype: .float32)
+            for _ in 0..<B { _ = inner.addRequest() }
+            let raCache = BatchedRetrievalAttentionKVCache(
+                inner: inner, B: B, nKVHeads: kvHeads, dHead: headDim,
+                layerIdx: layer, totalLayers: nLayers, raConfig: raCfg)
+
+            // Slot 0 prefill — deterministic per-layer key, identical
+            // across B=1 and B=2 callers so cross-cache comparison works.
+            let kSlot0 = MLXRandom.normal(
+                [1, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(layer + 1))
+            ).asType(.float32)
+            let vSlot0 = MLXRandom.normal(
+                [1, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(layer + 101))
+            ).asType(.float32)
+            inner.keys[0..<1, 0..., ..<T0, 0...] = kSlot0
+            inner.values[0..<1, 0..., ..<T0, 0...] = vSlot0
+            inner.offsets[0] = T0
+
+            // Remaining slots (only when B > 1) — distinct content so the
+            // sparse path's per-slot bookkeeping isn't accidentally
+            // sharing state across slot indices.
+            if B > 1 {
+                for s in 1..<B {
+                    let kS = MLXRandom.normal(
+                        [1, kvHeads, T0, headDim],
+                        key: MLXRandom.key(UInt64(layer * 1000 + s * 7 + 13))
+                    ).asType(.float32)
+                    let vS = MLXRandom.normal(
+                        [1, kvHeads, T0, headDim],
+                        key: MLXRandom.key(UInt64(layer * 1000 + s * 7 + 113))
+                    ).asType(.float32)
+                    inner.keys[s..<(s + 1), 0..., ..<T0, 0...] = kS
+                    inner.values[s..<(s + 1), 0..., ..<T0, 0...] = vS
+                    inner.offsets[s] = T0
+                }
+            }
+
+            // Feed selector: stack across all slots so block features
+            // exist for every (slot, kv-head) pair.
+            // `BatchedRetrievalAttentionKVCache.updateIndex` expects the
+            // full `[B, kvHeads, T0, headDim]` shape — read it back from
+            // `inner.keys` which we've just populated.
+            let fullPrefill = inner.keys[..<B, 0..., ..<T0, 0...]
+            raCache.updateIndex(newKeys: fullPrefill)
+
+            return raCache
+        }
+    }
+
+    @Test func sparseDecodeB1ShapesFiniteAndOffsetAdvance() {
+        let cfg = makeTinyConfig()
+        let raCfg = makeRaConfig()
+        let model = Qwen2Model(cfg)
+        eval(model)
+
+        let B = 1
+        let T0 = 128
+        let maxSeq = 256
+        let raCaches = buildCaches(
+            cfg: cfg, raCfg: raCfg, B: B, T0: T0, maxSeq: maxSeq)
+
+        // Pre-step offset snapshot — defensive copy so we can compare
+        // after the in-place advance in `sparseAttend` → inner.update.
+        let preOffsets = raCaches.map { $0.inner.offsets[0] }
+        #expect(preOffsets.allSatisfy { $0 == T0 },
+            "all layers should start at offset \(T0)")
+
+        // One decode step at B=1.
+        let tokens = MLXArray([Int32(0)]).reshaped(1, 1)
+        let logits = model.fullyBatchedSparseDecode(tokens, raCaches: raCaches)
+        eval(logits)
+
+        // Shape: [B=1, T=1, vocab].
+        #expect(logits.shape == [1, 1, cfg.vocabularySize],
+            "B=1 fullyBatchedSparseDecode output shape")
+
+        // Finite logits: no NaN/Inf leaking from the sparse path at B=1.
+        let asArr = logits.asArray(Float.self)
+        let allFinite = asArr.allSatisfy { $0.isFinite }
+        #expect(allFinite, "B=1 logits must be finite")
+
+        // Offset advance: every layer's slot 0 must have moved from T0
+        // to T0 + 1 after one decode step.
+        for (li, raCache) in raCaches.enumerated() {
+            #expect(raCache.inner.offsets[0] == T0 + 1,
+                "layer \(li) slot 0 offset advanced T0=\(T0) → T0+1")
+        }
+    }
+
+    @Test func sparseDecodeB1SlotSemanticEqualsB2Slot0() {
+        let cfg = makeTinyConfig()
+        let raCfg = makeRaConfig()
+        let model = Qwen2Model(cfg)
+        eval(model)
+
+        let T0 = 128
+        let maxSeq = 256
+
+        // Stack 1: B=1.
+        let raCachesB1 = buildCaches(
+            cfg: cfg, raCfg: raCfg, B: 1, T0: T0, maxSeq: maxSeq)
+        // Stack 2: B=2. Slot 0 deterministically equal to B1 slot 0
+        // (same per-layer RNG key); slot 1 unrelated.
+        let raCachesB2 = buildCaches(
+            cfg: cfg, raCfg: raCfg, B: 2, T0: T0, maxSeq: maxSeq)
+
+        // Decode tokens — slot 0 gets the same input in both runs.
+        // Slot 1 (B=2 only) gets a different token — doesn't matter for
+        // the slot-0 comparison.
+        let tokB1 = MLXArray([Int32(0)]).reshaped(1, 1)
+        let tokB2 = MLXArray([Int32(0), Int32(1)]).reshaped(2, 1)
+
+        let logitsB1 = model.fullyBatchedSparseDecode(tokB1, raCaches: raCachesB1)
+        let logitsB2 = model.fullyBatchedSparseDecode(tokB2, raCaches: raCachesB2)
+        eval(logitsB1, logitsB2)
+
+        #expect(logitsB1.shape == [1, 1, cfg.vocabularySize])
+        #expect(logitsB2.shape == [2, 1, cfg.vocabularySize])
+
+        // Slot 0 comparison. The sparse mask kernel + selector are
+        // per-slot independent, so slot 0 in the B=2 pass should match
+        // the lone slot of the B=1 pass to within fp32 noise.
+        let l1 = logitsB1[0, 0, 0...].asArray(Float.self)
+        let l2Slot0 = logitsB2[0, 0, 0...].asArray(Float.self)
+        #expect(l1.count == l2Slot0.count)
+
+        // Tolerance: SDPA + matmul reduction order varies with batch
+        // dimension on Metal (the kernel partitions work differently
+        // across `B`), so we cannot expect bitwise equality. What we
+        // CAN assert is that the slot 0 output stays close — i.e. there
+        // is no per-slot indexing bug where B=1 takes a fundamentally
+        // different code path than B=2 slot 0. Cosine similarity is the
+        // right metric: it is invariant to small fp magnitude drift but
+        // catches any systematic divergence.
+        var dot: Float = 0
+        var n1: Float = 0
+        var n2: Float = 0
+        var maxAbs: Float = 0
+        for i in 0..<l1.count {
+            dot += l1[i] * l2Slot0[i]
+            n1 += l1[i] * l1[i]
+            n2 += l2Slot0[i] * l2Slot0[i]
+            maxAbs = max(maxAbs, abs(l1[i] - l2Slot0[i]))
+        }
+        let cos = dot / (sqrt(n1) * sqrt(n2) + 1e-12)
+        let detail = "B=1 slot 0 logits must match B=2 slot 0 "
+            + "(cosine=\(cos), maxAbs=\(maxAbs))"
+        // Cosine > 0.999 means the directions are effectively the same
+        // — semantic equivalence proven, micro-noise from reduction
+        // ordering ignored. Empirically the sparse path lands at >0.9999
+        // on synthetic random weights.
+        #expect(cos > 0.999, "\(detail)")
+    }
+}

--- a/Tests/MLXLMTests/Qwen2BatchedSparseSmokeTests.swift
+++ b/Tests/MLXLMTests/Qwen2BatchedSparseSmokeTests.swift
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Synthetic smoke for the Qwen2 batched-sparse decode hook. Builds a
+// tiny random-weight Qwen2 model in memory (no checkpoint), reserves B
+// slots in per-layer BatchedRetrievalAttentionKVCache, runs prefill + a
+// few decode steps, and asserts output shape + finite logits.
+
+import Foundation
+import MLX
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Qwen2 batched-sparse synthetic smoke")
+struct Qwen2BatchedSparseSmokeTests {
+
+    private func makeTinyConfig() -> Qwen2Configuration {
+        let json = """
+        {
+          "hidden_size": 128,
+          "num_hidden_layers": 4,
+          "intermediate_size": 256,
+          "num_attention_heads": 4,
+          "rms_norm_eps": 1e-5,
+          "vocab_size": 256,
+          "num_key_value_heads": 2,
+          "rope_theta": 10000.0,
+          "rope_traditional": false,
+          "tie_word_embeddings": true
+        }
+        """.data(using: .utf8)!
+        return try! JSONDecoder().decode(Qwen2Configuration.self, from: json)
+    }
+
+    @Test func sparseDecodeShapesAndFiniteLogits() {
+        let cfg = makeTinyConfig()
+        let model = Qwen2Model(cfg)
+        // Random weights — we only need shape + dtype propagation correct.
+        eval(model)
+
+        let B = 2
+        let nLayers = cfg.hiddenLayers
+        let kvHeads = cfg.kvHeads
+        let headDim = cfg.hiddenSize / cfg.attentionHeads
+        let maxSeq = 256
+
+        var raCfg = RetrievalAttentionConfig()
+        raCfg.fineBlockSize = 32
+        raCfg.coarseRescueEnabled = false
+        raCfg.adaptiveTopK = false
+        raCfg.fineTopK = 2
+        raCfg.staticInit = 32
+        raCfg.slidingWindow = 64
+        raCfg.denseFirstN = 1
+        raCfg.denseLastN = 1
+        raCfg.sparseMinContext = 0
+
+        let raCaches: [BatchedRetrievalAttentionKVCache] = (0..<nLayers).map { layer in
+            let inner = BatchedKVCache(
+                maxBatch: B, kvHeads: kvHeads, headDim: headDim,
+                maxSeq: maxSeq, dtype: .float32)
+            for _ in 0..<B { _ = inner.addRequest() }
+            return BatchedRetrievalAttentionKVCache(
+                inner: inner, B: B, nKVHeads: kvHeads, dHead: headDim,
+                layerIdx: layer, totalLayers: nLayers, raConfig: raCfg)
+        }
+
+        // Synthetic prefill: write 128 tokens of fake K/V into each layer
+        // cache, advance per-slot offsets accordingly. Bypasses model
+        // forward to keep the smoke focused on the sparse decode path.
+        let T0 = 128
+        for raCache in raCaches {
+            let inner = raCache.inner
+            let kFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 1))
+            ).asType(.float32)
+            let vFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 101))
+            ).asType(.float32)
+            inner.keys[..<B, 0..., ..<T0, 0...] = kFill
+            inner.values[..<B, 0..., ..<T0, 0...] = vFill
+            for i in 0..<B { inner.offsets[i] = T0 }
+            // Selector index: feed the prefill so block features exist for
+            // sparse-eligible layers.
+            raCache.updateIndex(newKeys: kFill)
+        }
+
+        // Decode a few tokens. Random next-token ids.
+        let tokens = MLXArray([0, 1] as [Int32]).reshaped(B, 1)
+        let logits = model.fullyBatchedSparseDecode(tokens, raCaches: raCaches)
+        eval(logits)
+        #expect(logits.shape == [B, 1, cfg.vocabularySize],
+            "fullyBatchedSparseDecode output shape")
+        // Finite logits (no NaN/Inf leaking from the sparse kernel).
+        let asArr = logits.asArray(Float.self)
+        let allFinite = asArr.allSatisfy { $0.isFinite }
+        #expect(allFinite, "logits must be finite")
+    }
+}

--- a/Tests/MLXLMTests/Qwen35BatchedHybridCacheTests.swift
+++ b/Tests/MLXLMTests/Qwen35BatchedHybridCacheTests.swift
@@ -79,6 +79,9 @@ struct Qwen35BatchedHybridCacheTests {
             case .gdn:
                 #expect(!expectAttention,
                         "layer \(i) is GDN but pattern expects attention")
+            case .sparseAttention:
+                #expect(expectAttention,
+                        "layer \(i) is sparseAttention but pattern expects GDN")
             }
         }
     }
@@ -102,6 +105,7 @@ struct Qwen35BatchedHybridCacheTests {
             switch layer {
             case .attention(let c): #expect(c.active == 2)
             case .gdn(let c): #expect(c.active == 2)
+            case .sparseAttention(let ra): #expect(ra.inner.active == 2)
             }
         }
     }
@@ -123,6 +127,7 @@ struct Qwen35BatchedHybridCacheTests {
             switch layer {
             case .attention(let c): #expect(c.active == 2)
             case .gdn(let c): #expect(c.active == 2)
+            case .sparseAttention(let ra): #expect(ra.inner.active == 2)
             }
         }
     }
@@ -271,6 +276,11 @@ struct Qwen35BatchedHybridCacheTests {
                 #expect(c.kvHeads == DenseShape.kvHeads)
                 #expect(c.headDim == DenseShape.headDim)
                 #expect(c.maxSeq == 2048)  // default when parameters == nil
+            case .sparseAttention(let ra):
+                #expect(ra.inner.maxBatch == 2)
+                #expect(ra.inner.kvHeads == DenseShape.kvHeads)
+                #expect(ra.inner.headDim == DenseShape.headDim)
+                #expect(ra.inner.maxSeq == 2048)
             }
         }
     }

--- a/Tests/MLXLMTests/Qwen35BatchedSparseSmokeTests.swift
+++ b/Tests/MLXLMTests/Qwen35BatchedSparseSmokeTests.swift
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Synthetic smoke for the Qwen35 hybrid batched-sparse decode hook.
+//
+// `newBatchedHybridSparseCache` produces a BatchedHybridCache whose
+// attention slots are `.sparseAttention(BatchedRetrievalAttentionKVCache)`
+// and GDN slots stay `.gdn(BatchedMambaCache)`. The smoke test rotates
+// through the foundation surface (cache build, slot lifecycle) and then
+// runs a tiny synthetic forward to validate shape + finiteness.
+
+import Foundation
+import MLX
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Qwen35 hybrid batched-sparse synthetic smoke")
+struct Qwen35BatchedSparseSmokeTests {
+
+    /// Use the kernel-instantiated GDN dims (Dk=Dv=128, Hv=Hk=16, bfloat16)
+    /// so the GDN Metal kernel finds its instantiation. The dense config in
+    /// `Qwen35BatchedHybridCacheTests` uses tinier dims that would crash a
+    /// forward call.
+    private static let json = """
+        {
+            "model_type": "qwen3_5",
+            "hidden_size": 64,
+            "num_hidden_layers": 4,
+            "intermediate_size": 128,
+            "num_attention_heads": 8,
+            "num_key_value_heads": 2,
+            "linear_num_value_heads": 16,
+            "linear_num_key_heads": 16,
+            "linear_key_head_dim": 128,
+            "linear_value_head_dim": 128,
+            "linear_conv_kernel_dim": 4,
+            "rms_norm_eps": 1e-6,
+            "vocab_size": 256,
+            "rope_theta": 10000.0,
+            "partial_rotary_factor": 0.25,
+            "max_position_embeddings": 512,
+            "tie_word_embeddings": true,
+            "attention_bias": false,
+            "head_dim": 8,
+            "full_attention_interval": 4
+        }
+        """
+
+    @Test
+    func newBatchedHybridSparseCacheLayout() throws {
+        let cfg = try JSONDecoder().decode(
+            Qwen35TextConfiguration.self, from: Self.json.data(using: .utf8)!)
+        let model = Qwen35TextModel(cfg)
+
+        var raCfg = RetrievalAttentionConfig()
+        raCfg.fineBlockSize = 32
+        raCfg.coarseRescueEnabled = false
+        raCfg.adaptiveTopK = false
+        raCfg.fineTopK = 2
+        raCfg.staticInit = 32
+        raCfg.slidingWindow = 64
+        raCfg.denseFirstN = 0
+        raCfg.denseLastN = 0
+        raCfg.sparseMinContext = 0
+
+        let cache = model.newBatchedHybridSparseCache(
+            maxBatch: 2, parameters: nil, raConfig: raCfg)
+
+        #expect(cache.layers.count == 4, "layer count must match config")
+
+        var sparseAttentionCount = 0
+        var gdnCount = 0
+        for layer in cache.layers {
+            switch layer {
+            case .sparseAttention: sparseAttentionCount += 1
+            case .gdn: gdnCount += 1
+            case .attention:
+                Issue.record("hybrid sparse cache should not emit .attention")
+            }
+        }
+        // 4 layers, fullAttentionInterval=4 ⇒ 3 GDN + 1 sparseAttention.
+        #expect(sparseAttentionCount == 1)
+        #expect(gdnCount == 3)
+    }
+
+    @Test
+    func fullyBatchedSparseDecodeShapesAndFiniteLogits() throws {
+        let cfg = try JSONDecoder().decode(
+            Qwen35TextConfiguration.self, from: Self.json.data(using: .utf8)!)
+        let model = Qwen35TextModel(cfg)
+        eval(model)
+        // Cast params to bf16 so the GDN Metal kernel finds its instantiation.
+        let bf16Params = model.parameters().mapValues { (v: MLXArray) in v.asType(.bfloat16) }
+        try model.update(parameters: bf16Params, verify: [.noUnusedKeys])
+        eval(model)
+
+        var raCfg = RetrievalAttentionConfig()
+        raCfg.fineBlockSize = 32
+        raCfg.coarseRescueEnabled = false
+        raCfg.adaptiveTopK = false
+        raCfg.fineTopK = 2
+        raCfg.staticInit = 32
+        raCfg.slidingWindow = 64
+        raCfg.denseFirstN = 0
+        raCfg.denseLastN = 0
+        raCfg.sparseMinContext = 0
+
+        let B = 2
+        let cache = model.newBatchedHybridSparseCache(
+            maxBatch: B, parameters: nil, raConfig: raCfg)
+        for _ in 0..<B { cache.addSlot() }
+
+        let tokens = MLXArray([0, 1] as [Int32]).reshaped(B, 1)
+        let logits = model.fullyBatchedSparseDecode(tokens, caches: cache)
+        eval(logits)
+        #expect(logits.shape == [B, 1, cfg.vocabularySize])
+        let asArr = logits.asArray(Float.self)
+        #expect(asArr.allSatisfy { $0.isFinite }, "logits must be finite")
+    }
+}

--- a/Tests/MLXLMTests/Qwen35MoEBatchedHybridCacheTests.swift
+++ b/Tests/MLXLMTests/Qwen35MoEBatchedHybridCacheTests.swift
@@ -83,6 +83,7 @@ struct Qwen35MoEBatchedHybridCacheTests {
             switch layer {
             case .attention: #expect(expectAttention)
             case .gdn: #expect(!expectAttention)
+            case .sparseAttention: #expect(expectAttention)
             }
         }
     }
@@ -104,6 +105,7 @@ struct Qwen35MoEBatchedHybridCacheTests {
             switch layer {
             case .attention(let c): #expect(c.active == 2)
             case .gdn(let c): #expect(c.active == 2)
+            case .sparseAttention(let ra): #expect(ra.inner.active == 2)
             }
         }
 
@@ -133,6 +135,9 @@ struct Qwen35MoEBatchedHybridCacheTests {
             case .attention(let c):
                 #expect(c.kvHeads == MoEShape.kvHeads)
                 #expect(c.headDim == MoEShape.headDim)
+            case .sparseAttention(let ra):
+                #expect(ra.inner.kvHeads == MoEShape.kvHeads)
+                #expect(ra.inner.headDim == MoEShape.headDim)
             }
         }
     }

--- a/Tests/MLXLMTests/Qwen3BatchedSparseSmokeTests.swift
+++ b/Tests/MLXLMTests/Qwen3BatchedSparseSmokeTests.swift
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Synthetic smoke for the Qwen3 batched-sparse decode hook. Tiny random-
+// weight Qwen3 model in memory; B slots in per-layer
+// BatchedRetrievalAttentionKVCache; synthetic prefill + one decode step.
+
+import Foundation
+import MLX
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Qwen3 batched-sparse synthetic smoke")
+struct Qwen3BatchedSparseSmokeTests {
+
+    private func makeTinyConfig() -> Qwen3Configuration {
+        let json = """
+        {
+          "hidden_size": 128,
+          "num_hidden_layers": 4,
+          "intermediate_size": 256,
+          "num_attention_heads": 4,
+          "rms_norm_eps": 1e-5,
+          "vocab_size": 256,
+          "num_key_value_heads": 2,
+          "rope_theta": 10000.0,
+          "head_dim": 32,
+          "tie_word_embeddings": true
+        }
+        """.data(using: .utf8)!
+        return try! JSONDecoder().decode(Qwen3Configuration.self, from: json)
+    }
+
+    @Test func sparseDecodeShapesAndFiniteLogits() {
+        let cfg = makeTinyConfig()
+        let model = Qwen3Model(cfg)
+        eval(model)
+
+        // Read the config back via JSON encoding to extract fields, since
+        // Qwen3Configuration members are internal.
+        let cfgData = try! JSONEncoder().encode(cfg)
+        let cfgDict = try! JSONSerialization.jsonObject(with: cfgData) as! [String: Any]
+        let nLayers = cfgDict["num_hidden_layers"] as! Int
+        let kvHeads = cfgDict["num_key_value_heads"] as! Int
+        let headDim = cfgDict["head_dim"] as! Int
+        let vocab = cfgDict["vocab_size"] as! Int
+
+        let B = 2
+        let maxSeq = 256
+
+        var raCfg = RetrievalAttentionConfig()
+        raCfg.fineBlockSize = 32
+        raCfg.coarseRescueEnabled = false
+        raCfg.adaptiveTopK = false
+        raCfg.fineTopK = 2
+        raCfg.staticInit = 32
+        raCfg.slidingWindow = 64
+        raCfg.denseFirstN = 1
+        raCfg.denseLastN = 1
+        raCfg.sparseMinContext = 0
+
+        let raCaches: [BatchedRetrievalAttentionKVCache] = (0..<nLayers).map { layer in
+            let inner = BatchedKVCache(
+                maxBatch: B, kvHeads: kvHeads, headDim: headDim,
+                maxSeq: maxSeq, dtype: .float32)
+            for _ in 0..<B { _ = inner.addRequest() }
+            return BatchedRetrievalAttentionKVCache(
+                inner: inner, B: B, nKVHeads: kvHeads, dHead: headDim,
+                layerIdx: layer, totalLayers: nLayers, raConfig: raCfg)
+        }
+
+        // Synthetic prefill.
+        let T0 = 128
+        for raCache in raCaches {
+            let inner = raCache.inner
+            let kFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 1))
+            ).asType(.float32)
+            let vFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 101))
+            ).asType(.float32)
+            inner.keys[..<B, 0..., ..<T0, 0...] = kFill
+            inner.values[..<B, 0..., ..<T0, 0...] = vFill
+            for i in 0..<B { inner.offsets[i] = T0 }
+            raCache.updateIndex(newKeys: kFill)
+        }
+
+        let tokens = MLXArray([0, 1] as [Int32]).reshaped(B, 1)
+        let logits = model.fullyBatchedSparseDecode(tokens, raCaches: raCaches)
+        eval(logits)
+        #expect(logits.shape == [B, 1, vocab],
+            "fullyBatchedSparseDecode output shape")
+        let asArr = logits.asArray(Float.self)
+        let allFinite = asArr.allSatisfy { $0.isFinite }
+        #expect(allFinite, "logits must be finite")
+    }
+}

--- a/Tests/MLXLMTests/Qwen3MoEBatchedSparseSmokeTests.swift
+++ b/Tests/MLXLMTests/Qwen3MoEBatchedSparseSmokeTests.swift
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Synthetic smoke for the Qwen3MoE batched-sparse decode hook. Tiny
+// random-weight Qwen3MoE model in memory; B slots in per-layer
+// BatchedRetrievalAttentionKVCache; synthetic prefill + one decode step.
+
+import Foundation
+import MLX
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Qwen3MoE batched-sparse synthetic smoke")
+struct Qwen3MoEBatchedSparseSmokeTests {
+
+    /// Tiny config — uses a single dense MLP layer (mlp_only_layers covers all
+    /// indices) to keep the synthetic smoke focused on the attention path,
+    /// not the SwitchGLU expert routing.
+    private func makeTinyConfig() -> Qwen3MoEConfiguration {
+        let json = """
+        {
+          "hidden_size": 128,
+          "num_hidden_layers": 4,
+          "intermediate_size": 256,
+          "num_attention_heads": 4,
+          "rms_norm_eps": 1e-5,
+          "vocab_size": 256,
+          "num_key_value_heads": 2,
+          "rope_theta": 10000.0,
+          "head_dim": 32,
+          "tie_word_embeddings": true,
+          "num_experts": 0,
+          "num_experts_per_tok": 1,
+          "decoder_sparse_step": 1,
+          "moe_intermediate_size": 64,
+          "mlp_only_layers": [0, 1, 2, 3]
+        }
+        """.data(using: .utf8)!
+        return try! JSONDecoder().decode(Qwen3MoEConfiguration.self, from: json)
+    }
+
+    @Test func sparseDecodeShapesAndFiniteLogits() {
+        let cfg = makeTinyConfig()
+        let model = Qwen3MoEModel(cfg)
+        eval(model)
+
+        let nLayers = 4
+        let kvHeads = 2
+        let headDim = 32
+        let vocab = 256
+
+        let B = 2
+        let maxSeq = 256
+
+        var raCfg = RetrievalAttentionConfig()
+        raCfg.fineBlockSize = 32
+        raCfg.coarseRescueEnabled = false
+        raCfg.adaptiveTopK = false
+        raCfg.fineTopK = 2
+        raCfg.staticInit = 32
+        raCfg.slidingWindow = 64
+        raCfg.denseFirstN = 1
+        raCfg.denseLastN = 1
+        raCfg.sparseMinContext = 0
+
+        let raCaches: [BatchedRetrievalAttentionKVCache] = (0..<nLayers).map { layer in
+            let inner = BatchedKVCache(
+                maxBatch: B, kvHeads: kvHeads, headDim: headDim,
+                maxSeq: maxSeq, dtype: .float32)
+            for _ in 0..<B { _ = inner.addRequest() }
+            return BatchedRetrievalAttentionKVCache(
+                inner: inner, B: B, nKVHeads: kvHeads, dHead: headDim,
+                layerIdx: layer, totalLayers: nLayers, raConfig: raCfg)
+        }
+
+        let T0 = 128
+        for raCache in raCaches {
+            let inner = raCache.inner
+            let kFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 1))
+            ).asType(.float32)
+            let vFill = MLXRandom.normal(
+                [B, kvHeads, T0, headDim],
+                key: MLXRandom.key(UInt64(raCache.layerIdx + 101))
+            ).asType(.float32)
+            inner.keys[..<B, 0..., ..<T0, 0...] = kFill
+            inner.values[..<B, 0..., ..<T0, 0...] = vFill
+            for i in 0..<B { inner.offsets[i] = T0 }
+            raCache.updateIndex(newKeys: kFill)
+        }
+
+        let tokens = MLXArray([0, 1] as [Int32]).reshaped(B, 1)
+        let logits = model.fullyBatchedSparseDecode(tokens, raCaches: raCaches)
+        eval(logits)
+        #expect(logits.shape == [B, 1, vocab],
+            "fullyBatchedSparseDecode output shape")
+        let asArr = logits.asArray(Float.self)
+        let allFinite = asArr.allSatisfy { $0.isFinite }
+        #expect(allFinite, "logits must be finite")
+    }
+}

--- a/specs/044-batched-sparse-attention-decode.md
+++ b/specs/044-batched-sparse-attention-decode.md
@@ -85,6 +85,23 @@ The mask-kernel default depends on Apple's `sdpa_vector_2pass` Metal kernel runn
 
 The bridge (downstream) sets `MLX_SDPA_BLOCKS=128` at engine-create time. Setting the env BEFORE `python` invokes is preferable to setting it from Swift (PSO JIT timing) but both work; the difference is the first-call warmup window.
 
+## Legacy retirement
+
+The fork carried a single-stream sparse decode path (`RetrievalAttentionKVCache`,
+B=1 wrapper) plus a B≥1 batched cache (`BatchedRetrievalAttentionKVCache`,
+this PR). Both share the same selector + mask kernel. With the batched cache
+handling B=1 correctly (see `Qwen2BatchedSparseB1Tests`), the single-stream
+wrapper is redundant and is not proposed for upstreaming. Memory cost at
+B=1 long-context single-stream is `O(maxSeq)` rectangular preallocation —
+equivalent to the wrapper's dynamic-concat cost when `maxSeq` is sized to
+actual context. One cache, one selector, one mask kernel covers all batch
+sizes.
+
+Failed exploration paths (F-71b custom Metal sparse SDPA kernel at B=8 was
+14× slower than dense; F-76 implicit sparse was slower than dense at 128K;
+F-84 blockGather lost 1.3× at B=1) are documented in the project's research
+notes and not proposed for upstreaming.
+
 ## Open
 
 - **vllm-swift bridge dispatch** — wiring up `BatchedSparseLLM` / `BatchedHybridSparseLLM` casting in the engine's `decode_step` lives in the downstream `vllm-swift` consumer, NOT this repo.

--- a/specs/044-batched-sparse-attention-decode.md
+++ b/specs/044-batched-sparse-attention-decode.md
@@ -1,0 +1,99 @@
+# 044 — Batched sparse attention decode
+
+- **Status:** Proposed 2026-05-17 (this PR). Implementation in flight on `pr/alpha-batched-sparse-attention` ([PR #224](https://github.com/ekryski/mlx-swift-lm/pull/224)).
+- **Branch:** `pr/alpha-batched-sparse-attention`.
+- **Depends on:** none structurally. Composes orthogonally with [spec 041](041-flash-quantized-sdpa.md) (the affine + turbo quantized cache layouts) — the sparse wrapper composes via a held `BatchedKVCache` and routes through the same MLXFast SDPA primitives.
+
+## Problem
+
+Multi-client serving on a single `mlx-swift-lm` engine wants both batched decode (multiple concurrent requests sharing one GPU pass) AND long-context attention (32K+ KV per request). The two pull in opposite directions:
+
+- **Batched decode**: one `[B, 1]` token pass through the whole model. Existing `BatchedKVCache` already supports this on dense attention — the bandwidth cost per step is `O(B × nKVH × T × D)` (the rectangular cache fanned over `B` requests).
+- **Long-context sparse decode** (Quest / NSA / SeerAttention-R style): per-request retrieval index narrows attention from `T` to `K_topk ≪ T` candidate blocks. Existing sparse path (`RetrievalAttentionKVCache`) is per-request, B = 1 only — every callsite asserts dim(0) == 1.
+
+The product wants both: B concurrent requests, each at long context, each saving bandwidth via sparse selection. Bandwidth scales as `B × nKVH × T × D` for dense and `B × nKVH × K_topk × D` for sparse — a 4–8× saving at long context is exactly the cell where multi-client serving wants to spend its capacity.
+
+Today the dispatcher sees `B > 1` on a sparse request → falls back to a serial per-request decode loop. The sparse selector AND the SDPA both lose their batching, and the engine effectively serves the cohort at single-stream speed.
+
+- **Goal:** wire a per-`(B, KV-head)` selector index + a batched sparse SDPA path through every supported model family, so concurrent long-context decode keeps both the sparse bandwidth saving AND the single-batched-call dispatch shape.
+
+## Design
+
+### Protocols + cache
+
+Three new public surfaces in `Libraries/MLXLMCommon`:
+
+- `BatchedSparseLLM` (protocol) — pure-attention families. Single method `fullyBatchedSparseDecode(inputs:raCaches:)` over a `[BatchedRetrievalAttentionKVCache]` (one per layer).
+- `BatchedHybridSparseLLM: BatchedHybridLLM` — hybrid families (interleaved attention + SSM/GDN). Adds `fullyBatchedSparseDecode(inputs:caches:)` and `newBatchedHybridSparseCache(maxBatch:parameters:raConfig:)` over a `BatchedHybridCache`. Inherits dense `fullyBatchedDecode` from the parent.
+- `BatchedRetrievalAttentionKVCache` — composes an `inner: BatchedKVCache` (rectangular fp16 K/V) with a `BatchedRetrievalAttentionIndexB` (per-(B, KV-head) selector index, built lazily). Public API is `update(newKeys:newValues:)` → `updateIndex(newKeys:)` → `sparseAttend(queries:scale:)`.
+
+The composition is orthogonal to the quantization layout: `BatchedKVCache` is still the foundation — `BatchedRetrievalAttentionKVCache` just sits in front of it. A quantization-aware sparse path drops in by swapping the inner cache type without touching the selector or per-family forwards.
+
+### Kernels
+
+Three Metal kernels back the sparse step. All live in `Libraries/MLXLMCommon/RetrievalAttentionKernels/`:
+
+1. **Batched mask kernel** (default — `VSM_SPARSE_BATCHED_KERNEL=mask`). Builds a per-slot `[B, 1, 1, T]` fp16 additive mask from the per-(B, KV-head) top-K block selections, then calls `MLXFast.scaledDotProductAttention(mask: .array(...))`. This hits the tuned `sdpa_vector_2pass` Metal kernel on Apple Silicon (the same one dense uses) — the win comes from skipping non-selected tokens during the score pass, not from reducing K/V bandwidth.
+2. **Compose-gather kernel** (`gather`). Materialises `[B, nKVH, K_padded, D]` slabs via `takeAlong`, then calls dense `MLXFast.scaledDotProductAttention(mask: .none)` on the small slab. Saves actual K/V bandwidth; oversub-bound on Apple at low `K_padded / T` ratios.
+3. **Fused sparse group kernel** (`group`). Custom Metal kernel (`retrievalAttentionGroupSparseSDPA`) that gathers + SDPAs in one dispatch, GQA-coloaded per simdgroup. Experimental — wins on CUDA-style hardware but loses on M-series due to threadgroup-occupancy mismatch.
+
+Default is the mask kernel (option 1) — it composes with Apple's tuned SDPA fast path and is the only one that ships positive numbers across the longctx grid (see §"Performance" below).
+
+### Per-family hooks
+
+Every supported model has a `{Family}+Sparse.swift` extension file that adds `fullyBatchedSparseForward` overloads on its attention + transformer-block + model-inner classes. The conformance lands on the top-level model class. Pure-attention families implement `BatchedSparseLLM`; hybrids implement `BatchedHybridSparseLLM`.
+
+Family-specific work (because every attention layer's Q / K / V projection ordering differs):
+
+- **Qwen2 / Qwen3 / Llama / Mistral3 / Phi3** — straight projection → reshape → RoPE → cache update → sparse SDPA. Llama-style attention sits behind a uniform `LlamaAttention.fullyBatchedSparseForward` and is mirrored by Mistral3 / Phi3 (Phi3 has a fused qkv split, Mistral3 has a sliding/global layer mix that dispatches per-`layer.useSliding`).
+- **Qwen3 / Qwen3MoE** — Q/K RMSNorm applied pre-RoPE on the per-head reshape. MoE FFN (`Qwen3MoESparseMoeBlock`) is orthogonal — it routes by token (`UnaryLayer` conformance) regardless of dense vs sparse attention.
+- **Gemma3** — sliding-only attention layers; embedding scale + final-logit softcap preserved through the sparse output.
+- **Gemma4** — sliding + global layer mix with DIFFERENT head dims per layer kind; per-layer `BatchedRetrievalAttentionKVCache` shape must match. MoE blocks + `num_kv_shared_layers > 0` (e2b: 20 trailing layers reuse the donor's K/V) both supported — shared layers point at the donor's `BatchedRetrievalAttentionKVCache` instance (mirrors the dense `previousKVs` map), compute Q only, RoPE Q at the donor's pre-update offset.
+- **Qwen3.5 / Qwen3.6 (hybrid)** — attention + GatedDeltaNet interleave. Attention layers route through `.sparseAttention`; GDN layers stay on the existing `.gdn(BatchedMambaCache)` batched path. The MoE Qwen3.6 inherits the conformance from `Qwen35TextModel`.
+- **NemotronH (hybrid)** — Mamba2 + Llama-style attention + MLP + MoE pattern (4 block kinds via `hybridOverridePattern`). Attention layers (`*`) route to `.sparseAttention`; Mamba2 layers (`M`) route to a new `NemotronHMamba2Mixer.fullyBatchedForward` against `BatchedMambaCache` (with `recDtype` set to the model's compute dtype — Mamba2 has an input-dtype SSM state contract, unlike GDN's fp32). MLP (`-`) and MoE (`E`) blocks contribute NO cache slot — the per-layer dispatch walks the pattern and only advances the cache index on mamba/attention, mirroring `newCache`'s shape.
+
+### Activation
+
+Consumer side is opt-in: the bridge (downstream consumer, e.g. `vllm-swift`) casts the loaded model to `BatchedSparseLLM` / `BatchedHybridSparseLLM` and dispatches `fullyBatchedSparseDecode` when a `BatchedRetrievalAttentionKVCache` list / sparse-augmented `BatchedHybridCache` is in hand. Dispatch logic itself lives downstream — this repo just ships the model-side surface + kernels.
+
+Kernel choice env var: `VSM_SPARSE_BATCHED_KERNEL ∈ {mask, gather, group, loop}` (default `mask`).
+
+## Per-family coverage
+
+| Family | File | Type | Synthetic smoke |
+|---|---|---|---|
+| Qwen2 | `Qwen2+Sparse.swift` | `BatchedSparseLLM` | `Qwen2BatchedSparseSmokeTests` |
+| Qwen3 | `Qwen3+Sparse.swift` | `BatchedSparseLLM` | `Qwen3BatchedSparseSmokeTests` |
+| Qwen3MoE | `Qwen3MoE+Sparse.swift` | `BatchedSparseLLM` | `Qwen3MoEBatchedSparseSmokeTests` |
+| Llama | `Llama+Sparse.swift` | `BatchedSparseLLM` | `LlamaBatchedSparseSmokeTests` |
+| Mistral3 | `Mistral3+Sparse.swift` | `BatchedSparseLLM` | `Mistral3BatchedSparseSmokeTests` |
+| Phi3 | `Phi3+Sparse.swift` | `BatchedSparseLLM` | `Phi3BatchedSparseSmokeTests` |
+| Gemma3 | `Gemma3+Sparse.swift` | `BatchedSparseLLM` | `Gemma3BatchedSparseSmokeTests` |
+| Gemma4 | `Gemma4+Sparse.swift` | `BatchedSparseLLM` | `Gemma4BatchedSparseSmokeTests` (covers MoE + KV-shared) |
+| Qwen3.5 / Qwen3.6 | `Qwen35+Sparse.swift` | `BatchedHybridSparseLLM` | `Qwen35BatchedSparseSmokeTests` |
+| NemotronH | `NemotronH+Sparse.swift` | `BatchedHybridSparseLLM` | `NemotronHBatchedSparseSmokeTests` |
+
+Eight pure-attention families + two hybrid families. The 22 sparse tests across 12 suites cover protocol surface, cache layout, slot lifecycle, and end-to-end synthetic decode.
+
+## Coexistence with spec 041
+
+Spec 041 (flash quantized SDPA) reshapes the cache: `AffineQuantizedKVCache` / `TurboQuantizedKVCache` replace `StandardKVCache` for quantized configs. The sparse work composes orthogonally — `BatchedRetrievalAttentionKVCache` wraps a `BatchedKVCache` via the public `inner` member; a future quantization-aware sparse path drops in by swapping the inner type without touching the per-family `+Sparse` forwards. The kernel-selection env var (`VSM_SPARSE_BATCHED_KERNEL`) is independent of the quantization-strategy env var (`MLX_AFFINE_SDPA`).
+
+## Apple Silicon SDPA notes
+
+The mask-kernel default depends on Apple's `sdpa_vector_2pass` Metal kernel running with the right block size for the long-context regime. The default `blocks` heuristic in upstream MLX (`mlx-explore/mlx`) was tuned on the `_nomask` kernel and picks `blocks=256` at `N ∈ (8K, 32K]` on M5 Max, which oversubscribes the GPU for the `_floatmask` variant the sparse path uses. The sister PR [ekryski/mlx#34](https://github.com/ekryski/mlx/pull/34) backports the env-var override (`MLX_SDPA_BLOCKS`) from upstream PR 3455 + adds a per-shape blocks formula (`blocks ≈ ceil(960 × 1.1 / (B × nKVH × gqa))`). With it, the mask-kernel sparse path lands +24–42% over the upstream default on long-context batched cells; without it the sparse path can fall behind dense at `ctx ∈ (8K, 32K]` for `B ≥ 8`.
+
+The bridge (downstream) sets `MLX_SDPA_BLOCKS=128` at engine-create time. Setting the env BEFORE `python` invokes is preferable to setting it from Swift (PSO JIT timing) but both work; the difference is the first-call warmup window.
+
+## Open
+
+- **vllm-swift bridge dispatch** — wiring up `BatchedSparseLLM` / `BatchedHybridSparseLLM` casting in the engine's `decode_step` lives in the downstream `vllm-swift` consumer, NOT this repo.
+- **`.attention` slot on the sparse-decode path** — `BatchedHybridSparseLLM`'s `newBatchedHybridSparseCache` emits only `.sparseAttention` slots for attention layers. The per-block dispatch supports `.attention` slots as a defensive path (the parent `BatchedHybridLLM`'s dense `fullyBatchedDecode` reuses the same per-block forward), but it's not exercised by the sparse-decode dispatcher.
+- **Compressed-domain sparse decode** — when [spec 039](039-compressed-prefix-kv-cache.md) lands, swapping `BatchedKVCache` → quantized variant inside `BatchedRetrievalAttentionKVCache.inner` will let sparse decode read directly from compressed K/V. Out of scope for this spec.
+
+## References
+
+- **Prior art**: NSA ("Native Sparse Attention", DeepSeek-AI 2025), SeerAttention-R (2024), Quest (page-bounded top-K, Du et al. 2024), DuoAttention (retrieval/streaming head split, spec 036).
+- **Sister kernel PR**: [ekryski/mlx#34](https://github.com/ekryski/mlx/pull/34) — `MLX_SDPA_BLOCKS` env override + per-shape blocks heuristic.
+- **Composition spec**: [041 — Flash quantized SDPA](041-flash-quantized-sdpa.md) (cache composition compatibility).
+- **Adjacent specs**: [034 — Decode-side KV selection](034-decode-side-kv-selection.md), [035 — Quest page-bounded top-K](035-quest-page-bounded-topk-attention.md), [036 — DuoAttention](036-duoattention-retrieval-streaming-head-split.md).


### PR DESCRIPTION
## Summary

Production-tested batched sparse attention decode infrastructure used at scale in the vllm-swift project. Measured **1.16-1.73× decode throughput wins at batched long-context cells on M-series GPU** (Qwen2.5-14B-Instruct-1M-4bit, B=8 ctx=28K: 44.0 → 76.2 tok/s vs dense).

One cache, one selector, one mask kernel — covers **all batch sizes including B=1**. The fork's legacy single-stream `RetrievalAttentionKVCache` wrapper is retired in favor of this batched cache (see spec 044 §"Legacy retirement").

Spec: [`specs/044-batched-sparse-attention-decode.md`](specs/044-batched-sparse-attention-decode.md).

### Logical commits (8)

1. **Batched sparse attention decode infrastructure** — `BatchedRetrievalAttentionIndexB` (per-(B, KV-head) selector index with incremental running-mean block features), `BatchedRetrievalAttentionKVCache` (wraps `BatchedKVCache`, exposes `sparseAttend`), three Metal kernels (single-slot mask, batched mask, group-centric fused sparse SDPA), and the `BatchedSparseLLM` protocol. Selector amortizes across batch; bandwidth saving scales linearly with `B`. Covers B=1 through B=N uniformly — no separate single-stream path needed.

2. **Per-family attention hooks (initial three)** — Qwen2, Qwen3, and Llama each gain `fullyBatchedSparseForward` on Attention / TransformerBlock / ModelInner via additive extension files, plus `BatchedSparseLLM` conformance on the top-level model. Existing dense entry points are untouched. F-73 fp16 mask + MLXFast SDPA underneath (hits the `sdpa_vector_2pass` kernel variant).

3. **Per-family attention hooks (additional five)** — Qwen3MoE, Gemma3, Gemma4, Phi3, and Mistral3 each gain the same `+Sparse.swift` extension pattern + `BatchedSparseLLM` conformance. Family-specific quirks preserved: Qwen3MoE inherits Qwen3's q_norm/k_norm pre-RoPE (MoE expert routing is orthogonal); Gemma3 applies Q/K norm post-transpose pre-RoPE + sqrt(hiddenSize) embedding scale; Gemma4 dispatches sliding vs global per-layer with v_norm; Phi3 splits the fused qkv_proj + supports LongRoPE via the standard RoPELayer surface; Mistral3 threads Llama-4 attention scaling through a pre-computed attnScale tensor.

4. **Hybrid foundation + Qwen 3.5 / Qwen 3.6 hybrid sparse port** — Adds `.sparseAttention(BatchedRetrievalAttentionKVCache)` case to `BatchedHybridCache.BatchedLayerCache` alongside the existing `.attention` and `.gdn` cases, extends lockstep slot management through the wrapped inner cache, and introduces the `BatchedHybridSparseLLM: BatchedHybridLLM` protocol. `Qwen35TextModel` conforms via per-layer-type dispatch (GDN layers stay on the existing batched GDN path; attention layers route through the sparse SDPA). Conformance also covers Qwen 3.6 MoE through inheritance.

5. **Gemma4 KV-shared + MoE on the sparse path** — Drops the two `precondition` gates the initial Gemma4+Sparse stub had. KV-shared layers (e2b: trailing `num_kv_shared_layers=20` reuse the donor's K/V) now route through the donor's `BatchedRetrievalAttentionKVCache`, mirroring the dense `previousKVs` indirection — caller hands the SAME raCache instance for each shared layer; the shared layer computes Q only and RoPE-rotates at the donor's pre-update offset. MoE FFN blocks (`experts` / `router` non-nil) pass through the existing dense `Gemma4MoeBlock` branch as a UnaryLayer — sparse only touches the attention SDPA step. Synthetic smoke now exercises both: a 6-layer `num_kv_shared_layers=4` config asserting cache-instance identity on shared layers, plus an `enable_moe_block: true` config with 4 experts × top-K=2 driving an end-to-end decode step.

6. **NemotronH hybrid sparse port** — Adds `NemotronH+Sparse.swift` following the Qwen35 hybrid pattern. SSM/Mamba2 layers stay dense (no sparse concept for fixed-size SSM state) and route through a new batched `NemotronHMamba2Mixer.fullyBatchedForward` against `BatchedMambaCache`. Attention layers route through `BatchedRetrievalAttentionKVCache.sparseAttend` — NemotronH's attention is the simplest of the family (RoPE-free + no Q/K norm), so it's a strict subset of `Llama+Sparse`. Per-layer dispatch walks `hybridOverridePattern` and only advances the cache index on mamba/attention (MLP / MoE blocks contribute no slot, mirroring `newCache`'s shape). NemotronH's input-dtype SSM state contract preserved via a new `recDtype` parameter on `BatchedMambaCache` (default fp32 for GDN compatibility; NemotronH passes the model's compute dtype). Required widening visibility from `private` to default-internal on `NemotronHBlockType`, `NemotronHRMSNormGated`, `NemotronHMamba2Mixer`, `NemotronHAttention`, `NemotronHBlock`, `NemotronHBackbone`, and `NemotronHModel.backbone` — extension file is otherwise purely additive on the model side.

7. **Spec 044** — `specs/044-batched-sparse-attention-decode.md` documenting protocol surface, per-family coverage, kernel design, Apple Silicon SDPA notes, and spec 041 coexistence.

8. **B=1 smoke + retirement note** — `Qwen2BatchedSparseB1Tests` proves the batched cache works at single-stream (shape `[1, 1, vocab]`, finite logits, slot-0 offset advances T0 → T0+1, slot-0 logits match the B=2 slot-0 logits via cosine > 0.999). Spec 044 §"Legacy retirement" documents that the fork's single-stream `RetrievalAttentionKVCache` wrapper is redundant given the batched cache covers B=1 equivalently, and is not proposed for upstreaming. Failed exploration paths (F-71b custom Metal sparse SDPA kernel, F-76 implicit sparse, F-84 blockGather) are also noted as not-proposed-for-upstreaming.

### Family coverage

**8 pure-attention families** (`BatchedSparseLLM`): Qwen2, Qwen3, Qwen3MoE, Llama, Mistral3, Phi3, Gemma3, Gemma4. **2 hybrid families** (`BatchedHybridSparseLLM`): Qwen3.5 / Qwen3.6 (shared base) + NemotronH. **All batch sizes** including B=1 — single-stream is just the B=1 case of the batched cache.

### Self-contained scope

This PR includes ONLY what's required for batched sparse decode. The broader per-request retrieval-attention infrastructure from the TheTom fork (per-request KV cache, kernel zoo, scheduler, context machinery) is not part of this PR — the small subset of helpers needed by the batched path (config struct, JL projection, three Metal kernel functions) is inlined into the batched files themselves. The fork's legacy single-stream `RetrievalAttentionKVCache` wrapper is also not part of this PR — the batched cache covers B=1 (see commit 8).

### Activation

Default = dense everywhere. Sparse opt-in happens at the consumer (e.g. `vllm-swift` bridge) by:

- Pure attention families: build per-layer `BatchedRetrievalAttentionKVCache` and call `model.fullyBatchedSparseDecode(_:raCaches:)` after `as? BatchedSparseLLM`.
- Hybrid families: build a `BatchedHybridCache` via `model.newBatchedHybridSparseCache(maxBatch:parameters:raConfig:)` (returns `.sparseAttention` for attention layers, `.gdn` for linear layers) and call `model.fullyBatchedSparseDecode(_:caches:)` after `as? BatchedHybridSparseLLM`.

Three env knobs:
- `VSM_SPARSE_BATCHED_KERNEL`: `mask` (default), `loop`, `group`, `gather`.
- `MLX_SDPA_BLOCKS`: sister knob on `ekryski/mlx` (see notes below).

### Apple Silicon SDPA notes

The default sparse path hits MLX's `sdpa_vector_2pass` kernel via `mask=.array(fp16)`. A sister PR on `ekryski/mlx` ([ekryski/mlx#34](https://github.com/ekryski/mlx/pull/34)) adds the `MLX_SDPA_BLOCKS` env override for M-series GPU shape-dependent tuning — recommended but not required for this PR.

### Spec 041 coexistence

This PR is rebased on the current `alpha` (49d6b80) which includes spec 041 phase 1.2 (rotating affine cache + sliding-window fused kernel + step-uniform refactor). The batched sparse path is additive — does not touch the spec 041 `BatchedKVCache` surface or the sliding-window fused kernel. Composition is orthogonal: `BatchedRetrievalAttentionKVCache` wraps a `BatchedKVCache` via the public `inner` member; a future quantization-aware sparse path drops in by swapping the inner type without touching the per-family `+Sparse` forwards. No conflict.

## Test plan

- [x] Apple Silicon `swift build -c release` passes locally
- [x] `BatchedRetrievalAttention*` unit tests (mask kernel, index, KV cache feeder) — 27 sparse tests across 13 suites pass
- [x] Per-family synthetic smoke tests (Qwen2 / Qwen3 / Qwen3MoE / Llama / Gemma3 / Gemma4 / Phi3 / Mistral3 / Qwen3.5 / NemotronH) — tiny random-weight models, no checkpoint required
- [x] Gemma4 smoke now exercises `num_kv_shared_layers=4` (donor + 4 shared layers) AND `enable_moe_block=true` (4 experts, top-K=2)
- [x] NemotronH smoke covers pattern `MEMEM*` (3 mamba + 2 moe + 1 attention) with bf16 end-to-end decode
- [x] B=1 smoke (`Qwen2BatchedSparseB1Tests`) — single-stream output shape `[1, 1, vocab]`, finite logits, slot-0 offset advance, AND cosine equivalence vs B=2 slot 0 (cos > 0.999)
- [ ] Optional: real-model bench against Qwen2.5-14B at B=8 ctx=28K (validated locally on `feat/batched-sparse-attention` branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Related PRs — review together as a stack

| repo | PR | scope |
|---|---|---|
| `ekryski/mlx` | [#34](https://github.com/ekryski/mlx/pull/34) | MetalAllocator zero-on-recycle + `MLX_SDPA_BLOCKS` env override |
| `ekryski/mlx-swift` | [#36](https://github.com/ekryski/mlx-swift/pull/36) | Submodule bump to mlx#34 cleaned tip |
| `ekryski/mlx-swift-lm` | [#224](https://github.com/ekryski/mlx-swift-lm/pull/224) | Batched sparse attention decode + 8 attention + 2 hybrid families + spec 044 |
| `ekryski/mlx-swift-lm` | [#225](https://github.com/ekryski/mlx-swift-lm/pull/225) | Sparse PREFILL — extends mlx-swift-lm#224's batched cache to L>1 |

**Merge order**: mlx#34 → mlx-swift#36 → mlx-swift-lm#224 → mlx-swift-lm#225.

All four together comprise the batched sparse attention stack used in production by the `vllm-swift` project (M-series GPU, Qwen / Llama / Gemma / Phi / Mistral / NemotronH families). Spec 044 in PR #224 documents the design + retirement of legacy single-stream paths.